### PR TITLE
feat: harden routing and improve context selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,18 @@ on:
   pull_request:
 
 jobs:
-  test:
+  verify:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Install
         run: |
           python -m pip install --upgrade pip
@@ -23,6 +28,6 @@ jobs:
       - name: Type check
         run: mypy src
       - name: Tests
-        run: pytest --cov=vaner --cov-fail-under=70
+        run: pytest tests --cov=src/vaner --cov-fail-under=80
       - name: Security audit
         run: pip-audit

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,5 @@ build/
 .coverage
 htmlcov/
 .DS_Store
-.vaner/store.db
-.vaner/telemetry.db
-.vaner/runtime/
+.vaner/
+eval/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 dist/
 build/
 .env
+.env.local
 .env.*
 .pytest_cache/
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ pip install -e ".[dev]"
 pytest
 ```
 
+## Install
+
+```bash
+pip install .
+```
+
 ## Community
 
 - Contributing guide: `CONTRIBUTING.md`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,10 +22,14 @@ use_llm = false
 generation_model = "gpt-4o-mini"
 max_file_chars = 8000
 summary_max_tokens = 400
+max_concurrent_generations = 4
+max_generations_per_cycle = 200
 
 [proxy]
 proxy_token = ""
 max_requests_per_minute = 120
+ssl_certfile = ""
+ssl_keyfile = ""
 
 [privacy]
 allowed_paths = ["src/**", "docs/**"]
@@ -54,8 +58,12 @@ max_context_tokens = 4096
 - `generation.generation_model` (`str | null`, default: `null`): model used for generation; falls back to `backend.model`.
 - `generation.max_file_chars` (`int`, default: `8000`): max source chars sent to the summarizer.
 - `generation.summary_max_tokens` (`int`, default: `400`): output token cap for generated summaries.
+- `generation.max_concurrent_generations` (`int`, default: `4`): max concurrent summary generation jobs per daemon cycle.
+- `generation.max_generations_per_cycle` (`int`, default: `200`): hard cap of file summaries generated in one `run_once` pass.
 - `proxy.proxy_token` (`str`, default: empty): if set, proxy requires `Authorization: Bearer <token>`.
 - `proxy.max_requests_per_minute` (`int`, default: `120`): in-memory per-process request cap for `/v1/chat/completions`.
+- `proxy.ssl_certfile` (`str | null`, default: `null`): optional TLS certificate path passed to `uvicorn.run`.
+- `proxy.ssl_keyfile` (`str | null`, default: `null`): optional TLS private key path passed to `uvicorn.run`.
 - `privacy.allowed_paths` (`list[str]`, default: `["."]`): include-globs for files considered by planner.
 - `privacy.excluded_patterns` (`list[str]`, default shown above): deny-globs applied after allowed paths.
 - `privacy.redact_patterns` (`list[str]`, default: `[]`): case-insensitive regex patterns replaced with `[REDACTED]`.
@@ -68,3 +76,4 @@ max_context_tokens = 4096
 - Missing config file falls back to defaults.
 - Invalid `redact_patterns` entries are skipped with a warning.
 - `allowed_paths = ["."]` means "allow all paths under the repo."
+- For production TLS, prefer terminating HTTPS at a reverse proxy and keeping Vaner bound to localhost.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,12 @@ name = "openai"
 base_url = "https://api.openai.com/v1"
 model = "gpt-4o-mini"
 api_key_env = "OPENAI_API_KEY"
+prefer_local = true
+fallback_enabled = false
+fallback_base_url = "https://api.openai.com/v1"
+fallback_model = "gpt-4o-mini"
+fallback_api_key_env = "OPENAI_API_KEY"
+remote_budget_per_hour = 60
 
 [privacy]
 allowed_paths = ["src/**", "docs/**"]
@@ -28,6 +34,12 @@ max_context_tokens = 4096
 - `backend.base_url` (`str`, default: `https://api.openai.com/v1`): OpenAI-compatible endpoint.
 - `backend.model` (`str`, default: `gpt-4o-mini`): model sent to backend requests.
 - `backend.api_key_env` (`str`, default: `OPENAI_API_KEY`): environment variable holding API key.
+- `backend.prefer_local` (`bool`, default: `true`): prefer local backends and use cloud only on fallback.
+- `backend.fallback_enabled` (`bool`, default: `false`): enable cloud fallback when primary is unavailable.
+- `backend.fallback_base_url` (`str | null`, default: `null`): fallback OpenAI-compatible endpoint.
+- `backend.fallback_model` (`str | null`, default: `null`): fallback model name when switching providers.
+- `backend.fallback_api_key_env` (`str`, default: `OPENAI_API_KEY`): API key env var for fallback provider.
+- `backend.remote_budget_per_hour` (`int`, default: `60`): hard cap for hourly fallback requests.
 - `privacy.allowed_paths` (`list[str]`, default: `["."]`): include-globs for files considered by planner.
 - `privacy.excluded_patterns` (`list[str]`, default shown above): deny-globs applied after allowed paths.
 - `privacy.redact_patterns` (`list[str]`, default: `[]`): case-insensitive regex patterns replaced with `[REDACTED]`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,16 @@ fallback_model = "gpt-4o-mini"
 fallback_api_key_env = "OPENAI_API_KEY"
 remote_budget_per_hour = 60
 
+[generation]
+use_llm = false
+generation_model = "gpt-4o-mini"
+max_file_chars = 8000
+summary_max_tokens = 400
+
+[proxy]
+proxy_token = ""
+max_requests_per_minute = 120
+
 [privacy]
 allowed_paths = ["src/**", "docs/**"]
 excluded_patterns = ["*.env", "*.key", "*.pem", "credentials*", "secrets*"]
@@ -40,6 +50,12 @@ max_context_tokens = 4096
 - `backend.fallback_model` (`str | null`, default: `null`): fallback model name when switching providers.
 - `backend.fallback_api_key_env` (`str`, default: `OPENAI_API_KEY`): API key env var for fallback provider.
 - `backend.remote_budget_per_hour` (`int`, default: `60`): hard cap for hourly fallback requests.
+- `generation.use_llm` (`bool`, default: `false`): enable backend LLM summarization for file and diff artefacts.
+- `generation.generation_model` (`str | null`, default: `null`): model used for generation; falls back to `backend.model`.
+- `generation.max_file_chars` (`int`, default: `8000`): max source chars sent to the summarizer.
+- `generation.summary_max_tokens` (`int`, default: `400`): output token cap for generated summaries.
+- `proxy.proxy_token` (`str`, default: empty): if set, proxy requires `Authorization: Bearer <token>`.
+- `proxy.max_requests_per_minute` (`int`, default: `120`): in-memory per-process request cap for `/v1/chat/completions`.
 - `privacy.allowed_paths` (`list[str]`, default: `["."]`): include-globs for files considered by planner.
 - `privacy.excluded_patterns` (`list[str]`, default shown above): deny-globs applied after allowed paths.
 - `privacy.redact_patterns` (`list[str]`, default: `[]`): case-insensitive regex patterns replaced with `[REDACTED]`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,10 +5,13 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
 vaner init
-vaner daemon start
+vaner prepare
 vaner query "explain the auth flow"
 vaner inspect --last
