### PR TITLE
fix(docker): include README in build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # Install Vaner with all optional dependencies
 COPY pyproject.toml ./
+COPY README.md ./
 COPY src/ ./src/
 
 RUN pip install --no-cache-dir -e ".[all]"


### PR DESCRIPTION
## Summary
- copy README.md in Dockerfile before Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/abo/repos/Vaner
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: aiosqlite>=0.20 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (0.22.1)
Requirement already satisfied: fastapi>=0.115 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (0.135.3)
Requirement already satisfied: httpx>=0.27 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (0.28.1)
Requirement already satisfied: lightgbm>=4.5 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (4.6.0)
Requirement already satisfied: numpy>=1.26 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (2.4.4)
Requirement already satisfied: pydantic>=2.7 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (2.13.1)
Requirement already satisfied: tiktoken>=0.7 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (0.12.0)
Requirement already satisfied: typer>=0.12 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (0.24.1)
Requirement already satisfied: uvicorn>=0.30 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (0.44.0)
Requirement already satisfied: watchdog>=4.0 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (6.0.0)
Collecting mcp>=1.0 (from mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading mcp-1.27.0-py3-none-any.whl.metadata (8.2 kB)
Requirement already satisfied: sentence-transformers>=3.0 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (5.4.1)
Requirement already satisfied: starlette>=0.40 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (1.0.0)
Requirement already satisfied: torch>=2.3 in /home/abo/.local/lib/python3.12/site-packages (from vaner==0.1.0) (2.11.0)
Requirement already satisfied: typing-extensions>=4.8.0 in /home/abo/.local/lib/python3.12/site-packages (from fastapi>=0.115->vaner==0.1.0) (4.15.0)
Requirement already satisfied: typing-inspection>=0.4.2 in /home/abo/.local/lib/python3.12/site-packages (from fastapi>=0.115->vaner==0.1.0) (0.4.2)
Requirement already satisfied: annotated-doc>=0.0.2 in /home/abo/.local/lib/python3.12/site-packages (from fastapi>=0.115->vaner==0.1.0) (0.0.4)
Requirement already satisfied: anyio in /home/abo/.local/lib/python3.12/site-packages (from httpx>=0.27->vaner==0.1.0) (4.13.0)
Requirement already satisfied: certifi in /usr/lib/python3/dist-packages (from httpx>=0.27->vaner==0.1.0) (2023.11.17)
Requirement already satisfied: httpcore==1.* in /home/abo/.local/lib/python3.12/site-packages (from httpx>=0.27->vaner==0.1.0) (1.0.9)
Requirement already satisfied: idna in /usr/lib/python3/dist-packages (from httpx>=0.27->vaner==0.1.0) (3.6)
Requirement already satisfied: h11>=0.16 in /home/abo/.local/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.27->vaner==0.1.0) (0.16.0)
Requirement already satisfied: scipy in /home/abo/.local/lib/python3.12/site-packages (from lightgbm>=4.5->vaner==0.1.0) (1.17.1)
Collecting httpx-sse>=0.4 (from mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading httpx_sse-0.4.3-py3-none-any.whl.metadata (9.7 kB)
Collecting jsonschema>=4.20.0 (from mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading jsonschema-4.26.0-py3-none-any.whl.metadata (7.6 kB)
Collecting pydantic-settings>=2.5.2 (from mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading pydantic_settings-2.13.1-py3-none-any.whl.metadata (3.4 kB)
Collecting pyjwt>=2.10.1 (from pyjwt[crypto]>=2.10.1->mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading pyjwt-2.12.1-py3-none-any.whl.metadata (4.1 kB)
Collecting python-multipart>=0.0.9 (from mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading python_multipart-0.0.26-py3-none-any.whl.metadata (2.1 kB)
Collecting sse-starlette>=1.6.1 (from mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading sse_starlette-3.3.4-py3-none-any.whl.metadata (14 kB)
Collecting python-dotenv>=1.0.0 (from mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading python_dotenv-1.2.2-py3-none-any.whl.metadata (27 kB)
Requirement already satisfied: annotated-types>=0.6.0 in /home/abo/.local/lib/python3.12/site-packages (from pydantic>=2.7->vaner==0.1.0) (0.7.0)
Requirement already satisfied: pydantic-core==2.46.1 in /home/abo/.local/lib/python3.12/site-packages (from pydantic>=2.7->vaner==0.1.0) (2.46.1)
Requirement already satisfied: transformers<6.0.0,>=4.41.0 in /home/abo/.local/lib/python3.12/site-packages (from sentence-transformers>=3.0->vaner==0.1.0) (5.5.4)
Requirement already satisfied: huggingface-hub>=0.23.0 in /home/abo/.local/lib/python3.12/site-packages (from sentence-transformers>=3.0->vaner==0.1.0) (1.10.2)
Requirement already satisfied: scikit-learn>=0.22.0 in /home/abo/.local/lib/python3.12/site-packages (from sentence-transformers>=3.0->vaner==0.1.0) (1.8.0)
Requirement already satisfied: tqdm>=4.0.0 in /home/abo/.local/lib/python3.12/site-packages (from sentence-transformers>=3.0->vaner==0.1.0) (4.67.3)
Requirement already satisfied: regex>=2022.1.18 in /home/abo/.local/lib/python3.12/site-packages (from tiktoken>=0.7->vaner==0.1.0) (2026.4.4)
Requirement already satisfied: requests>=2.26.0 in /home/abo/.local/lib/python3.12/site-packages (from tiktoken>=0.7->vaner==0.1.0) (2.33.1)
Requirement already satisfied: filelock in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (3.28.0)
Requirement already satisfied: setuptools<82 in /usr/lib/python3/dist-packages (from torch>=2.3->vaner==0.1.0) (68.1.2)
Requirement already satisfied: sympy>=1.13.3 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (1.14.0)
Requirement already satisfied: networkx>=2.5.1 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (3.6.1)
Requirement already satisfied: jinja2 in /usr/lib/python3/dist-packages (from torch>=2.3->vaner==0.1.0) (3.1.2)
Requirement already satisfied: fsspec>=0.8.5 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (2026.2.0)
Requirement already satisfied: cuda-toolkit==13.0.2 in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (13.0.2)
Requirement already satisfied: cuda-bindings<14,>=13.0.3 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (13.2.0)
Requirement already satisfied: nvidia-cudnn-cu13==9.19.0.56 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (9.19.0.56)
Requirement already satisfied: nvidia-cusparselt-cu13==0.8.0 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (0.8.0)
Requirement already satisfied: nvidia-nccl-cu13==2.28.9 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (2.28.9)
Requirement already satisfied: nvidia-nvshmem-cu13==3.4.5 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (3.4.5)
Requirement already satisfied: triton==3.6.0 in /home/abo/.local/lib/python3.12/site-packages (from torch>=2.3->vaner==0.1.0) (3.6.0)
Requirement already satisfied: nvidia-cublas==13.1.0.3.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (13.1.0.3)
Requirement already satisfied: nvidia-cuda-runtime==13.0.96.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (13.0.96)
Requirement already satisfied: nvidia-cufft==12.0.0.61.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (12.0.0.61)
Requirement already satisfied: nvidia-cufile==1.15.1.6.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (1.15.1.6)
Requirement already satisfied: nvidia-cuda-cupti==13.0.85.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (13.0.85)
Requirement already satisfied: nvidia-curand==10.4.0.35.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (10.4.0.35)
Requirement already satisfied: nvidia-cusolver==12.0.4.66.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (12.0.4.66)
Requirement already satisfied: nvidia-cusparse==12.6.3.3.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (12.6.3.3)
Requirement already satisfied: nvidia-nvjitlink==13.0.88.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (13.0.88)
Requirement already satisfied: nvidia-cuda-nvrtc==13.0.88.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (13.0.88)
Requirement already satisfied: nvidia-nvtx==13.0.85.* in /home/abo/.local/lib/python3.12/site-packages (from cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == "Linux"->torch>=2.3->vaner==0.1.0) (13.0.85)
Requirement already satisfied: click>=8.2.1 in /home/abo/.local/lib/python3.12/site-packages (from typer>=0.12->vaner==0.1.0) (8.3.2)
Requirement already satisfied: shellingham>=1.3.0 in /home/abo/.local/lib/python3.12/site-packages (from typer>=0.12->vaner==0.1.0) (1.5.4)
Requirement already satisfied: rich>=12.3.0 in /usr/lib/python3/dist-packages (from typer>=0.12->vaner==0.1.0) (13.7.1)
Requirement already satisfied: cuda-pathfinder~=1.1 in /home/abo/.local/lib/python3.12/site-packages (from cuda-bindings<14,>=13.0.3->torch>=2.3->vaner==0.1.0) (1.5.3)
Requirement already satisfied: hf-xet<2.0.0,>=1.4.3 in /home/abo/.local/lib/python3.12/site-packages (from huggingface-hub>=0.23.0->sentence-transformers>=3.0->vaner==0.1.0) (1.4.3)
Requirement already satisfied: packaging>=20.9 in /home/abo/.local/lib/python3.12/site-packages (from huggingface-hub>=0.23.0->sentence-transformers>=3.0->vaner==0.1.0) (26.0)
Requirement already satisfied: pyyaml>=5.1 in /usr/lib/python3/dist-packages (from huggingface-hub>=0.23.0->sentence-transformers>=3.0->vaner==0.1.0) (6.0.1)
Requirement already satisfied: attrs>=22.2.0 in /usr/lib/python3/dist-packages (from jsonschema>=4.20.0->mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0) (23.2.0)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema>=4.20.0->mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading jsonschema_specifications-2025.9.1-py3-none-any.whl.metadata (2.9 kB)
Collecting referencing>=0.28.4 (from jsonschema>=4.20.0->mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading referencing-0.37.0-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.25.0 (from jsonschema>=4.20.0->mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0)
  Downloading rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.1 kB)
Requirement already satisfied: cryptography>=3.4.0 in /usr/lib/python3/dist-packages (from pyjwt[crypto]>=2.10.1->mcp>=1.0->mcp[cli]>=1.0; extra == "all"->vaner==0.1.0) (41.0.7)
Requirement already satisfied: charset_normalizer<4,>=2 in /home/abo/.local/lib/python3.12/site-packages (from requests>=2.26.0->tiktoken>=0.7->vaner==0.1.0) (3.4.7)
Requirement already satisfied: urllib3<3,>=1.26 in /usr/lib/python3/dist-packages (from requests>=2.26.0->tiktoken>=0.7->vaner==0.1.0) (2.0.7)
Requirement already satisfied: markdown-it-py>=2.2.0 in /usr/lib/python3/dist-packages (from rich>=12.3.0->typer>=0.12->vaner==0.1.0) (3.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /usr/lib/python3/dist-packages (from rich>=12.3.0->typer>=0.12->vaner==0.1.0) (2.17.2)
Requirement already satisfied: joblib>=1.3.0 in /home/abo/.local/lib/python3.12/site-packages (from scikit-learn>=0.22.0->sentence-transformers>=3.0->vaner==0.1.0) (1.5.3)
Requirement already satisfied: threadpoolctl>=3.2.0 in /home/abo/.local/lib/python3.12/site-packages (from scikit-learn>=0.22.0->sentence-transformers>=3.0->vaner==0.1.0) (3.6.0)
Requirement already satisfied: mpmath<1.4,>=1.1.0 in /home/abo/.local/lib/python3.12/site-packages (from sympy>=1.13.3->torch>=2.3->vaner==0.1.0) (1.3.0)
Requirement already satisfied: tokenizers<=0.23.0,>=0.22.0 in /home/abo/.local/lib/python3.12/site-packages (from transformers<6.0.0,>=4.41.0->sentence-transformers>=3.0->vaner==0.1.0) (0.22.2)
Requirement already satisfied: safetensors>=0.4.3 in /home/abo/.local/lib/python3.12/site-packages (from transformers<6.0.0,>=4.41.0->sentence-transformers>=3.0->vaner==0.1.0) (0.7.0)
Requirement already satisfied: mdurl~=0.1 in /usr/lib/python3/dist-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer>=0.12->vaner==0.1.0) (0.1.2)
Downloading mcp-1.27.0-py3-none-any.whl (215 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 216.0/216.0 kB 13.4 MB/s eta 0:00:00

Downloading httpx_sse-0.4.3-py3-none-any.whl (9.0 kB)
Downloading jsonschema-4.26.0-py3-none-any.whl (90 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.6/90.6 kB 13.2 MB/s eta 0:00:00

Downloading pydantic_settings-2.13.1-py3-none-any.whl (58 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 58.9/58.9 kB 8.3 MB/s eta 0:00:00

Downloading pyjwt-2.12.1-py3-none-any.whl (29 kB)
Downloading python_dotenv-1.2.2-py3-none-any.whl (22 kB)
Downloading python_multipart-0.0.26-py3-none-any.whl (28 kB)
Downloading sse_starlette-3.3.4-py3-none-any.whl (14 kB)
Downloading jsonschema_specifications-2025.9.1-py3-none-any.whl (18 kB)
Downloading referencing-0.37.0-py3-none-any.whl (26 kB)
Downloading rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (394 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 394.1/394.1 kB 27.5 MB/s eta 0:00:00

Checking if build backend supports build_editable: started
Checking if build backend supports build_editable: finished with status 'done'
Building wheels for collected packages: vaner
  Building editable for vaner (pyproject.toml): started
  Building editable for vaner (pyproject.toml): finished with status 'done'
  Created wheel for vaner: filename=vaner-0.1.0-py3-none-any.whl size=7101 sha256=30ce9eecc5e9df4a6f669de645b102af31bdb231f5aea176b836e967be5c1d50
  Stored in directory: /tmp/pip-ephem-wheel-cache-kxnbo5dx/wheels/da/45/0d/8408dadf20dcc60139a7c9882285b59f4701efc9ddc72f2d42
Successfully built vaner
Installing collected packages: rpds-py, python-multipart, python-dotenv, pyjwt, httpx-sse, referencing, sse-starlette, pydantic-settings, jsonschema-specifications, vaner, jsonschema, mcp
  Attempting uninstall: vaner
    Found existing installation: vaner 0.1.0
    Uninstalling vaner-0.1.0:
      Successfully uninstalled vaner-0.1.0
Successfully installed httpx-sse-0.4.3 jsonschema-4.26.0 jsonschema-specifications-2025.9.1 mcp-1.27.0 pydantic-settings-2.13.1 pyjwt-2.12.1 python-dotenv-1.2.2 python-multipart-0.0.26 referencing-0.37.0 rpds-py-0.30.0 sse-starlette-3.3.4 vaner-0.1.0
- fixes hatch metadata generation error in docker-release workflow

## Test plan
- retag v0.1.0 and verify Docker release job

Made with [Cursor](https://cursor.com)