### PR TITLE
fix(release): unblock docker tags and tolerate missing PyPI publisher

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
       id-token: write
     env:
-      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vaner
+      IMAGE_NAME: ghcr.io/borgels/vaner
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,5 @@ jobs:
         with:
           subject-path: "dist/*"
       - name: Publish to PyPI
+        continue-on-error: true
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Summary
- set Docker release image name to lowercase ghcr path
- keep PyPI publish step non-fatal until trusted publisher mapping is finalized

## Test plan
- retag v0.1.0 after merge and confirm Release and Docker workflows succeed

Made with [Cursor](https://cursor.com)