+vaner run-eval
+# optional long-running background daemon
+vaner daemon start --no-once
 ```
 
-Note: `vaner daemon start` currently writes a status marker at `.vaner/runtime/daemon.pid`.
-This is a lightweight v1 status file, not an operating-system process PID.
+`vaner daemon start --no-once` runs a background process and writes its real PID to `.vaner/runtime/daemon.pid`.
+Use `vaner daemon status` and `vaner daemon stop` to manage it.

--- a/eval/cases/default.json
+++ b/eval/cases/default.json
@@ -1,0 +1,49 @@
+[
+  {
+    "case_id": "daemon_flow",
+    "question": "Explain how the daemon prepares artefacts from repository changes.",
+    "expected_paths": [
+      "src/vaner/daemon/runner.py",
+      "src/vaner/daemon/engine/planner.py"
+    ],
+    "expected_points": [
+      "run_once",
+      "plan_targets",
+      "score_paths",
+      "upsert_working_set"
+    ],
+    "question_type": "mechanism"
+  },
+  {
+    "case_id": "broker_selection",
+    "question": "How does Vaner select and compress context artefacts at query time?",
+    "expected_paths": [
+      "src/vaner/broker/selector.py",
+      "src/vaner/broker/compressor.py",
+      "src/vaner/broker/assembler.py"
+    ],
+    "expected_points": [
+      "select_artefacts",
+      "compress_context",
+      "token_budget",
+      "keyword_overlap"
+    ],
+    "question_type": "understanding"
+  },
+  {
+    "case_id": "proxy_enrichment",
+    "question": "How does the OpenAI-compatible proxy enrich chat completions with repository context?",
+    "expected_paths": [
+      "src/vaner/router/proxy.py",
+      "src/vaner/api.py",
+      "src/vaner/router/backends.py"
+    ],
+    "expected_points": [
+      "chat/completions",
+      "injected_context",
+      "forward_chat_completion",
+      "stream_chat_completion"
+    ],
+    "question_type": "wiring"
+  }
+]

--- a/eval/cases/default.json
+++ b/eval/cases/default.json
@@ -15,6 +15,47 @@
     "question_type": "mechanism"
   },
   {
+    "case_id": "daemon_origin_runner",
+    "question": "Where is the daemon run loop implemented, and which method executes a single pass?",
+    "expected_paths": [
+      "src/vaner/daemon/runner.py"
+    ],
+    "expected_points": [
+      "VanerDaemon",
+      "run_forever",
+      "run_once"
+    ],
+    "question_type": "origin"
+  },
+  {
+    "case_id": "planner_structure",
+    "question": "Describe the planner pipeline that turns signals into candidate file targets.",
+    "expected_paths": [
+      "src/vaner/daemon/engine/planner.py",
+      "src/vaner/models/signal.py"
+    ],
+    "expected_points": [
+      "plan_targets",
+      "SignalEvent",
+      "allowed_paths"
+    ],
+    "question_type": "structure"
+  },
+  {
+    "case_id": "scorer_conditional",
+    "question": "When do git-prioritized files receive ranking preference in daemon target scoring?",
+    "expected_paths": [
+      "src/vaner/daemon/engine/scorer.py",
+      "src/vaner/daemon/runner.py"
+    ],
+    "expected_points": [
+      "score_paths",
+      "prioritized_paths",
+      "ranked_targets"
+    ],
+    "question_type": "conditional"
+  },
+  {
     "case_id": "broker_selection",
     "question": "How does Vaner select and compress context artefacts at query time?",
     "expected_paths": [
@@ -31,6 +72,47 @@
     "question_type": "understanding"
   },
   {
+    "case_id": "selector_origin_bonus",
+    "question": "How does selector reranking handle origin-style questions about where symbols are defined?",
+    "expected_paths": [
+      "src/vaner/broker/selector.py"
+    ],
+    "expected_points": [
+      "_is_origin_question",
+      "_origin_bonus",
+      "select_artefacts"
+    ],
+    "question_type": "mechanism"
+  },
+  {
+    "case_id": "compressor_budget_logic",
+    "question": "What logic determines which artefacts fit within the context token budget?",
+    "expected_paths": [
+      "src/vaner/broker/compressor.py",
+      "src/vaner/policy/budget.py"
+    ],
+    "expected_points": [
+      "compress_context",
+      "max_tokens",
+      "count_tokens"
+    ],
+    "question_type": "cross_file"
+  },
+  {
+    "case_id": "assembler_output_shape",
+    "question": "What structure does the broker assembler return for selected context and metadata?",
+    "expected_paths": [
+      "src/vaner/broker/assembler.py",
+      "src/vaner/models/context.py"
+    ],
+    "expected_points": [
+      "assemble_context",
+      "token_budget",
+      "ContextPackage"
+    ],
+    "question_type": "structure"
+  },
+  {
     "case_id": "proxy_enrichment",
     "question": "How does the OpenAI-compatible proxy enrich chat completions with repository context?",
     "expected_paths": [
@@ -43,6 +125,122 @@
       "injected_context",
       "forward_chat_completion",
       "stream_chat_completion"
+    ],
+    "question_type": "wiring"
+  },
+  {
+    "case_id": "proxy_auth_error_path",
+    "question": "How does the proxy reject unauthorized requests when a proxy token is configured?",
+    "expected_paths": [
+      "src/vaner/router/proxy.py",
+      "src/vaner/models/config.py"
+    ],
+    "expected_points": [
+      "Authorization",
+      "HTTPException",
+      "proxy_token"
+    ],
+    "question_type": "error_path"
+  },
+  {
+    "case_id": "backend_fallback_conditional",
+    "question": "Under what conditions does chat forwarding switch from local backend to fallback cloud backend?",
+    "expected_paths": [
+      "src/vaner/router/backends.py",
+      "src/vaner/models/config.py"
+    ],
+    "expected_points": [
+      "_should_use_fallback",
+      "fallback_enabled",
+      "remote_budget_per_hour"
+    ],
+    "question_type": "conditional"
+  },
+  {
+    "case_id": "api_prepare_wiring",
+    "question": "Trace the API path for prepare from public API call to daemon execution.",
+    "expected_paths": [
+      "src/vaner/api.py",
+      "src/vaner/daemon/runner.py"
+    ],
+    "expected_points": [
+      "prepare",
+      "VanerDaemon",
+      "run_once"
+    ],
+    "question_type": "wiring"
+  },
+  {
+    "case_id": "query_pipeline_cross_file",
+    "question": "How does a query flow from API entrypoint through selector and compressor into injected context?",
+    "expected_paths": [
+      "src/vaner/api.py",
+      "src/vaner/broker/selector.py",
+      "src/vaner/broker/compressor.py",
+      "src/vaner/broker/assembler.py"
+    ],
+    "expected_points": [
+      "query",
+      "select_artefacts",
+      "compress_context",
+      "injected_context"
+    ],
+    "question_type": "cross_file"
+  },
+  {
+    "case_id": "daemon_git_signal_origin",
+    "question": "Where are git diff and staged signals read before planning daemon targets?",
+    "expected_paths": [
+      "src/vaner/daemon/signals/git_reader.py",
+      "src/vaner/daemon/runner.py"
+    ],
+    "expected_points": [
+      "read_git_state",
+      "read_git_diff",
+      "git_changed"
+    ],
+    "question_type": "origin"
+  },
+  {
+    "case_id": "store_working_set_structure",
+    "question": "How is the working set stored and updated after daemon generation?",
+    "expected_paths": [
+      "src/vaner/store/artefacts.py",
+      "src/vaner/models/session.py",
+      "src/vaner/daemon/runner.py"
+    ],
+    "expected_points": [
+      "upsert_working_set",
+      "WorkingSet",
+      "artefact_keys"
+    ],
+    "question_type": "structure"
+  },
+  {
+    "case_id": "config_loading_mechanism",
+    "question": "Explain how Vaner loads backend, generation, and proxy settings from config.toml.",
+    "expected_paths": [
+      "src/vaner/cli/commands/config.py",
+      "src/vaner/models/config.py"
+    ],
+    "expected_points": [
+      "load_config",
+      "GenerationConfig",
+      "ProxyConfig"
+    ],
+    "question_type": "mechanism"
+  },
+  {
+    "case_id": "cli_proxy_wiring",
+    "question": "How does the CLI proxy command construct and run the FastAPI proxy server?",
+    "expected_paths": [
+      "src/vaner/cli/main.py",
+      "src/vaner/router/proxy.py"
+    ],
+    "expected_points": [
+      "@app.command(\"proxy\")",
+      "create_app",
+      "uvicorn.run"
     ],
     "question_type": "wiring"
   }

--- a/eval/synthetic/generate_cases.py
+++ b/eval/synthetic/generate_cases.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import httpx
+
+from vaner.cli.commands.config import load_config
+from vaner.models.artefact import ArtefactKind
+from vaner.store.artefacts import ArtefactStore
+
+QUESTION_TYPES = ["origin", "mechanism", "structure", "conditional", "wiring", "error_path", "cross_file"]
+
+GENERATOR_PROMPT = """Given the file summary below, generate {count} developer questions for these types: {question_types}.
+
+Return ONLY a JSON array. Each item must include:
+- question
+- question_type
+- expected_points (4-6 concise factual bullets)
+
+File path: {source_path}
+Summary:
+{summary}
+"""
+
+
+def _extract_message_text(payload: dict) -> str:
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices:
+        message = choices[0].get("message", {})
+        content = message.get("content", "")
+        if isinstance(content, str):
+            return content
+    return ""
+
+
+def _extract_json_array(text: str) -> list[dict]:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = "\n".join(line for line in stripped.splitlines() if not line.startswith("```"))
+    start = stripped.find("[")
+    end = stripped.rfind("]")
+    if start == -1 or end == -1:
+        return []
+    loaded = json.loads(stripped[start : end + 1])
+    return loaded if isinstance(loaded, list) else []
+
+
+async def _list_file_summaries(store: ArtefactStore) -> list:
+    await store.initialize()
+    return await store.list(kind=ArtefactKind.FILE_SUMMARY, limit=400)
+
+
+async def _generate_questions(prompt: str, *, base_url: str, model: str, api_key_env: str) -> list[dict]:
+    headers = {"Content-Type": "application/json"}
+    api_key = os.getenv(api_key_env, "")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    payload = {"model": model, "messages": [{"role": "user", "content": prompt}], "temperature": 0.2}
+    async with httpx.AsyncClient(timeout=60) as client:
+        response = await client.post(f"{base_url.rstrip('/')}/chat/completions", json=payload, headers=headers)
+        response.raise_for_status()
+    return _extract_json_array(_extract_message_text(response.json()))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate synthetic benchmark cases from cached file summaries.")
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=None, help="Output JSON path")
+    parser.add_argument("--questions-per-file", type=int, default=1)
+    parser.add_argument("--types", nargs="+", default=QUESTION_TYPES)
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    config = load_config(repo_root)
+    store = ArtefactStore(config.store_path)
+    artefacts = asyncio.run(_list_file_summaries(store))
+    if not artefacts:
+        raise SystemExit("No file summaries found. Run `vaner prepare` first.")
+
+    output = args.output or (repo_root / "eval" / "synthetic" / "cases" / "raw.json")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    cases: list[dict] = []
+
+    for idx, artefact in enumerate(artefacts):
+        prompt = GENERATOR_PROMPT.format(
+            count=args.questions_per_file,
+            question_types=", ".join(args.types),
+            source_path=artefact.source_path,
+            summary=artefact.content,
+        )
+        questions = asyncio.run(
+            _generate_questions(
+                prompt,
+                base_url=config.backend.base_url,
+                model=config.generation.generation_model or config.backend.model,
+                api_key_env=config.backend.api_key_env,
+            )
+        )
+        for q in questions:
+            if not isinstance(q, dict) or "question" not in q:
+                continue
+            case_id = f"syn-{idx:04d}-{len(cases):03d}"
+            cases.append(
+                {
+                    "case_id": case_id,
+                    "question": q.get("question", ""),
+                    "question_type": q.get("question_type", "understanding"),
+                    "expected_paths": [artefact.source_path],
+                    "expected_points": [p for p in q.get("expected_points", []) if isinstance(p, str)],
+                }
+            )
+
+    output.write_text(json.dumps(cases, indent=2), encoding="utf-8")
+    print(f"Wrote {len(cases)} synthetic cases to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/synthetic/weak_label.py
+++ b/eval/synthetic/weak_label.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from vaner import api
+
+
+def _label_case(repo_root: Path, case: dict) -> dict:
+    question = str(case.get("question", ""))
+    package = api.query(question, repo_root)
+    selected_paths = [selection.source_path for selection in package.selections]
+    expected_paths = [str(path) for path in case.get("expected_paths", [])]
+
+    matched = [path for path in expected_paths if path in selected_paths]
+    top_3 = selected_paths[:3]
+    hit_at_3 = any(path in top_3 for path in expected_paths)
+    confidence = "high" if hit_at_3 else ("medium" if matched else "low")
+
+    secondary = [path for path in selected_paths if path not in expected_paths][:5]
+    flags: list[str] = []
+    if not hit_at_3:
+        flags.append("drifted")
+    if confidence == "low":
+        flags.append("low_confidence")
+
+    enriched = dict(case)
+    enriched["secondary_units"] = secondary
+    enriched["label_confidence"] = confidence
+    enriched["flags"] = flags
+    return enriched
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Weak-label synthetic benchmark cases using current retrieval behavior.")
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--input", type=Path, default=None, help="Input synthetic raw cases JSON")
+    parser.add_argument("--output", type=Path, default=None, help="Output labeled cases JSON")
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    input_path = args.input or (repo_root / "eval" / "synthetic" / "cases" / "raw.json")
+    output_path = args.output or (repo_root / "eval" / "synthetic" / "cases" / "labeled.json")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    raw = json.loads(input_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise SystemExit(f"Expected JSON array in {input_path}")
+
+    labeled = [_label_case(repo_root, case) for case in raw if isinstance(case, dict)]
+    output_path.write_text(json.dumps(labeled, indent=2), encoding="utf-8")
+    print(f"Wrote {len(labeled)} labeled cases to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vaner/broker/assembler.py
+++ b/src/vaner/broker/assembler.py
@@ -31,12 +31,17 @@ def assemble_context_package(
     repo_root: Path | None = None,
     max_age_seconds: int = 3600,
 ) -> ContextPackage:
-    injected_context, token_map, used, kept_keys = compress_context(artefacts, max_tokens=max_tokens)
+    score_map = {artefact.key: score_artefact(prompt, artefact) for artefact in artefacts}
+    injected_context, token_map, used, kept_keys = compress_context(
+        artefacts,
+        max_tokens=max_tokens,
+        score_by_key=score_map,
+    )
     selections = [
         ContextSelection(
             artefact_key=artefact.key,
             source_path=artefact.source_path,
-            score=score_artefact(prompt, artefact),
+            score=score_map.get(artefact.key, 0.0),
             stale=_is_stale(artefact, repo_root, max_age_seconds),
             token_count=token_map.get(artefact.key, 0),
             rationale="keyword_overlap",

--- a/src/vaner/broker/compressor.py
+++ b/src/vaner/broker/compressor.py
@@ -9,9 +9,11 @@ from vaner.policy.budget import count_tokens
 def compress_context(
     artefacts: list[Artefact],
     max_tokens: int,
+    score_by_key: dict[str, float] | None = None,
 ) -> tuple[str, dict[str, int], int, set[str]]:
     token_map: dict[str, int] = {}
-    kept_chunks: list[str] = []
+    chunk_map: dict[str, str] = {}
+    ordered_keys: list[str] = []
     kept_keys: set[str] = set()
     used = 0
 
@@ -19,10 +21,20 @@ def compress_context(
         chunk = f"### {artefact.source_path}\n{artefact.content}\n"
         chunk_tokens = count_tokens(chunk)
         token_map[artefact.key] = chunk_tokens
+        chunk_map[artefact.key] = chunk
+        ordered_keys.append(artefact.key)
+
+    if score_by_key is not None:
+        ordered_keys.sort(key=lambda key: score_by_key.get(key, 0.0), reverse=True)
+
+    # Greedy knapsack approximation: pack highest-score artefacts first while
+    # still trying lower-ranked/smaller chunks that fit remaining budget.
+    for key in ordered_keys:
+        chunk_tokens = token_map[key]
         if used + chunk_tokens > max_tokens:
             continue
-        kept_chunks.append(chunk)
-        kept_keys.add(artefact.key)
+        kept_keys.add(key)
         used += chunk_tokens
 
+    kept_chunks = [chunk_map[key] for key in ordered_keys if key in kept_keys]
     return "\n".join(kept_chunks), token_map, used, kept_keys

--- a/src/vaner/broker/selector.py
+++ b/src/vaner/broker/selector.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import re
 import time
 
 from vaner.models.artefact import Artefact
@@ -23,6 +24,29 @@ def score_artefact(prompt: str, artefact: Artefact) -> float:
     return float(hits) + recency_bonus
 
 
+def _is_origin_question(prompt: str) -> bool:
+    q = prompt.lower().strip()
+    return (
+        (q.startswith("where ") or q.startswith("how "))
+        and any(term in q for term in ("checked", "implemented", "defined"))
+    ) or q.startswith("what conditions")
+
+
+def _origin_bonus(prompt: str, content: str) -> float:
+    prompt_tokens = {token for token in re.findall(r"[a-z0-9_]+", prompt.lower()) if len(token) > 2}
+    def_terms = set(re.findall(r"`([a-zA-Z_][a-zA-Z0-9_]*)`", content))
+    def_terms |= set(re.findall(r"\*\*([a-zA-Z_][a-zA-Z0-9_]*)\*\*", content))
+    def_terms |= set(re.findall(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\(", content))
+    lowered_terms = {term.lower() for term in def_terms}
+
+    bonus = 0.0
+    for token in prompt_tokens:
+        for term in lowered_terms:
+            if token == term or token in term or term in token:
+                bonus += 1.5
+    return bonus
+
+
 def select_artefacts(
     prompt: str,
     artefacts: list[Artefact],
@@ -32,9 +56,12 @@ def select_artefacts(
 ) -> list[Artefact]:
     preferred_paths = preferred_paths or set()
     preferred_keys = preferred_keys or set()
+    apply_origin_rerank = _is_origin_question(prompt)
 
     def _score(artefact: Artefact) -> float:
         score = score_artefact(prompt, artefact)
+        if apply_origin_rerank:
+            score += _origin_bonus(prompt, artefact.content)
         if artefact.source_path in preferred_paths:
             score += 0.8
         if artefact.key in preferred_keys:

--- a/src/vaner/cli/commands/config.py
+++ b/src/vaner/cli/commands/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-from vaner.models.config import BackendConfig, PrivacyConfig, VanerConfig
+from vaner.models.config import BackendConfig, GenerationConfig, PrivacyConfig, ProxyConfig, VanerConfig
 
 
 def load_config(repo_root: Path) -> VanerConfig:
@@ -15,7 +15,9 @@ def load_config(repo_root: Path) -> VanerConfig:
         parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
 
     backend_section = parsed.get("backend", {})
+    generation_section = parsed.get("generation", {})
     privacy_section = parsed.get("privacy", {})
+    proxy_section = parsed.get("proxy", {})
     limits_section = parsed.get("limits", {})
 
     backend = (
@@ -27,6 +29,16 @@ def load_config(repo_root: Path) -> VanerConfig:
         PrivacyConfig(**privacy_section)
         if isinstance(privacy_section, dict)
         else PrivacyConfig()
+    )
+    generation = (
+        GenerationConfig(**generation_section)
+        if isinstance(generation_section, dict)
+        else GenerationConfig()
+    )
+    proxy = (
+        ProxyConfig(**proxy_section)
+        if isinstance(proxy_section, dict)
+        else ProxyConfig()
     )
 
     max_age_seconds = (
@@ -50,4 +62,6 @@ def load_config(repo_root: Path) -> VanerConfig:
         max_context_tokens=max_context_tokens,
         backend=backend,
         privacy=privacy,
+        generation=generation,
+        proxy=proxy,
     )

--- a/src/vaner/cli/commands/init.py
+++ b/src/vaner/cli/commands/init.py
@@ -21,10 +21,14 @@ use_llm = false
 generation_model = "gpt-4o-mini"
 max_file_chars = 8000
 summary_max_tokens = 400
+max_concurrent_generations = 4
+max_generations_per_cycle = 200
 
 [proxy]
 proxy_token = ""
 max_requests_per_minute = 120
+ssl_certfile = ""
+ssl_keyfile = ""
 
 [privacy]
 allowed_paths = ["."]

--- a/src/vaner/cli/commands/init.py
+++ b/src/vaner/cli/commands/init.py
@@ -16,6 +16,16 @@ fallback_model = "gpt-4o-mini"
 fallback_api_key_env = "OPENAI_API_KEY"
 remote_budget_per_hour = 60
 
+[generation]
+use_llm = false
+generation_model = "gpt-4o-mini"
+max_file_chars = 8000
+summary_max_tokens = 400
+
+[proxy]
+proxy_token = ""
+max_requests_per_minute = 120
+
 [privacy]
 allowed_paths = ["."]
 excluded_patterns = ["*.env", "*.key", "*.pem", "credentials*", "secrets*"]

--- a/src/vaner/cli/commands/init.py
+++ b/src/vaner/cli/commands/init.py
@@ -9,6 +9,12 @@ name = "openai"
 base_url = "https://api.openai.com/v1"
 model = "gpt-4o-mini"
 api_key_env = "OPENAI_API_KEY"
+prefer_local = true
+fallback_enabled = false
+fallback_base_url = "https://api.openai.com/v1"
+fallback_model = "gpt-4o-mini"
+fallback_api_key_env = "OPENAI_API_KEY"
+remote_budget_per_hour = 60
 
 [privacy]
 allowed_paths = ["."]

--- a/src/vaner/cli/main.py
+++ b/src/vaner/cli/main.py
@@ -11,7 +11,7 @@ from vaner.cli.commands.config import load_config
 from vaner.cli.commands.daemon import daemon_status, run_daemon_forever, start_daemon, stop_daemon
 from vaner.cli.commands.init import init_repo
 from vaner.daemon.runner import VanerDaemon
-from vaner.eval import evaluate_repo
+from vaner.eval import evaluate_repo, run_eval
 from vaner.router.proxy import create_app
 
 app = typer.Typer(help="Vaner CLI")
@@ -96,6 +96,21 @@ def config_show(path: str | None = typer.Option(None, help="Repository root")) -
 @app.command("eval")
 def eval_repo(path: str | None = typer.Option(None, help="Repository root")) -> None:
     result = evaluate_repo(_repo_root(path))
+    typer.echo(result.model_dump_json(indent=2))
+
+
+@app.command("run-eval")
+def run_eval_command(
+    path: str | None = typer.Option(None, help="Repository root"),
+    cases_file: str | None = typer.Option(None, "--cases-file", help="Path to eval cases JSON"),
+    output_dir: str | None = typer.Option(None, "--output-dir", help="Directory for eval run JSON output"),
+) -> None:
+    repo_root = _repo_root(path)
+    result = run_eval(
+        repo_root,
+        cases_path=Path(cases_file).resolve() if cases_file else None,
+        output_dir=Path(output_dir).resolve() if output_dir else None,
+    )
     typer.echo(result.model_dump_json(indent=2))
 
 

--- a/src/vaner/cli/main.py
+++ b/src/vaner/cli/main.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import traceback
 from pathlib import Path
 
+import aiosqlite
+import httpx
 import typer
 
 from vaner import api
@@ -17,10 +20,31 @@ from vaner.router.proxy import create_app
 app = typer.Typer(help="Vaner CLI")
 daemon_app = typer.Typer(help="Daemon controls")
 config_app = typer.Typer(help="Show config")
+_VERBOSE = False
 
 
 def _repo_root(path: str | None) -> Path:
     return Path(path).resolve() if path else Path.cwd()
+
+
+def _friendly_error_message(exc: Exception) -> str:
+    if isinstance(exc, FileNotFoundError):
+        return f"File not found: {exc}. Check your repo path or run `vaner init`."
+    if isinstance(exc, PermissionError):
+        return f"Permission denied: {exc}. Check file permissions for `.vaner/` and your repo."
+    if isinstance(exc, httpx.HTTPError):
+        return f"Backend request failed: {exc}. Check network access and API key configuration."
+    if isinstance(exc, aiosqlite.Error):
+        return f"Database error: {exc}. Remove `.vaner/store.db` if it is corrupted, then rerun."
+    return f"Vaner failed: {exc}"
+
+
+@app.callback()
+def app_callback(
+    verbose: bool = typer.Option(False, "--verbose", help="Show full traceback on errors"),
+) -> None:
+    global _VERBOSE
+    _VERBOSE = verbose
 
 
 @app.command("init")
@@ -126,7 +150,13 @@ def proxy(
     config = load_config(repo_root)
     daemon = VanerDaemon(config)
     app_instance = create_app(config, daemon.store)
-    uvicorn.run(app_instance, host=host, port=port)
+    uvicorn.run(
+        app_instance,
+        host=host,
+        port=port,
+        ssl_certfile=config.proxy.ssl_certfile or None,
+        ssl_keyfile=config.proxy.ssl_keyfile or None,
+    )
 
 
 app.add_typer(daemon_app, name="daemon")
@@ -134,7 +164,18 @@ app.add_typer(config_app, name="config")
 
 
 def run() -> None:
-    app()
+    try:
+        app()
+    except (FileNotFoundError, PermissionError, httpx.HTTPError, aiosqlite.Error) as exc:
+        typer.secho(_friendly_error_message(exc), fg=typer.colors.RED, err=True)
+        if _VERBOSE:
+            traceback.print_exc()
+        raise typer.Exit(code=1) from exc
+    except Exception as exc:  # pragma: no cover - defensive CLI guard
+        typer.secho(_friendly_error_message(exc), fg=typer.colors.RED, err=True)
+        if _VERBOSE:
+            traceback.print_exc()
+        raise typer.Exit(code=1) from exc
 
 
 if __name__ == "__main__":

--- a/src/vaner/cli/main.py
+++ b/src/vaner/cli/main.py
@@ -75,6 +75,12 @@ def query(prompt: str, path: str | None = typer.Option(None, help="Repository ro
     typer.echo(package.injected_context)
 
 
+@app.command("prepare")
+def prepare(path: str | None = typer.Option(None, help="Repository root")) -> None:
+    generated = api.prepare(_repo_root(path))
+    typer.echo(f"Prepared artefacts: {generated}")
+
+
 @app.command("forget")
 def forget(path: str | None = typer.Option(None, help="Repository root")) -> None:
     removed = api.forget(_repo_root(path))

--- a/src/vaner/daemon/engine/generator.py
+++ b/src/vaner/daemon/engine/generator.py
@@ -3,13 +3,54 @@
 from __future__ import annotations
 
 import ast
+import asyncio
 import hashlib
+import logging
 import re
 import time
 from pathlib import Path
 
+import httpx
+
 from vaner.models.artefact import Artefact, ArtefactKind
+from vaner.models.config import VanerConfig
 from vaner.policy.privacy import redact_text
+
+logger = logging.getLogger(__name__)
+
+FILE_SUMMARY_PROMPT = """You are generating a precise implementation reference for a developer context system.
+A model will later use this summary to answer exact questions about this file.
+Your summary MUST enable correct answers — not just plausible ones.
+
+Include ALL of the following that are present in the file:
+
+1. CLASSES: name, base class, key attributes with types/defaults
+2. FUNCTIONS/METHODS: name, parameter names and types, return type, one-line behavior description
+3. KEY CONSTANTS: exact name and exact value
+4. IMPORTANT CONDITIONALS: exact conditions and what branches they control
+5. EXCEPTION TYPES: which exceptions are caught or raised and why
+6. FORMULAS/ALGORITHMS: exact expressions
+7. LIMITS/TRUNCATION/CACHING: exact caps, slices, TTLs, or bounded windows
+8. WHAT THIS FILE DOES NOT DO: avoid conflating it with files that call it
+
+Do NOT paraphrase implementation details. Use exact names from the code.
+Do NOT summarize in prose where specifics exist.
+Maximum {max_tokens} tokens.
+
+File: {path}
+---
+{content}
+---
+Implementation reference:"""
+
+DIFF_SUMMARY_PROMPT = """Summarize the following git diff for a developer context system.
+State clearly what changed, which modules/functions were affected, and likely intent.
+Call out exact limits/guards/conditionals when visible.
+Be concise.
+
+{diff}
+---
+Summary:"""
 
 
 def _extract_python_shapes(text: str) -> tuple[list[str], list[str]]:
@@ -105,16 +146,79 @@ def _build_artefact(
     )
 
 
-def generate_file_summary(
+def _extract_message_text(payload: dict) -> str:
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices:
+        message = choices[0].get("message", {})
+        content = message.get("content", "")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+            return "\n".join(parts)
+    return ""
+
+
+async def _llm_summarize(text: str, prompt_template: str, config: VanerConfig, source_label: str) -> str | None:
+    model = config.generation.generation_model or config.backend.model
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt_template}],
+        "temperature": 0,
+        "max_tokens": config.generation.summary_max_tokens,
+    }
+    headers = {"Content-Type": "application/json"}
+    api_key = ""
+    if config.backend.api_key_env:
+        import os
+
+        api_key = os.getenv(config.backend.api_key_env, "")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        async with httpx.AsyncClient(timeout=45) as client:
+            response = await client.post(f"{config.backend.base_url.rstrip('/')}/chat/completions", json=payload, headers=headers)
+            response.raise_for_status()
+        content = _extract_message_text(response.json()).strip()
+        return content or None
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.warning("LLM summary failed for %s: %s", source_label, exc)
+        return None
+
+
+async def agenerate_file_summary(
     source_path: Path,
     repo_root: Path,
     model_name: str = "heuristic-local",
     redact_patterns: list[str] | None = None,
+    config: VanerConfig | None = None,
 ) -> Artefact:
     raw_text = source_path.read_text(encoding="utf-8", errors="ignore")
     sanitized_text = redact_text(raw_text, redact_patterns or [])
     rel_path = str(source_path.relative_to(repo_root))
-    content = _summarize_text(sanitized_text, source_path)
+    max_chars = config.generation.max_file_chars if config is not None else 8000
+    bounded_text = sanitized_text[:max_chars]
+    heuristic_content = _summarize_text(bounded_text, source_path)
+    content = heuristic_content
+    summary_mode = "heuristic"
+
+    if config is not None and config.generation.use_llm and model_name != "heuristic-local":
+        llm_prompt = FILE_SUMMARY_PROMPT.format(
+            path=rel_path,
+            content=bounded_text,
+            max_tokens=config.generation.summary_max_tokens,
+        )
+        llm_content = await _llm_summarize(bounded_text, llm_prompt, config, rel_path)
+        if llm_content:
+            content = llm_content
+            summary_mode = "llm"
+
     return _build_artefact(
         key=f"{ArtefactKind.FILE_SUMMARY.value}:{rel_path}",
         kind=ArtefactKind.FILE_SUMMARY,
@@ -122,7 +226,28 @@ def generate_file_summary(
         source_mtime=source_path.stat().st_mtime,
         model_name=model_name,
         content=content,
-        metadata={"hash": hashlib.sha256(sanitized_text.encode("utf-8")).hexdigest()[:16]},
+        metadata={
+            "hash": hashlib.sha256(sanitized_text.encode("utf-8")).hexdigest()[:16],
+            "summary_mode": summary_mode,
+        },
+    )
+
+
+def generate_file_summary(
+    source_path: Path,
+    repo_root: Path,
+    model_name: str = "heuristic-local",
+    redact_patterns: list[str] | None = None,
+    config: VanerConfig | None = None,
+) -> Artefact:
+    return asyncio.run(
+        agenerate_file_summary(
+            source_path,
+            repo_root,
+            model_name=model_name,
+            redact_patterns=redact_patterns,
+            config=config,
+        )
     )
 
 
@@ -168,15 +293,21 @@ def generate_repo_index(repo_root: Path, files: list[Path], model_name: str = "h
     )
 
 
-def generate_diff_summary(
+async def agenerate_diff_summary(
     repo_root: Path,
     relative_path: str,
     diff_text: str,
     model_name: str = "heuristic-local",
     redact_patterns: list[str] | None = None,
+    config: VanerConfig | None = None,
 ) -> Artefact:
     redacted_diff = redact_text(diff_text, redact_patterns or [])
     compact = _summarize_text(redacted_diff, repo_root / relative_path, max_lines=20)
+    if config is not None and config.generation.use_llm and model_name != "heuristic-local":
+        llm_prompt = DIFF_SUMMARY_PROMPT.format(diff=redacted_diff[: config.generation.max_file_chars])
+        llm_content = await _llm_summarize(redacted_diff, llm_prompt, config, relative_path)
+        if llm_content:
+            compact = llm_content
     abs_path = (repo_root / relative_path).resolve()
     mtime = abs_path.stat().st_mtime if abs_path.exists() else time.time()
     return _build_artefact(
@@ -187,6 +318,26 @@ def generate_diff_summary(
         model_name=model_name,
         content=compact,
         metadata={"lines": str(len(redacted_diff.splitlines()))},
+    )
+
+
+def generate_diff_summary(
+    repo_root: Path,
+    relative_path: str,
+    diff_text: str,
+    model_name: str = "heuristic-local",
+    redact_patterns: list[str] | None = None,
+    config: VanerConfig | None = None,
+) -> Artefact:
+    return asyncio.run(
+        agenerate_diff_summary(
+            repo_root,
+            relative_path,
+            diff_text,
+            model_name=model_name,
+            redact_patterns=redact_patterns,
+            config=config,
+        )
     )
 
 

--- a/src/vaner/daemon/engine/generator.py
+++ b/src/vaner/daemon/engine/generator.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
+import re
 import time
 from pathlib import Path
 
@@ -10,11 +12,75 @@ from vaner.models.artefact import Artefact, ArtefactKind
 from vaner.policy.privacy import redact_text
 
 
-def _summarize_text(text: str, max_lines: int = 8) -> str:
+def _extract_python_shapes(text: str) -> tuple[list[str], list[str]]:
+    """Extract class and function signatures from python sources."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return [], []
+
+    classes: list[str] = []
+    functions: list[str] = []
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            classes.append(node.name)
+        elif isinstance(node, ast.FunctionDef):
+            args = [arg.arg for arg in node.args.args]
+            functions.append(f"{node.name}({', '.join(args)})")
+
+    return classes[:8], functions[:12]
+
+
+def _extract_limits(text: str) -> list[str]:
+    limit_patterns = [
+        r"\b(max|min|limit|ttl|timeout|window|top_n|slice|budget)\w*\b.*",
+        r".*\[\s*:\s*\d+\s*\].*",
+    ]
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    found: list[str] = []
+    for line in lines:
+        lowered = line.lower()
+        if any(re.search(pattern, lowered) for pattern in limit_patterns):
+            found.append(line[:180])
+    return found[:10]
+
+
+def _extract_constants(text: str) -> list[str]:
+    constants: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "=" not in stripped:
+            continue
+        lhs = stripped.split("=", 1)[0].strip()
+        if lhs.isupper() and lhs.replace("_", "").isalnum():
+            constants.append(stripped[:180])
+    return constants[:12]
+
+
+def _summarize_text(text: str, source_path: Path, max_lines: int = 8) -> str:
     lines = [line.strip() for line in text.splitlines() if line.strip()]
     if not lines:
         return "Empty or whitespace-only file."
-    return " ".join(lines[:max_lines])[:1600]
+
+    sections: list[str] = []
+    constants = _extract_constants(text)
+    limits = _extract_limits(text)
+
+    if source_path.suffix == ".py":
+        classes, functions = _extract_python_shapes(text)
+        if classes:
+            sections.append("Classes: " + ", ".join(classes))
+        if functions:
+            sections.append("Functions: " + ", ".join(functions))
+
+    if constants:
+        sections.append("Constants: " + "; ".join(constants[:6]))
+    if limits:
+        sections.append("Limits: " + "; ".join(limits[:6]))
+
+    sections.append("Snippet: " + " ".join(lines[:max_lines])[:900])
+    return "\n".join(sections)[:1600]
 
 
 def _build_artefact(
@@ -48,7 +114,7 @@ def generate_file_summary(
     raw_text = source_path.read_text(encoding="utf-8", errors="ignore")
     sanitized_text = redact_text(raw_text, redact_patterns or [])
     rel_path = str(source_path.relative_to(repo_root))
-    content = _summarize_text(sanitized_text)
+    content = _summarize_text(sanitized_text, source_path)
     return _build_artefact(
         key=f"{ArtefactKind.FILE_SUMMARY.value}:{rel_path}",
         kind=ArtefactKind.FILE_SUMMARY,
@@ -68,7 +134,7 @@ def generate_dir_summary(
 ) -> Artefact:
     rel_dir = str(directory.relative_to(repo_root))
     aggregate = " ".join(summary.content for summary in child_summaries)
-    content = _summarize_text(aggregate, max_lines=12)
+    content = _summarize_text(aggregate, directory, max_lines=12)
     return _build_artefact(
         key=f"{ArtefactKind.DIR_SUMMARY.value}:{rel_dir}",
         kind=ArtefactKind.DIR_SUMMARY,
@@ -110,7 +176,7 @@ def generate_diff_summary(
     redact_patterns: list[str] | None = None,
 ) -> Artefact:
     redacted_diff = redact_text(diff_text, redact_patterns or [])
-    compact = _summarize_text(redacted_diff, max_lines=20)
+    compact = _summarize_text(redacted_diff, repo_root / relative_path, max_lines=20)
     abs_path = (repo_root / relative_path).resolve()
     mtime = abs_path.stat().st_mtime if abs_path.exists() else time.time()
     return _build_artefact(

--- a/src/vaner/daemon/runner.py
+++ b/src/vaner/daemon/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from collections import defaultdict
@@ -23,6 +24,8 @@ from vaner.models.session import WorkingSet
 from vaner.models.signal import SignalEvent
 from vaner.store.artefacts import ArtefactStore
 from vaner.store.telemetry import TelemetryStore
+
+logger = logging.getLogger(__name__)
 
 
 class VanerDaemon:
@@ -72,18 +75,30 @@ class VanerDaemon:
         )
         prioritized_abs = {str((repo_root / rel_path).resolve()) for rel_path in git_paths}
         ranked_targets = [path for path, _ in score_paths(targets, prioritized_paths=prioritized_abs)]
+        max_per_cycle = max(1, self.config.generation.max_generations_per_cycle)
+        concurrent_limit = max(1, self.config.generation.max_concurrent_generations)
+        generation_semaphore = asyncio.Semaphore(concurrent_limit)
         written = 0
         generated_files = []
-        for target in ranked_targets:
-            artefact = await agenerate_file_summary(
-                target,
-                repo_root,
-                model_name=self.config.backend.model,
-                redact_patterns=self.config.privacy.redact_patterns,
-                config=self.config,
-            )
-            await self.store.upsert(artefact)
-            generated_files.append(artefact)
+
+        async def _generate_with_limit(target: Path):
+            async with generation_semaphore:
+                return await agenerate_file_summary(
+                    target,
+                    repo_root,
+                    model_name=self.config.backend.model,
+                    redact_patterns=self.config.privacy.redact_patterns,
+                    config=self.config,
+                )
+
+        generation_tasks = [_generate_with_limit(target) for target in ranked_targets[:max_per_cycle]]
+        generated_results = await asyncio.gather(*generation_tasks, return_exceptions=True)
+        for result in generated_results:
+            if isinstance(result, Exception):
+                logger.warning("Skipping failed file summary generation", exc_info=result)
+                continue
+            await self.store.upsert(result)
+            generated_files.append(result)
             written += 1
 
         by_parent: dict[Path, list] = defaultdict(list)

--- a/src/vaner/daemon/runner.py
+++ b/src/vaner/daemon/runner.py
@@ -9,9 +9,9 @@ from collections import defaultdict
 from pathlib import Path
 
 from vaner.daemon.engine.generator import (
-    generate_diff_summary,
+    agenerate_diff_summary,
+    agenerate_file_summary,
     generate_dir_summary,
-    generate_file_summary,
     generate_repo_index,
 )
 from vaner.daemon.engine.planner import plan_targets
@@ -75,11 +75,12 @@ class VanerDaemon:
         written = 0
         generated_files = []
         for target in ranked_targets:
-            artefact = generate_file_summary(
+            artefact = await agenerate_file_summary(
                 target,
                 repo_root,
                 model_name=self.config.backend.model,
                 redact_patterns=self.config.privacy.redact_patterns,
+                config=self.config,
             )
             await self.store.upsert(artefact)
             generated_files.append(artefact)
@@ -104,12 +105,13 @@ class VanerDaemon:
             diff_text = read_git_diff(repo_root, rel_path)
             if not diff_text:
                 continue
-            diff_artefact = generate_diff_summary(
+            diff_artefact = await agenerate_diff_summary(
                 repo_root,
                 rel_path,
                 diff_text,
                 model_name=self.config.backend.model,
                 redact_patterns=self.config.privacy.redact_patterns,
+                config=self.config,
             )
             await self.store.upsert(diff_artefact)
             written += 1

--- a/src/vaner/eval.py
+++ b/src/vaner/eval.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -9,44 +11,66 @@ from pydantic import BaseModel, Field
 from vaner import api
 
 
-class EvalCase(BaseModel):
-    name: str
-    prompt: str
+class BenchmarkCase(BaseModel):
+    case_id: str
+    question: str
     expected_paths: list[str] = Field(default_factory=list)
+    expected_points: list[str] = Field(default_factory=list)
+    question_type: str = "understanding"
 
 
 class EvalCaseResult(BaseModel):
-    name: str
+    case_id: str
+    question_type: str
     selected_paths: list[str]
     expected_paths: list[str]
     matched_paths: list[str]
+    hit_at_1: bool
+    hit_at_3: bool
+    path_coverage: float
+    point_coverage: float
     token_used: int
     token_budget: int
-    score: float
 
 
 class EvalReport(BaseModel):
+    run_id: str
     repo_root: str
-    overall_score: float
+    cases_path: str
+    results_path: str
+    overall_hit_at_1: float
+    overall_hit_at_3: float
+    overall_path_coverage: float
+    overall_point_coverage: float
     cases: list[EvalCaseResult]
 
 
-DEFAULT_EVAL_CASES = [
-    EvalCase(
-        name="daemon_flow",
-        prompt="Explain how the daemon prepares artefacts.",
-        expected_paths=["src/vaner/daemon/runner.py"],
-    ),
-    EvalCase(
-        name="broker_selection",
-        prompt="How does Vaner select context artefacts?",
-        expected_paths=["src/vaner/broker/selector.py", "src/vaner/broker/assembler.py"],
-    ),
-    EvalCase(
-        name="proxy_enrichment",
-        prompt="How does the OpenAI-compatible proxy enrich requests?",
-        expected_paths=["src/vaner/router/proxy.py"],
-    ),
+DEFAULT_CASES_DATA = [
+    {
+        "case_id": "daemon_flow",
+        "question": "Explain how the daemon prepares artefacts from repository changes.",
+        "expected_paths": ["src/vaner/daemon/runner.py", "src/vaner/daemon/engine/planner.py"],
+        "expected_points": ["run_once", "plan_targets", "score_paths", "upsert_working_set"],
+        "question_type": "mechanism",
+    },
+    {
+        "case_id": "broker_selection",
+        "question": "How does Vaner select and compress context artefacts at query time?",
+        "expected_paths": [
+            "src/vaner/broker/selector.py",
+            "src/vaner/broker/compressor.py",
+            "src/vaner/broker/assembler.py",
+        ],
+        "expected_points": ["select_artefacts", "compress_context", "token_budget", "keyword_overlap"],
+        "question_type": "understanding",
+    },
+    {
+        "case_id": "proxy_enrichment",
+        "question": "How does the OpenAI-compatible proxy enrich chat completions with repository context?",
+        "expected_paths": ["src/vaner/router/proxy.py", "src/vaner/api.py", "src/vaner/router/backends.py"],
+        "expected_points": ["chat/completions", "injected_context", "forward_chat_completion", "stream_chat_completion"],
+        "question_type": "wiring",
+    },
 ]
 
 
@@ -54,27 +78,97 @@ def _resolve_repo_root(path: Path | str) -> Path:
     return path.resolve() if isinstance(path, Path) else Path(path).resolve()
 
 
-def evaluate_repo(repo_root: Path | str) -> EvalReport:
+def _default_cases_path(repo_root: Path) -> Path:
+    return repo_root / "eval" / "cases" / "default.json"
+
+
+def _default_output_dir(repo_root: Path) -> Path:
+    return repo_root / "eval" / "runs"
+
+
+def load_cases(repo_root: Path, cases_path: Path | None = None) -> list[BenchmarkCase]:
+    resolved_cases_path = (cases_path or _default_cases_path(repo_root)).resolve()
+    if not resolved_cases_path.exists():
+        return [BenchmarkCase(**item) for item in DEFAULT_CASES_DATA]
+    raw = json.loads(resolved_cases_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError(f"Cases file must contain a JSON array: {resolved_cases_path}")
+    return [BenchmarkCase(**item) for item in raw]
+
+
+def _score_case(case: BenchmarkCase, selected_paths: list[str], injected_context: str) -> tuple[list[str], bool, bool, float, float]:
+    matched_paths = [path for path in case.expected_paths if path in selected_paths]
+    top_1 = selected_paths[:1]
+    top_3 = selected_paths[:3]
+    hit_at_1 = any(path in top_1 for path in case.expected_paths)
+    hit_at_3 = any(path in top_3 for path in case.expected_paths)
+    path_coverage = len(matched_paths) / max(1, len(case.expected_paths))
+
+    lowered_context = injected_context.lower()
+    matched_points = sum(1 for point in case.expected_points if point.lower() in lowered_context)
+    point_coverage = matched_points / max(1, len(case.expected_points))
+    return matched_paths, hit_at_1, hit_at_3, path_coverage, point_coverage
+
+
+def run_eval(
+    repo_root: Path | str,
+    *,
+    cases_path: Path | None = None,
+    output_dir: Path | None = None,
+) -> EvalReport:
     resolved_root = _resolve_repo_root(repo_root)
+    resolved_cases_path = (cases_path or _default_cases_path(resolved_root)).resolve()
+    resolved_output_dir = (output_dir or _default_output_dir(resolved_root)).resolve()
+    cases = load_cases(resolved_root, resolved_cases_path)
+
     api.prepare(resolved_root)
     results: list[EvalCaseResult] = []
+    run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
 
-    for case in DEFAULT_EVAL_CASES:
-        package = api.query(case.prompt, resolved_root)
+    for case in cases:
+        package = api.query(case.question, resolved_root)
         selected_paths = [selection.source_path for selection in package.selections]
-        matched_paths = [path for path in case.expected_paths if path in selected_paths]
-        score = len(matched_paths) / max(1, len(case.expected_paths))
+        matched_paths, hit_at_1, hit_at_3, path_coverage, point_coverage = _score_case(
+            case, selected_paths, package.injected_context
+        )
         results.append(
             EvalCaseResult(
-                name=case.name,
+                case_id=case.case_id,
+                question_type=case.question_type,
                 selected_paths=selected_paths,
                 expected_paths=case.expected_paths,
                 matched_paths=matched_paths,
+                hit_at_1=hit_at_1,
+                hit_at_3=hit_at_3,
+                path_coverage=path_coverage,
+                point_coverage=point_coverage,
                 token_used=package.token_used,
                 token_budget=package.token_budget,
-                score=score,
             )
         )
 
-    overall_score = sum(result.score for result in results) / max(1, len(results))
-    return EvalReport(repo_root=str(resolved_root), overall_score=overall_score, cases=results)
+    overall_hit_at_1 = sum(1.0 for result in results if result.hit_at_1) / max(1, len(results))
+    overall_hit_at_3 = sum(1.0 for result in results if result.hit_at_3) / max(1, len(results))
+    overall_path_coverage = sum(result.path_coverage for result in results) / max(1, len(results))
+    overall_point_coverage = sum(result.point_coverage for result in results) / max(1, len(results))
+
+    resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    results_path = resolved_output_dir / f"{run_id}.json"
+    report = EvalReport(
+        run_id=run_id,
+        repo_root=str(resolved_root),
+        cases_path=str(resolved_cases_path),
+        results_path=str(results_path),
+        overall_hit_at_1=overall_hit_at_1,
+        overall_hit_at_3=overall_hit_at_3,
+        overall_path_coverage=overall_path_coverage,
+        overall_point_coverage=overall_point_coverage,
+        cases=results,
+    )
+    results_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+    return report
+
+
+def evaluate_repo(repo_root: Path | str) -> EvalReport:
+    """Backward compatible entrypoint used by existing tests/CLI."""
+    return run_eval(repo_root)

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -19,6 +19,12 @@ class BackendConfig(BaseModel):
     base_url: str = "https://api.openai.com/v1"
     model: str = "gpt-4o-mini"
     api_key_env: str = "OPENAI_API_KEY"
+    prefer_local: bool = True
+    fallback_enabled: bool = False
+    fallback_base_url: str | None = None
+    fallback_model: str | None = None
+    fallback_api_key_env: str = "OPENAI_API_KEY"
+    remote_budget_per_hour: int = 60
 
 
 class VanerConfig(BaseModel):

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -32,11 +32,15 @@ class GenerationConfig(BaseModel):
     generation_model: str | None = None
     max_file_chars: int = 8000
     summary_max_tokens: int = 400
+    max_concurrent_generations: int = 4
+    max_generations_per_cycle: int = 200
 
 
 class ProxyConfig(BaseModel):
     proxy_token: str | None = None
     max_requests_per_minute: int = 120
+    ssl_certfile: str | None = None
+    ssl_keyfile: str | None = None
 
 
 class VanerConfig(BaseModel):

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -27,6 +27,18 @@ class BackendConfig(BaseModel):
     remote_budget_per_hour: int = 60
 
 
+class GenerationConfig(BaseModel):
+    use_llm: bool = False
+    generation_model: str | None = None
+    max_file_chars: int = 8000
+    summary_max_tokens: int = 400
+
+
+class ProxyConfig(BaseModel):
+    proxy_token: str | None = None
+    max_requests_per_minute: int = 120
+
+
 class VanerConfig(BaseModel):
     repo_root: Path
     store_path: Path
@@ -35,3 +47,5 @@ class VanerConfig(BaseModel):
     max_context_tokens: int = 4096
     backend: BackendConfig = Field(default_factory=BackendConfig)
     privacy: PrivacyConfig = Field(default_factory=PrivacyConfig)
+    generation: GenerationConfig = Field(default_factory=GenerationConfig)
+    proxy: ProxyConfig = Field(default_factory=ProxyConfig)

--- a/src/vaner/router/backends.py
+++ b/src/vaner/router/backends.py
@@ -2,42 +2,147 @@
 
 from __future__ import annotations
 
+import json
 import os
+import time
+from pathlib import Path
 from typing import Any
 
 import httpx
 
-from vaner.models.config import BackendConfig
+from vaner.models.config import BackendConfig, VanerConfig
 
 
-async def forward_chat_completion(backend: BackendConfig, payload: dict[str, Any]) -> dict[str, Any]:
-    api_key = os.getenv(backend.api_key_env, "")
+def _headers(backend: BackendConfig, *, use_fallback: bool = False) -> dict[str, str]:
+    key_env = backend.fallback_api_key_env if use_fallback else backend.api_key_env
+    api_key = os.getenv(key_env, "")
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _base_url(backend: BackendConfig, *, use_fallback: bool = False) -> str:
+    if use_fallback and backend.fallback_base_url:
+        return backend.fallback_base_url.rstrip("/")
+    return backend.base_url.rstrip("/")
+
+
+def _is_local_backend(base_url: str) -> bool:
+    lowered = base_url.lower()
+    return "localhost" in lowered or "127.0.0.1" in lowered or "0.0.0.0" in lowered
+
+
+def _budget_state_path(repo_root: Path) -> Path:
+    return repo_root / ".vaner" / "runtime" / "remote_budget.json"
+
+
+def _consume_remote_budget(repo_root: Path, max_per_hour: int) -> bool:
+    now = int(time.time())
+    hour = now // 3600
+    state_path = _budget_state_path(repo_root)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    state = {"hour": hour, "used": 0}
+    if state_path.exists():
+        try:
+            parsed = json.loads(state_path.read_text(encoding="utf-8"))
+            if isinstance(parsed, dict):
+                state["hour"] = int(parsed.get("hour", hour))
+                state["used"] = int(parsed.get("used", 0))
+        except Exception:
+            state = {"hour": hour, "used": 0}
+
+    if state["hour"] != hour:
+        state = {"hour": hour, "used": 0}
+    if state["used"] >= max_per_hour:
+        return False
+
+    state["used"] += 1
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    return True
+
+
+async def _post_chat(backend: BackendConfig, payload: dict[str, Any], *, use_fallback: bool = False) -> dict[str, Any]:
+    headers = _headers(backend, use_fallback=use_fallback)
+    base_url = _base_url(backend, use_fallback=use_fallback)
+    model_name = backend.fallback_model if use_fallback and backend.fallback_model else backend.model
+    final_payload = payload if "model" in payload else {**payload, "model": model_name}
     async with httpx.AsyncClient(timeout=60) as client:
         response = await client.post(
-            f"{backend.base_url}/chat/completions",
-            json=payload,
+            f"{base_url}/chat/completions",
+            json=final_payload,
             headers=headers,
         )
         response.raise_for_status()
         return response.json()
 
 
-async def stream_chat_completion(backend: BackendConfig, payload: dict[str, Any]):
+def _should_use_fallback(config: VanerConfig, primary_failed: bool) -> bool:
+    backend = config.backend
+    has_fallback = bool(backend.fallback_base_url)
+    if not backend.fallback_enabled or not has_fallback:
+        return False
+    if primary_failed:
+        return True
+    # Local-first routing: use fallback only when primary isn't local.
+    return backend.prefer_local and not _is_local_backend(backend.base_url)
+
+
+async def forward_chat_completion(config: VanerConfig, payload: dict[str, Any]) -> dict[str, Any]:
+    backend = config.backend
+    primary_error: Exception | None = None
+
     api_key = os.getenv(backend.api_key_env, "")
-    headers = {"Content-Type": "application/json"}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        # If no primary credentials exist and fallback is configured, skip straight to fallback.
+        if api_key or _is_local_backend(backend.base_url):
+            return await _post_chat(backend, payload, use_fallback=False)
+        primary_error = RuntimeError("Primary backend credentials are missing.")
+    except Exception as exc:
+        primary_error = exc
+
+    if _should_use_fallback(config, primary_failed=True):
+        if not _consume_remote_budget(config.repo_root, backend.remote_budget_per_hour):
+            raise RuntimeError("Remote fallback budget exhausted for this hour.") from primary_error
+        return await _post_chat(backend, payload, use_fallback=True)
+
+    assert primary_error is not None
+    raise primary_error
+
+
+async def _stream_chat(backend: BackendConfig, payload: dict[str, Any], *, use_fallback: bool = False):
+    headers = _headers(backend, use_fallback=use_fallback)
+    base_url = _base_url(backend, use_fallback=use_fallback)
+    model_name = backend.fallback_model if use_fallback and backend.fallback_model else backend.model
+    final_payload = payload if "model" in payload else {**payload, "model": model_name}
     async with httpx.AsyncClient(timeout=60) as client:
         async with client.stream(
             "POST",
-            f"{backend.base_url}/chat/completions",
-            json=payload,
+            f"{base_url}/chat/completions",
+            json=final_payload,
             headers=headers,
         ) as response:
             response.raise_for_status()
             async for chunk in response.aiter_bytes():
                 if chunk:
                     yield chunk
+
+
+async def stream_chat_completion(config: VanerConfig, payload: dict[str, Any]):
+    backend = config.backend
+    api_key = os.getenv(backend.api_key_env, "")
+    try:
+        if api_key or _is_local_backend(backend.base_url):
+            async for chunk in _stream_chat(backend, payload, use_fallback=False):
+                yield chunk
+            return
+        raise RuntimeError("Primary backend credentials are missing.")
+    except Exception as exc:
+        if _should_use_fallback(config, primary_failed=True):
+            if not _consume_remote_budget(config.repo_root, backend.remote_budget_per_hour):
+                raise RuntimeError("Remote fallback budget exhausted for this hour.") from exc
+            async for chunk in _stream_chat(backend, payload, use_fallback=True):
+                yield chunk
+            return
+        raise

--- a/src/vaner/router/proxy.py
+++ b/src/vaner/router/proxy.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import time
+from collections import deque
 from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from vaner.api import aquery
@@ -37,6 +39,22 @@ def _normalize_message_content(content: Any) -> str:
     return ""
 
 
+class _RateLimiter:
+    def __init__(self, max_requests_per_minute: int) -> None:
+        self.max_requests_per_minute = max(1, max_requests_per_minute)
+        self._timestamps = deque()
+
+    def allow(self) -> bool:
+        now = time.monotonic()
+        cutoff = now - 60.0
+        while self._timestamps and self._timestamps[0] < cutoff:
+            self._timestamps.popleft()
+        if len(self._timestamps) >= self.max_requests_per_minute:
+            return False
+        self._timestamps.append(now)
+        return True
+
+
 def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
     @asynccontextmanager
     async def lifespan(_: FastAPI):
@@ -44,9 +62,18 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
         yield
 
     app = FastAPI(title="Vaner Proxy", version="0.1.0", lifespan=lifespan)
+    limiter = _RateLimiter(config.proxy.max_requests_per_minute)
+    required_token = (config.proxy.proxy_token or "").strip()
 
     @app.post("/v1/chat/completions")
-    async def chat_completions(payload: dict[str, Any]) -> Any:
+    async def chat_completions(payload: dict[str, Any], request: Request) -> Any:
+        if required_token:
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header != f"Bearer {required_token}":
+                raise HTTPException(status_code=401, detail="Missing or invalid proxy token.")
+        if not limiter.allow():
+            raise HTTPException(status_code=429, detail="Rate limit exceeded.")
+
         user_messages = [msg for msg in payload.get("messages", []) if msg.get("role") == "user"]
         prompt = _normalize_message_content(user_messages[-1].get("content")) if user_messages else ""
         context_package = await aquery(prompt, config.repo_root, config=config, top_n=6)

--- a/src/vaner/router/proxy.py
+++ b/src/vaner/router/proxy.py
@@ -53,8 +53,8 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
         enriched = _inject_context(payload, context_package.injected_context)
         try:
             if payload.get("stream") is True:
-                return StreamingResponse(stream_chat_completion(config.backend, enriched), media_type="text/event-stream")
-            return await forward_chat_completion(config.backend, enriched)
+                return StreamingResponse(stream_chat_completion(config, enriched), media_type="text/event-stream")
+            return await forward_chat_completion(config, enriched)
         except Exception as exc:  # pragma: no cover - network errors
             raise HTTPException(status_code=502, detail=str(exc)) from exc
 

--- a/tests/test_broker/test_compressor.py
+++ b/tests/test_broker/test_compressor.py
@@ -42,3 +42,17 @@ def test_compressor_counts_tokens_once():
     artefacts = [_artefact("a", "a.py", "alpha " * 20), _artefact("b", "b.py", "beta " * 20)]
     _, token_map, used, kept = compress_context(artefacts, max_tokens=200)
     assert used == sum(token_map[key] for key in kept)
+
+
+def test_compressor_prefers_high_score_when_order_unsorted():
+    artefacts = [
+        _artefact("low", "low.py", "tiny chunk"),
+        _artefact("high", "high.py", "tiny chunk"),
+    ]
+    context, _, _, kept = compress_context(
+        artefacts,
+        max_tokens=100,
+        score_by_key={"high": 10.0, "low": 1.0},
+    )
+    assert kept == {"high", "low"}
+    assert context.index("high.py") < context.index("low.py")

--- a/tests/test_broker/test_selector.py
+++ b/tests/test_broker/test_selector.py
@@ -62,3 +62,28 @@ def test_select_artefacts_prefers_git_and_working_set_matches():
         preferred_keys={"file_summary:b.py"},
     )
     assert selected[0].key == "file_summary:b.py"
+
+
+def test_select_artefacts_origin_rerank_prefers_definition_files():
+    artefacts = [
+        Artefact(
+            key="file_summary:a.py",
+            kind=ArtefactKind.FILE_SUMMARY,
+            source_path="a.py",
+            source_mtime=time.time(),
+            generated_at=time.time(),
+            model="test",
+            content="Functions: evaluate() Snippet: generic processing",
+        ),
+        Artefact(
+            key="file_summary:b.py",
+            kind=ArtefactKind.FILE_SUMMARY,
+            source_path="b.py",
+            source_mtime=time.time(),
+            generated_at=time.time(),
+            model="test",
+            content="Functions: _is_stale_cache() Snippet: stale checks and refresh decisions",
+        ),
+    ]
+    selected = select_artefacts("where is stale cache checked", artefacts, top_n=1)
+    assert selected[0].key == "file_summary:b.py"

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -15,6 +15,18 @@ name = "openai"
 base_url = "https://example.com/v1"
 model = "example-model"
 api_key_env = "API_KEY"
+prefer_local = true
+fallback_enabled = true
+fallback_base_url = "https://fallback.example.com/v1"
+fallback_model = "fallback-model"
+fallback_api_key_env = "FALLBACK_KEY"
+remote_budget_per_hour = 12
+
+[generation]
+use_llm = true
+generation_model = "gpt-test"
+max_file_chars = 5000
+summary_max_tokens = 256
 
 [privacy]
 allowed_paths = ["src/**"]
@@ -32,6 +44,10 @@ max_context_tokens = 2048
     config = load_config(temp_repo)
 
     assert config.backend.base_url == "https://example.com/v1"
+    assert config.backend.fallback_enabled is True
+    assert config.backend.remote_budget_per_hour == 12
+    assert config.generation.use_llm is True
+    assert config.generation.generation_model == "gpt-test"
     assert config.privacy.allowed_paths == ["src/**"]
     assert config.max_age_seconds == 120
     assert config.max_context_tokens == 2048

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -27,6 +27,14 @@ use_llm = true
 generation_model = "gpt-test"
 max_file_chars = 5000
 summary_max_tokens = 256
+max_concurrent_generations = 2
+max_generations_per_cycle = 15
+
+[proxy]
+proxy_token = "token"
+max_requests_per_minute = 10
+ssl_certfile = "/tmp/test-cert.pem"
+ssl_keyfile = "/tmp/test-key.pem"
 
 [privacy]
 allowed_paths = ["src/**"]
@@ -48,6 +56,10 @@ max_context_tokens = 2048
     assert config.backend.remote_budget_per_hour == 12
     assert config.generation.use_llm is True
     assert config.generation.generation_model == "gpt-test"
+    assert config.generation.max_concurrent_generations == 2
+    assert config.generation.max_generations_per_cycle == 15
+    assert config.proxy.proxy_token == "token"
+    assert config.proxy.ssl_certfile == "/tmp/test-cert.pem"
     assert config.privacy.allowed_paths == ["src/**"]
     assert config.max_age_seconds == 120
     assert config.max_context_tokens == 2048

--- a/tests/test_cli/test_eval.py
+++ b/tests/test_cli/test_eval.py
@@ -9,3 +9,4 @@ def test_eval_report_shape(temp_repo):
     report = evaluate_repo(temp_repo)
     assert report.repo_root
     assert report.cases
+    assert report.results_path

--- a/tests/test_daemon/test_generator.py
+++ b/tests/test_daemon/test_generator.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from vaner.daemon.engine.generator import generate_artefact, generate_diff_summary
+import asyncio
+
+from vaner.daemon.engine import generator as generator_mod
+from vaner.daemon.engine.generator import agenerate_file_summary, generate_artefact, generate_diff_summary
+from vaner.models.config import GenerationConfig, VanerConfig
 
 
 def test_generate_artefact_for_normal_file(temp_repo):
@@ -45,3 +49,55 @@ def test_generate_diff_summary_redacts_patterns(temp_repo):
         redact_patterns=[r"secret\d+"],
     )
     assert "REDACTED" in artefact.content
+
+
+def test_agenerate_file_summary_uses_llm_when_enabled(temp_repo, monkeypatch):
+    source = temp_repo / "llm.py"
+    source.write_text("def x():\n    return 1\n", encoding="utf-8")
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+        generation=GenerationConfig(use_llm=True, generation_model="gpt-test"),
+    )
+
+    async def _fake_llm(text: str, prompt_template: str, config_obj: VanerConfig, source_label: str) -> str:
+        return "LLM precise summary"
+
+    monkeypatch.setattr(generator_mod, "_llm_summarize", _fake_llm)
+    artefact = asyncio.run(
+        agenerate_file_summary(
+            source,
+            temp_repo,
+            model_name="gpt-test",
+            config=config,
+        )
+    )
+    assert artefact.content == "LLM precise summary"
+    assert artefact.metadata["summary_mode"] == "llm"
+
+
+def test_agenerate_file_summary_falls_back_to_heuristic_when_llm_fails(temp_repo, monkeypatch):
+    source = temp_repo / "fallback.py"
+    source.write_text("MAX_A = 10\n\ndef x():\n    return MAX_A\n", encoding="utf-8")
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+        generation=GenerationConfig(use_llm=True, generation_model="gpt-test"),
+    )
+
+    async def _fake_llm_none(text: str, prompt_template: str, config_obj: VanerConfig, source_label: str) -> str | None:
+        return None
+
+    monkeypatch.setattr(generator_mod, "_llm_summarize", _fake_llm_none)
+    artefact = asyncio.run(
+        agenerate_file_summary(
+            source,
+            temp_repo,
+            model_name="gpt-test",
+            config=config,
+        )
+    )
+    assert "Functions:" in artefact.content
+    assert artefact.metadata["summary_mode"] == "heuristic"

--- a/tests/test_daemon/test_generator.py
+++ b/tests/test_daemon/test_generator.py
@@ -7,10 +7,19 @@ from vaner.daemon.engine.generator import generate_artefact, generate_diff_summa
 
 def test_generate_artefact_for_normal_file(temp_repo):
     source = temp_repo / "normal.py"
-    source.write_text("def f():\n    return 1\n", encoding="utf-8")
+    source.write_text(
+        "MAX_ITEMS = 10\n\n"
+        "class Service:\n"
+        "    pass\n\n"
+        "def f(limit: int = 5):\n"
+        "    return list(range(limit))[:MAX_ITEMS]\n",
+        encoding="utf-8",
+    )
     artefact = generate_artefact(source, temp_repo)
     assert artefact.source_path == "normal.py"
-    assert artefact.content
+    assert "Functions:" in artefact.content
+    assert "Constants:" in artefact.content
+    assert "Limits:" in artefact.content
 
 
 def test_generate_artefact_for_empty_file(temp_repo):

--- a/tests/test_daemon/test_runner.py
+++ b/tests/test_daemon/test_runner.py
@@ -19,3 +19,23 @@ async def test_daemon_run_once_writes_artefacts(temp_repo):
     await daemon.initialize()
     written = await daemon.run_once()
     assert written >= 1
+
+
+@pytest.mark.asyncio
+async def test_daemon_respects_max_generations_per_cycle(temp_repo):
+    for idx in range(5):
+        (temp_repo / f"mod_{idx}.py").write_text(f"def fn_{idx}():\n    return {idx}\n", encoding="utf-8")
+
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+    )
+    config.generation.max_generations_per_cycle = 2
+
+    daemon = VanerDaemon(config)
+    await daemon.initialize()
+    written = await daemon.run_once(changed_files=sorted(temp_repo.glob("*.py")))
+
+    # Includes capped file summaries plus a repo index artefact.
+    assert written <= config.generation.max_generations_per_cycle + 2

--- a/tests/test_eval_report.py
+++ b/tests/test_eval_report.py
@@ -7,5 +7,6 @@ from vaner.eval import evaluate_repo
 
 def test_evaluate_repo_returns_report(temp_repo):
     report = evaluate_repo(temp_repo)
-    assert 0.0 <= report.overall_score <= 1.0
+    assert 0.0 <= report.overall_hit_at_3 <= 1.0
+    assert 0.0 <= report.overall_path_coverage <= 1.0
     assert len(report.cases) >= 1

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from vaner.eval import load_cases, run_eval
+
+
+def test_load_cases_reads_default_cases(temp_repo):
+    cases = load_cases(temp_repo)
+    assert len(cases) >= 1
+    assert cases[0].case_id
+
+
+def test_run_eval_writes_report_file(temp_repo):
+    report = run_eval(temp_repo)
+    assert report.results_path
+    assert report.cases_path.endswith("eval/cases/default.json")

--- a/tests/test_router/test_backends.py
+++ b/tests/test_router/test_backends.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+
+from vaner.models.config import BackendConfig, VanerConfig
+from vaner.router import backends
+
+
+def _config(temp_repo, **backend_overrides) -> VanerConfig:
+    backend = BackendConfig(**backend_overrides)
+    return VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+        backend=backend,
+    )
+
+
+def test_is_local_backend():
+    assert backends._is_local_backend("http://localhost:11434/v1")
+    assert backends._is_local_backend("http://127.0.0.1:8000/v1")
+    assert not backends._is_local_backend("https://api.openai.com/v1")
+
+
+def test_remote_budget_is_enforced(temp_repo):
+    assert backends._consume_remote_budget(temp_repo, max_per_hour=2)
+    assert backends._consume_remote_budget(temp_repo, max_per_hour=2)
+    assert not backends._consume_remote_budget(temp_repo, max_per_hour=2)
+
+
+def test_forward_chat_completion_uses_fallback_when_primary_fails(temp_repo, monkeypatch):
+    config = _config(
+        temp_repo,
+        base_url="http://localhost:11434/v1",
+        fallback_enabled=True,
+        fallback_base_url="https://api.openai.com/v1",
+        remote_budget_per_hour=3,
+    )
+
+    calls: list[bool] = []
+
+    async def _fake_post_chat(backend, payload, *, use_fallback=False):
+        calls.append(use_fallback)
+        if not use_fallback:
+            raise RuntimeError("primary unavailable")
+        return {"id": "ok"}
+
+    monkeypatch.setattr(backends, "_post_chat", _fake_post_chat)
+    result = asyncio.run(backends.forward_chat_completion(config, {"messages": []}))
+    assert result["id"] == "ok"
+    assert calls == [False, True]

--- a/tests/test_router/test_proxy_app.py
+++ b/tests/test_router/test_proxy_app.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from vaner.models.config import VanerConfig
+from fastapi.testclient import TestClient
+
+from vaner.models.config import ProxyConfig, VanerConfig
+from vaner.router import proxy as proxy_module
 from vaner.router.proxy import create_app
 from vaner.store.artefacts import ArtefactStore
 
@@ -15,3 +18,62 @@ def test_create_proxy_app(temp_repo):
     )
     app = create_app(config, ArtefactStore(config.store_path))
     assert app.title == "Vaner Proxy"
+
+
+def test_proxy_requires_token_when_configured(temp_repo, monkeypatch):
+    class _Package:
+        injected_context = "context"
+
+    async def _fake_aquery(prompt, repo_root, config=None, top_n=6):
+        return _Package()
+
+    async def _fake_forward_chat_completion(config, payload):
+        return {"id": "ok"}
+
+    monkeypatch.setattr(proxy_module, "aquery", _fake_aquery)
+    monkeypatch.setattr(proxy_module, "forward_chat_completion", _fake_forward_chat_completion)
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+        proxy=ProxyConfig(proxy_token="abc123", max_requests_per_minute=10),
+    )
+    app = create_app(config, ArtefactStore(config.store_path))
+    client = TestClient(app)
+
+    no_auth = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]})
+    assert no_auth.status_code == 401
+
+    with_auth = client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer abc123"},
+    )
+    assert with_auth.status_code == 200
+
+
+def test_proxy_rate_limits_requests(temp_repo, monkeypatch):
+    class _Package:
+        injected_context = "context"
+
+    async def _fake_aquery(prompt, repo_root, config=None, top_n=6):
+        return _Package()
+
+    async def _fake_forward_chat_completion(config, payload):
+        return {"id": "ok"}
+
+    monkeypatch.setattr(proxy_module, "aquery", _fake_aquery)
+    monkeypatch.setattr(proxy_module, "forward_chat_completion", _fake_forward_chat_completion)
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+        proxy=ProxyConfig(max_requests_per_minute=1),
+    )
+    app = create_app(config, ArtefactStore(config.store_path))
+    client = TestClient(app)
+
+    first = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]})
+    second = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]})
+    assert first.status_code == 200
+    assert second.status_code == 429


### PR DESCRIPTION
## Summary
- add local-first backend routing with cloud fallback budget gating and coverage tests
- improve heuristic generator summaries (AST classes/functions, constants, limits) and origin-aware reranking
- expand CI to Python 3.11/3.12 matrix with stricter coverage threshold

## Test plan
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/pytest tests/`

Made with [Cursor](https://cursor.com)