### PR TITLE
chore(hardening): restore workflow integrity and release assets

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,6 +9,11 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Run actionlint
         run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.7
+      - name: Zizmor
+        uses: zizmorcore/zizmor-action@814f9778aceea8641503a8cd8f0cffebc55d790c # v0.5.3
+        with:
+          inputs: .github/workflows
+          online-audits: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - os: windows-latest
             python-version: "3.12"
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -49,7 +49,7 @@ jobs:
   examples-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Initialize CodeQL
         uses: github/codeql-action/init@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
         with:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,7 +18,7 @@ jobs:
       IMAGE_NAME: ghcr.io/borgels/vaner
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,7 +12,7 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: crazy-max/ghaction-github-labeler@53ca8ce8f58f2f3da03595f5d4f390d05f9dcd17 # v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/moat-guard.yml
+++ b/.github/workflows/moat-guard.yml
@@ -9,7 +9,7 @@ jobs:
   no-moat-paths:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Block forbidden directories
         run: |
           for p in eval infra scripts/data scripts/remote; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       attestations: write
       id-token: write
-      contents: read
+      contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
@@ -38,3 +38,9 @@ jobs:
       - name: Publish to PyPI
         continue-on-error: true
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - name: Attach release assets
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          files: |
+            dist/*
+            sbom.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,11 +20,11 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,6 +25,15 @@ Vaner is a local-first predictive context engine for coding assistants.
 - Safety and privacy policy modules gate what leaves local storage.
 - Training and moat-sensitive workflows are intentionally isolated to private repos.
 
+## Decision transparency
+
+- Every `query` writes a structured decision record to `.vaner/runtime/decisions/`.
+- The record captures package-level metadata (`cache_tier`, `partial_similarity`, token usage), per-selection scoring factors, and prediction links when the package came from precompute/frontier exploration.
+- CLI surfaces share this record:
+  - `vaner inspect --last [--verbose|--json]`
+  - `vaner why [decision-id] [--list|--verbose|--json]`
+  - `vaner query --explain [--verbose|--json]`
+
 ## More details
 
 Detailed architecture docs live at `https://docs.vaner.ai/architecture`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+title: "Vaner"
+message: "If you use Vaner in research or publications, please cite it using the metadata below."
+type: software
+authors:
+  - family-names: "Olsen"
+    given-names: "Abo"
+repository-code: "https://github.com/Borgels/vaner"
+url: "https://vaner.ai"
+license: "Apache-2.0"
+version: "0.1.0"
+date-released: "2026-04-19"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,19 @@ This adds a `Signed-off-by:` trailer to the commit.
 
 User-facing documentation is published at [docs.vaner.ai](https://docs.vaner.ai).
 Keep repository docs minimal and point broad usage guidance there.
+
+## PyPI Trusted Publishing Checklist
+
+Vaner uses PyPI Trusted Publishing for release tags.
+
+Before expecting a tagged release to publish to PyPI:
+
+1. Open `https://pypi.org/manage/project/vaner/settings/publishing/`.
+2. Add a trusted publisher for:
+   - Owner: `Borgels`
+   - Repository: `vaner`
+   - Workflow filename: `release.yml`
+   - Environment name: leave empty
+3. Verify the GitHub release workflow keeps `id-token: write`.
+
+If this is not configured yet, the `Publish to PyPI` step is non-fatal and can be retried after setup.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ CLI walkthrough:
 ```bash
 vaner init --path .
 vaner daemon start --no-once --path .
-vaner query "where is auth enforced?" --path .
+vaner query "where is auth enforced?" --explain --path .
 vaner inspect --last --path .
+vaner why --list --path .
 ```
 
 Asciinema demo: coming soon.
@@ -38,8 +39,9 @@ pip install .
 ```bash
 vaner init --path .
 vaner daemon start --no-once --path .
-vaner query "where is auth enforced?" --path .
+vaner query "where is auth enforced?" --explain --path .
 vaner inspect --last --path .
+vaner why --list --path .
 ```
 
 ## Documentation

--- a/src/vaner/broker/assembler.py
+++ b/src/vaner/broker/assembler.py
@@ -10,6 +10,7 @@ from vaner.broker.compressor import compress_context
 from vaner.broker.selector import score_artefact
 from vaner.models.artefact import Artefact
 from vaner.models.context import ContextPackage, ContextSelection
+from vaner.models.decision import DecisionRecord, ScoreFactor, SelectionDecision
 from vaner.policy.staleness import is_stale_timestamp
 
 
@@ -31,34 +32,71 @@ def assemble_context_package(
     repo_root: Path | None = None,
     max_age_seconds: int = 3600,
     score_map: dict[str, float] | None = None,
-) -> ContextPackage:
+    factor_map: dict[str, list[ScoreFactor]] | None = None,
+    drop_reasons: dict[str, str] | None = None,
+    return_decision: bool = False,
+) -> ContextPackage | tuple[ContextPackage, DecisionRecord]:
     resolved_score_map = score_map or {artefact.key: score_artefact(prompt, artefact) for artefact in artefacts}
     injected_context, token_map, used, kept_keys = compress_context(
         artefacts,
         max_tokens=max_tokens,
         score_by_key=resolved_score_map,
     )
-    selections = [
-        ContextSelection(
+    selection_decisions: list[SelectionDecision] = []
+    context_selections: list[ContextSelection] = []
+    for artefact in artefacts:
+        stale = _is_stale(artefact, repo_root, max_age_seconds)
+        factors = list((factor_map or {}).get(artefact.key, []))
+        kept = artefact.key in kept_keys
+        drop_reason = None if kept else (drop_reasons or {}).get(artefact.key, "budget")
+        rationale_tokens = [factor.name for factor in factors if factor.contribution > 0]
+        if not rationale_tokens:
+            rationale_tokens = ["intent_ranked" if score_map is not None else "keyword_overlap"]
+        rationale = "+".join(rationale_tokens[:4])
+        decision = SelectionDecision(
             artefact_key=artefact.key,
             source_path=artefact.source_path,
-            score=resolved_score_map.get(artefact.key, 0.0),
-            stale=_is_stale(artefact, repo_root, max_age_seconds),
+            final_score=resolved_score_map.get(artefact.key, 0.0),
+            stale=stale,
             token_count=token_map.get(artefact.key, 0),
-            rationale="intent_ranked" if score_map is not None else "keyword_overlap",
-            corpus_id=str(artefact.metadata.get("corpus_id", "default")),
-            privacy_zone=str(artefact.metadata.get("privacy_zone", "local")),
+            kept=kept,
+            drop_reason=drop_reason,
+            rationale=rationale,
+            factors=factors,
         )
-        for artefact in artefacts
-        if artefact.key in kept_keys
-    ]
+        selection_decisions.append(decision)
+        if kept:
+            context_selections.append(
+                ContextSelection(
+                    artefact_key=artefact.key,
+                    source_path=artefact.source_path,
+                    score=decision.final_score,
+                    stale=decision.stale,
+                    token_count=decision.token_count,
+                    rationale=decision.rationale,
+                    corpus_id=str(artefact.metadata.get("corpus_id", "default")),
+                    privacy_zone=str(artefact.metadata.get("privacy_zone", "local")),
+                )
+            )
     prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
-    return ContextPackage(
+    context_package = ContextPackage(
         id=f"ctx_{prompt_hash[:12]}",
         prompt_hash=prompt_hash,
         assembled_at=time.time(),
         token_budget=max_tokens,
         token_used=used,
-        selections=selections,
+        selections=context_selections,
         injected_context=injected_context,
     )
+    decision_record = DecisionRecord(
+        id=context_package.id,
+        prompt=prompt,
+        prompt_hash=prompt_hash,
+        assembled_at=context_package.assembled_at,
+        token_budget=max_tokens,
+        token_used=used,
+        selections=selection_decisions,
+    )
+    if return_decision:
+        return context_package, decision_record
+    return context_package

--- a/src/vaner/broker/selector.py
+++ b/src/vaner/broker/selector.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from fnmatch import fnmatch
 
 from vaner.models.artefact import Artefact
+from vaner.models.decision import ScoreFactor
 
 
 def _recency_bonus(artefact: Artefact, decay_half_life_seconds: int = 1800) -> float:
@@ -28,13 +29,13 @@ _COMMON_WORDS = frozenset(
 )
 
 
-def score_artefact(prompt: str, artefact: Artefact) -> float:
+def score_artefact(prompt: str, artefact: Artefact, *, factor_sink: list[ScoreFactor] | None = None) -> float:
     # Extract identifiers: split on non-alphanumeric boundaries so
     # "col_insert()" → "col_insert", "Matrix.foo" → ["matrix", "foo"]
     raw_terms = re.findall(r"[a-z][a-z0-9_]{2,}", prompt.lower())
     text = f"{artefact.source_path} {artefact.content}".lower()
 
-    score = 0.0
+    keyword_overlap = 0.0
     for term in raw_terms:
         if term in _COMMON_WORDS:
             continue
@@ -42,10 +43,26 @@ def score_artefact(prompt: str, artefact: Artefact) -> float:
             continue
         # Code identifiers (containing underscore) are stronger signals
         weight = 3.0 if "_" in term else 1.0
-        score += weight
+        keyword_overlap += weight
 
     recency_bonus = _recency_bonus(artefact)
-    return score + recency_bonus
+    if factor_sink is not None:
+        if keyword_overlap > 0:
+            factor_sink.append(
+                ScoreFactor(
+                    name="keyword_overlap",
+                    contribution=keyword_overlap,
+                    detail="prompt terms matched source path/content",
+                )
+            )
+        factor_sink.append(
+            ScoreFactor(
+                name="recency",
+                contribution=recency_bonus,
+                detail="recently generated or accessed artefacts are boosted",
+            )
+        )
+    return keyword_overlap + recency_bonus
 
 
 def _is_origin_question(prompt: str) -> bool:
@@ -87,6 +104,8 @@ async def select_artefacts_fts(
     exclude_private: bool = False,
     path_bonuses: list[str] | None = None,
     path_excludes: list[str] | None = None,
+    capture_factors: dict[str, list[ScoreFactor]] | None = None,
+    capture_drop_reasons: dict[str, str] | None = None,
 ) -> list[Artefact]:
     """Two-phase selection: FTS candidate retrieval, then scorer re-rank.
 
@@ -134,6 +153,8 @@ async def select_artefacts_fts(
         exclude_private=exclude_private,
         path_bonuses=path_bonuses,
         path_excludes=path_excludes,
+        capture_factors=capture_factors,
+        capture_drop_reasons=capture_drop_reasons,
     )
 
 
@@ -147,6 +168,8 @@ def select_artefacts(
     exclude_private: bool = False,
     path_bonuses: list[str] | None = None,
     path_excludes: list[str] | None = None,
+    capture_factors: dict[str, list[ScoreFactor]] | None = None,
+    capture_drop_reasons: dict[str, str] | None = None,
 ) -> list[Artefact]:
     preferred_paths = preferred_paths or set()
     preferred_keys = preferred_keys or set()
@@ -157,18 +180,68 @@ def select_artefacts(
     scored_rows: list[tuple[float, Artefact]] = []
     for artefact in artefacts:
         if exclude_private and str(artefact.metadata.get("privacy_zone", "")).lower() == "private_local":
+            if capture_drop_reasons is not None:
+                capture_drop_reasons[artefact.key] = "privacy_excluded"
             continue
         if any(fnmatch(artefact.source_path, pattern) for pattern in path_excludes):
+            if capture_drop_reasons is not None:
+                capture_drop_reasons[artefact.key] = "path_excluded"
             continue
-        score = scorer(prompt, artefact) if scorer is not None else score_artefact(prompt, artefact)
+        factors: list[ScoreFactor] = []
+        if scorer is not None:
+            score = scorer(prompt, artefact)
+            factors.append(
+                ScoreFactor(
+                    name="intent_score",
+                    contribution=score,
+                    detail="intent scorer baseline for prompt and artefact",
+                )
+            )
+        else:
+            score = score_artefact(prompt, artefact, factor_sink=factors)
         if apply_origin_rerank:
-            score += _origin_bonus(prompt, artefact.content)
+            origin_bonus = _origin_bonus(prompt, artefact.content)
+            if origin_bonus:
+                factors.append(
+                    ScoreFactor(
+                        name="origin_bonus",
+                        contribution=origin_bonus,
+                        detail="question asks for definition/implementation origin",
+                    )
+                )
+                score += origin_bonus
         if artefact.source_path in preferred_paths:
-            score += 0.8
+            preferred_path_bonus = 0.8
+            factors.append(
+                ScoreFactor(
+                    name="preferred_path",
+                    contribution=preferred_path_bonus,
+                    detail="path appears in recent git activity",
+                )
+            )
+            score += preferred_path_bonus
         if artefact.key in preferred_keys:
-            score += 0.8
+            preferred_key_bonus = 0.8
+            factors.append(
+                ScoreFactor(
+                    name="working_set",
+                    contribution=preferred_key_bonus,
+                    detail="artefact already in working set or warm-start keys",
+                )
+            )
+            score += preferred_key_bonus
         if any(fnmatch(artefact.source_path, pattern) for pattern in path_bonuses):
-            score += 0.3
+            pinned_path_bonus = 0.3
+            factors.append(
+                ScoreFactor(
+                    name="pinned_path_bonus",
+                    contribution=pinned_path_bonus,
+                    detail="path matched user-pinned focus glob",
+                )
+            )
+            score += pinned_path_bonus
+        if capture_factors is not None:
+            capture_factors[artefact.key] = factors
         scored_rows.append((score, artefact))
 
     ranked = sorted(scored_rows, key=lambda item: item[0], reverse=True)
@@ -177,6 +250,8 @@ def select_artefacts(
     min_competitive_score = ranked[0][0] * 0.45 if ranked else 0.0
     for score, artefact in ranked:
         if score < min_competitive_score:
+            if capture_drop_reasons is not None:
+                capture_drop_reasons[artefact.key] = "below_competitive_threshold"
             continue
         corpus_id = str(artefact.metadata.get("corpus_id", "default"))
         if selected and corpus_id not in seen_corpora:
@@ -187,4 +262,10 @@ def select_artefacts(
             seen_corpora.add(corpus_id)
         if len(selected) >= top_n:
             break
+    if capture_drop_reasons is not None:
+        selected_keys = {artefact.key for artefact in selected}
+        for _, artefact in ranked:
+            if artefact.key in selected_keys:
+                continue
+            capture_drop_reasons.setdefault(artefact.key, "ranked_below_top_n")
     return selected[:top_n]

--- a/src/vaner/cli/commands/app_legacy.py
+++ b/src/vaner/cli/commands/app_legacy.py
@@ -13,7 +13,11 @@ import typer
 from vaner import api
 from vaner.cli.commands.config import load_config
 from vaner.cli.commands.daemon import daemon_status, run_daemon_forever, start_daemon, stop_daemon
+from vaner.cli.commands.explain import render_human, render_json
 from vaner.cli.commands.init import init_repo
+from vaner.cli.commands.inspect import inspect_decision as inspect_decision_output
+from vaner.cli.commands.inspect import inspect_last as inspect_last_output
+from vaner.cli.commands.inspect import list_decisions as list_decisions_output
 from vaner.cli.commands.profile import export_pins, import_pins, pin_fact, profile_show, unpin_fact
 from vaner.daemon.runner import VanerDaemon
 from vaner.eval import evaluate_repo, run_eval
@@ -89,17 +93,49 @@ def daemon_run_forever(
 def inspect(
     path: str | None = typer.Option(None, help="Repository root"),
     last: bool = typer.Option(False, "--last", help="Show last context decision"),
+    verbose: bool = typer.Option(False, "--verbose", help="Show detailed scoring factors"),
+    as_json: bool = typer.Option(False, "--json", help="Show decision record as JSON"),
 ) -> None:
     if last:
-        typer.echo(api.inspect_last(_repo_root(path)))
+        typer.echo(inspect_last_output(_repo_root(path), verbose=verbose, as_json=as_json))
         return
     typer.echo(api.inspect(_repo_root(path)))
 
 
 @app.command("query")
-def query(prompt: str, path: str | None = typer.Option(None, help="Repository root")) -> None:
+def query(
+    prompt: str,
+    path: str | None = typer.Option(None, help="Repository root"),
+    explain: bool = typer.Option(False, "--explain", help="Show why this context package was chosen"),
+    verbose: bool = typer.Option(False, "--verbose", help="Include detailed score factors with --explain"),
+    as_json: bool = typer.Option(False, "--json", help="Show explanation as JSON with --explain"),
+) -> None:
     package = api.query(prompt, _repo_root(path))
     typer.echo(package.injected_context)
+    if not explain:
+        return
+    decision_record = api.inspect_last_decision(_repo_root(path))
+    if decision_record is None:
+        typer.echo("\nNo context decisions recorded yet.")
+        return
+    typer.echo("")
+    typer.echo(render_json(decision_record) if as_json else render_human(decision_record, verbose=verbose))
+
+
+@app.command("why")
+def why(
+    decision_id: str | None = typer.Argument(None, help="Decision id, defaults to latest"),
+    path: str | None = typer.Option(None, help="Repository root"),
+    list_ids: bool = typer.Option(False, "--list", help="List recent decision ids"),
+    limit: int = typer.Option(20, "--limit", min=1, max=200, help="Number of ids to list"),
+    verbose: bool = typer.Option(False, "--verbose", help="Show detailed scoring factors"),
+    as_json: bool = typer.Option(False, "--json", help="Show decision record as JSON"),
+) -> None:
+    repo_root = _repo_root(path)
+    if list_ids:
+        typer.echo(list_decisions_output(repo_root, limit=limit))
+        return
+    typer.echo(inspect_decision_output(repo_root, decision_id, verbose=verbose, as_json=as_json))
 
 
 @app.command("prepare")

--- a/src/vaner/cli/commands/explain.py
+++ b/src/vaner/cli/commands/explain.py
@@ -26,12 +26,7 @@ def _render_prediction(link: PredictionLink | None) -> list[str]:
 def _selection_line(selection: SelectionDecision) -> str:
     status = "kept" if selection.kept else f"dropped ({selection.drop_reason or 'unknown'})"
     rationale = selection.rationale or "n/a"
-    return (
-        f"  {selection.source_path:<40} "
-        f"score {selection.final_score:>5.2f}  "
-        f"{status}, {selection.token_count} tokens  "
-        f"{rationale}"
-    )
+    return f"  {selection.source_path:<40} score {selection.final_score:>5.2f}  {status}, {selection.token_count} tokens  {rationale}"
 
 
 def render_human(record: DecisionRecord, verbose: bool = False) -> str:
@@ -47,10 +42,7 @@ def render_human(record: DecisionRecord, verbose: bool = False) -> str:
         lines.extend(_render_prediction(record.prediction_links.get(selection.artefact_key)))
         if verbose and selection.factors:
             for factor in selection.factors:
-                lines.append(
-                    f"    - factor {factor.name}: {factor.contribution:.2f}"
-                    + (f" ({factor.detail})" if factor.detail else "")
-                )
+                lines.append(f"    - factor {factor.name}: {factor.contribution:.2f}" + (f" ({factor.detail})" if factor.detail else ""))
     prewarmed = sum(1 for selection in record.selections if selection.kept and selection.artefact_key in record.prediction_links)
     kept = sum(1 for selection in record.selections if selection.kept)
     lines.extend(

--- a/src/vaner/cli/commands/explain.py
+++ b/src/vaner/cli/commands/explain.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from vaner.models.decision import DecisionRecord, PredictionLink, SelectionDecision
+
+
+def render_json(record: DecisionRecord) -> str:
+    return record.to_json()
+
+
+def _render_prediction(link: PredictionLink | None) -> list[str]:
+    if link is None:
+        return []
+    lines = [f"    - predicted by: {link.source}"]
+    if link.scenario_question:
+        confidence = f" (conf {link.confidence:.2f})" if link.confidence is not None else ""
+        lines.append(f'      "{link.scenario_question}"{confidence}')
+    elif link.confidence is not None:
+        lines.append(f"      confidence: {link.confidence:.2f}")
+    if link.scenario_rationale:
+        lines.append(f"      rationale: {link.scenario_rationale}")
+    return lines
+
+
+def _selection_line(selection: SelectionDecision) -> str:
+    status = "kept" if selection.kept else f"dropped ({selection.drop_reason or 'unknown'})"
+    rationale = selection.rationale or "n/a"
+    return (
+        f"  {selection.source_path:<40} "
+        f"score {selection.final_score:>5.2f}  "
+        f"{status}, {selection.token_count} tokens  "
+        f"{rationale}"
+    )
+
+
+def render_human(record: DecisionRecord, verbose: bool = False) -> str:
+    similarity = f" (sim {record.partial_similarity:.2f})" if record.cache_tier == "partial_hit" else ""
+    lines = [
+        f"prompt: {record.prompt}",
+        f"decision: {record.id}  cache={record.cache_tier}{similarity}  tokens {record.token_used}/{record.token_budget}",
+        "",
+        "selections:",
+    ]
+    for selection in record.selections:
+        lines.append(_selection_line(selection))
+        lines.extend(_render_prediction(record.prediction_links.get(selection.artefact_key)))
+        if verbose and selection.factors:
+            for factor in selection.factors:
+                lines.append(
+                    f"    - factor {factor.name}: {factor.contribution:.2f}"
+                    + (f" ({factor.detail})" if factor.detail else "")
+                )
+    prewarmed = sum(1 for selection in record.selections if selection.kept and selection.artefact_key in record.prediction_links)
+    kept = sum(1 for selection in record.selections if selection.kept)
+    lines.extend(
+        [
+            "",
+            f"{prewarmed} artefacts linked to predictions out of {kept} kept selections.",
+        ]
+    )
+    if record.notes:
+        lines.append("notes:")
+        lines.extend([f"  - {note}" for note in record.notes])
+    return "\n".join(lines)

--- a/src/vaner/cli/commands/inspect.py
+++ b/src/vaner/cli/commands/inspect.py
@@ -5,11 +5,39 @@ from __future__ import annotations
 from pathlib import Path
 
 from vaner import api
+from vaner.cli.commands.explain import render_human, render_json
 
 
 def inspect_cache(repo_root: Path) -> str:
     return api.inspect(repo_root)
 
 
-def inspect_last(repo_root: Path) -> str:
+def inspect_last(repo_root: Path, *, verbose: bool = False, as_json: bool = False) -> str:
+    record = api.inspect_last_decision(repo_root)
+    if record is not None:
+        if as_json:
+            return render_json(record)
+        return render_human(record, verbose=verbose)
     return api.inspect_last(repo_root)
+
+
+def inspect_decision(
+    repo_root: Path,
+    decision_id: str | None = None,
+    *,
+    verbose: bool = False,
+    as_json: bool = False,
+) -> str:
+    record = api.inspect_decision(repo_root, decision_id)
+    if record is None:
+        return "No context decisions recorded yet."
+    if as_json:
+        return render_json(record)
+    return render_human(record, verbose=verbose)
+
+
+def list_decisions(repo_root: Path, *, limit: int = 20) -> str:
+    ids = api.list_decisions(repo_root, limit=limit)
+    if not ids:
+        return "No context decisions recorded yet."
+    return "\n".join(ids)

--- a/src/vaner/engine_legacy.py
+++ b/src/vaner/engine_legacy.py
@@ -36,6 +36,7 @@ from vaner.learning.reward import RewardInput, compute_reward
 from vaner.models.artefact import Artefact, ArtefactKind
 from vaner.models.config import ExplorationConfig, VanerConfig
 from vaner.models.context import ContextPackage
+from vaner.models.decision import DecisionRecord, PredictionLink, ScoreFactor
 from vaner.models.signal import SignalEvent
 from vaner.store.artefacts import ArtefactStore
 
@@ -135,6 +136,7 @@ class VanerEngine:
         self._last_policy_persist_at = 0.0
         self._policy_persist_interval_seconds = 2.0
         self._learning_state_loaded = False
+        self._last_decision_record: DecisionRecord | None = None
 
     async def initialize(self) -> None:
         await self.store.initialize()
@@ -370,6 +372,13 @@ class VanerEngine:
                 await self._persist_learning_state()
                 cache_result.package.cache_tier = "full_hit"
                 cache_result.package.partial_similarity = cache_result.similarity
+                self._last_decision_record = self._build_decision_record_from_package(
+                    prompt,
+                    cache_result.package,
+                    cache_tier="full_hit",
+                    partial_similarity=cache_result.similarity,
+                    enrichment=cache_result.enrichment,
+                )
                 return cache_result.package
 
             if cache_result.tier == "partial_hit" and cache_result.package is not None:
@@ -381,6 +390,8 @@ class VanerEngine:
                 all_artefacts = await self.store.list(limit=2000)
                 artefacts_by_key = {a.key: a for a in all_artefacts}
                 selected = [artefacts_by_key[k] for k in cache_keys if k in artefacts_by_key]
+                factor_map: dict[str, list[ScoreFactor]] = {}
+                drop_reasons: dict[str, str] = {}
                 if len(selected) < top_n:
                     heuristic_picks = select_artefacts(
                         prompt,
@@ -389,6 +400,8 @@ class VanerEngine:
                         exclude_private=self.config.privacy.exclude_private,
                         path_bonuses=self._pinned_focus_paths,
                         path_excludes=self._pinned_avoid_paths,
+                        capture_factors=factor_map,
+                        capture_drop_reasons=drop_reasons,
                     )
                     seen = {a.key for a in selected}
                     for pick in heuristic_picks:
@@ -406,13 +419,16 @@ class VanerEngine:
                     cache_tier=cache_result.tier,
                 )
                 score_map = {a.key: self._intent_scorer.score(prompt, a, features=features) for a in selected}
-                package = assemble_context_package(
+                package, decision_record = assemble_context_package(
                     prompt,
                     selected,
                     max_tokens if max_tokens is not None else self.config.max_context_tokens,
                     repo_root=self.config.repo_root,
                     max_age_seconds=self.config.max_age_seconds,
                     score_map=score_map,
+                    factor_map=factor_map,
+                    drop_reasons=drop_reasons,
+                    return_decision=True,
                 )
             else:
                 if cache_result.tier == "cold_miss":
@@ -436,7 +452,7 @@ class VanerEngine:
                     preferred_keys |= set(working_set.artefact_keys)
                 if cache_result.tier == "warm_start":
                     preferred_keys |= set(str(key) for key in cache_result.enrichment.get("relevant_keys", []))
-                package, selected = await self._build_package_for_prompt(
+                package, selected, decision_record = await self._build_package_for_prompt(
                     prompt,
                     max_tokens=max_tokens,
                     top_n=top_n,
@@ -567,6 +583,10 @@ class VanerEngine:
             await self._persist_learning_state()
             package.cache_tier = cache_result.tier if cache_result.tier != "full_hit" else "miss"
             package.partial_similarity = cache_result.similarity if cache_result.tier == "partial_hit" else 0.0
+            decision_record.cache_tier = package.cache_tier
+            decision_record.partial_similarity = package.partial_similarity
+            self._attach_prediction_links(decision_record, cache_result.enrichment)
+            self._last_decision_record = decision_record
             return package
         finally:
             self._notify_user_request_end()
@@ -829,6 +849,9 @@ class VanerEngine:
     def get_explored_scenarios(self) -> list[ExploredScenario]:
         """Return scenarios explored in the most recent precompute cycle."""
         return list(self._last_explored_scenarios)
+
+    def get_last_decision_record(self) -> DecisionRecord | None:
+        return self._last_decision_record
 
     @staticmethod
     def _should_use_llm(scenario: ExplorationScenario, ecfg: ExplorationConfig) -> bool:
@@ -1455,6 +1478,7 @@ class VanerEngine:
             # Both keys used by TieredPredictionCache._path_overlap_score
             "source_paths": scenario.file_paths,
             "anchor_files": scenario.file_paths,
+            "scenario_question": scenario.question,
             "confidence": scenario.confidence,
             "rationale": scenario.rationale,
             "exploration_source": exploration_source,
@@ -1496,13 +1520,14 @@ class VanerEngine:
         # without penalising files that happen to overlap with heuristic picks.
         _heuristic = heuristic_paths or set()
         score_map = {artefact.key: (1.0 if artefact.source_path in _heuristic else 1.3) for artefact in selected}
-        package = assemble_context_package(
+        package, _decision_record = assemble_context_package(
             question,
             selected[:8],
             self.config.max_context_tokens,
             repo_root=self.config.repo_root,
             max_age_seconds=self.config.max_age_seconds,
             score_map=score_map,
+            return_decision=True,
         )
         return package, selected_keys
 
@@ -1659,7 +1684,7 @@ class VanerEngine:
         top_n: int = 8,
         source_key: str | None = None,
         preferred_keys: set[str] | None = None,
-    ) -> tuple[ContextPackage, list]:
+    ) -> tuple[ContextPackage, list, DecisionRecord]:
         artefacts = await self.store.list(limit=2000)
         if not artefacts:
             await self.prepare()
@@ -1680,6 +1705,8 @@ class VanerEngine:
         def _score_with_model(question: str, artefact) -> float:
             return self._intent_scorer.score(question, artefact, features=features)
 
+        factor_map: dict[str, list[ScoreFactor]] = {}
+        drop_reasons: dict[str, str] = {}
         selected = await select_artefacts_fts(
             prompt,
             self.store,
@@ -1690,6 +1717,8 @@ class VanerEngine:
             exclude_private=self.config.privacy.exclude_private,
             path_bonuses=self._pinned_focus_paths,
             path_excludes=self._pinned_avoid_paths,
+            capture_factors=factor_map,
+            capture_drop_reasons=drop_reasons,
         )
         if source_key is None and selected:
             source_key = selected[0].key
@@ -1708,17 +1737,78 @@ class VanerEngine:
                 exclude_private=self.config.privacy.exclude_private,
                 path_bonuses=self._pinned_focus_paths,
                 path_excludes=self._pinned_avoid_paths,
+                capture_factors=factor_map,
+                capture_drop_reasons=drop_reasons,
             )
         score_map = {artefact.key: self._intent_scorer.score(prompt, artefact, features=features) for artefact in selected}
-        package = assemble_context_package(
+        package, decision_record = assemble_context_package(
             prompt,
             selected,
             max_tokens if max_tokens is not None else self.config.max_context_tokens,
             repo_root=self.config.repo_root,
             max_age_seconds=self.config.max_age_seconds,
             score_map=score_map,
+            factor_map=factor_map,
+            drop_reasons=drop_reasons,
+            return_decision=True,
         )
-        return package, selected
+        return package, selected, decision_record
+
+    def _build_decision_record_from_package(
+        self,
+        prompt: str,
+        package: ContextPackage,
+        *,
+        cache_tier: str,
+        partial_similarity: float,
+        enrichment: dict[str, object] | None,
+    ) -> DecisionRecord:
+        decision_record = DecisionRecord(
+            id=package.id,
+            prompt=prompt,
+            prompt_hash=package.prompt_hash,
+            assembled_at=package.assembled_at,
+            cache_tier=cache_tier,
+            partial_similarity=partial_similarity,
+            token_budget=package.token_budget,
+            token_used=package.token_used,
+            selections=[
+                {
+                    "artefact_key": selection.artefact_key,
+                    "source_path": selection.source_path,
+                    "final_score": selection.score,
+                    "token_count": selection.token_count,
+                    "stale": selection.stale,
+                    "kept": True,
+                    "drop_reason": None,
+                    "rationale": selection.rationale,
+                    "factors": [],
+                }
+                for selection in package.selections
+            ],
+        )
+        self._attach_prediction_links(decision_record, enrichment)
+        return decision_record
+
+    def _attach_prediction_links(self, decision_record: DecisionRecord, enrichment: dict[str, object] | None) -> None:
+        if not enrichment:
+            return
+        source = str(enrichment.get("exploration_source", "")).strip()
+        if not source:
+            return
+        scenario_question_raw = enrichment.get("scenario_question") or enrichment.get("prompt_hint")
+        scenario_question = str(scenario_question_raw) if scenario_question_raw else None
+        rationale_raw = enrichment.get("rationale")
+        scenario_rationale = str(rationale_raw) if rationale_raw else None
+        confidence_value = enrichment.get("confidence")
+        confidence = float(confidence_value) if isinstance(confidence_value, (int, float)) else None
+        for selection in decision_record.selections:
+            decision_record.prediction_links[selection.artefact_key] = PredictionLink(
+                source=source,
+                scenario_question=scenario_question,
+                scenario_rationale=scenario_rationale,
+                confidence=confidence,
+            )
 
     def _resolve_llm(self, llm: LLMCallable | str | None) -> LLMCallable | None:
         if llm is None or callable(llm):

--- a/src/vaner/models/__init__.py
+++ b/src/vaner/models/__init__.py
@@ -3,6 +3,7 @@
 from vaner.models.artefact import Artefact, ArtefactKind
 from vaner.models.config import VanerConfig
 from vaner.models.context import ContextPackage, ContextSelection
+from vaner.models.decision import DecisionRecord, PredictionLink, ScoreFactor, SelectionDecision
 from vaner.models.session import SessionState, WorkingSet
 from vaner.models.signal import SignalEvent
 
@@ -11,6 +12,10 @@ __all__ = [
     "ArtefactKind",
     "ContextPackage",
     "ContextSelection",
+    "DecisionRecord",
+    "PredictionLink",
+    "ScoreFactor",
+    "SelectionDecision",
     "SessionState",
     "SignalEvent",
     "VanerConfig",

--- a/src/vaner/models/decision.py
+++ b/src/vaner/models/decision.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+class ScoreFactor(BaseModel):
+    name: str
+    contribution: float
+    detail: str = ""
+
+
+class SelectionDecision(BaseModel):
+    artefact_key: str
+    source_path: str
+    final_score: float
+    token_count: int
+    stale: bool
+    kept: bool = True
+    drop_reason: str | None = None
+    rationale: str = ""
+    factors: list[ScoreFactor] = Field(default_factory=list)
+
+
+class PredictionLink(BaseModel):
+    source: str
+    scenario_question: str | None = None
+    scenario_rationale: str | None = None
+    confidence: float | None = None
+
+
+class DecisionRecord(BaseModel):
+    id: str
+    prompt: str
+    prompt_hash: str
+    assembled_at: float
+    cache_tier: str = "miss"
+    partial_similarity: float = 0.0
+    token_budget: int
+    token_used: int
+    selections: list[SelectionDecision] = Field(default_factory=list)
+    prediction_links: dict[str, PredictionLink] = Field(default_factory=dict)
+    notes: list[str] = Field(default_factory=list)
+
+    def to_legacy_markdown(self) -> str:
+        lines = [
+            f"prompt: {self.prompt}",
+            f"token_used: {self.token_used}/{self.token_budget}",
+            "",
+        ]
+        for selection in self.selections:
+            if not selection.kept:
+                continue
+            lines.append(
+                "- "
+                f"{selection.artefact_key} "
+                f"score={selection.final_score:.2f} "
+                f"stale={selection.stale} "
+                f"tokens={selection.token_count} "
+                f"rationale={selection.rationale}"
+            )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _runtime_dir(repo_root: Path) -> Path:
+        return repo_root / ".vaner" / "runtime"
+
+    @classmethod
+    def _decisions_dir(cls, repo_root: Path) -> Path:
+        return cls._runtime_dir(repo_root) / "decisions"
+
+    def write(self, repo_root: Path) -> Path:
+        runtime_dir = self._runtime_dir(repo_root)
+        decisions_dir = self._decisions_dir(repo_root)
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        decisions_dir.mkdir(parents=True, exist_ok=True)
+
+        record_path = decisions_dir / f"{self.id}.json"
+        record_path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+        (runtime_dir / "last_decision.json").write_text(self.model_dump_json(indent=2), encoding="utf-8")
+        return record_path
+
+    @classmethod
+    def read_latest(cls, repo_root: Path) -> DecisionRecord | None:
+        path = cls._runtime_dir(repo_root) / "last_decision.json"
+        if not path.exists():
+            return None
+        return cls.model_validate_json(path.read_text(encoding="utf-8"))
+
+    @classmethod
+    def read_by_id(cls, repo_root: Path, decision_id: str) -> DecisionRecord | None:
+        path = cls._decisions_dir(repo_root) / f"{decision_id}.json"
+        if not path.exists():
+            return None
+        return cls.model_validate_json(path.read_text(encoding="utf-8"))
+
+    @classmethod
+    def list_recent_ids(cls, repo_root: Path, limit: int = 20) -> list[str]:
+        decisions_dir = cls._decisions_dir(repo_root)
+        if not decisions_dir.exists():
+            return []
+        records = sorted(
+            decisions_dir.glob("*.json"),
+            key=lambda item: item.stat().st_mtime,
+            reverse=True,
+        )
+        return [record.stem for record in records[:limit]]
+
+    def to_json(self) -> str:
+        payload = self.model_dump(mode="json")
+        return json.dumps(payload, indent=2)

--- a/src/vaner/server_legacy.py
+++ b/src/vaner/server_legacy.py
@@ -9,6 +9,7 @@ from vaner.cli.commands.config import load_config
 from vaner.engine import build_default_engine
 from vaner.models.config import VanerConfig
 from vaner.models.context import ContextPackage
+from vaner.models.decision import DecisionRecord
 
 
 def _resolve_repo_root(repo: Path | str | None) -> Path:
@@ -23,19 +24,10 @@ def _resolve_config(repo_root: Path, config: VanerConfig | None) -> VanerConfig:
     return config if config is not None else load_config(repo_root)
 
 
-def _write_last_context(repo_root: Path, prompt: str, package: ContextPackage) -> None:
+def _write_last_context(repo_root: Path, record: DecisionRecord) -> None:
+    record.write(repo_root)
     inspect_path = repo_root / ".vaner" / "runtime" / "last_context.md"
-    inspect_path.parent.mkdir(parents=True, exist_ok=True)
-    inspect_lines = [
-        f"prompt: {prompt}",
-        f"token_used: {package.token_used}/{package.token_budget}",
-        "",
-    ]
-    for item in package.selections:
-        inspect_lines.append(
-            f"- {item.artefact_key} score={item.score:.2f} stale={item.stale} tokens={item.token_count} rationale={item.rationale}"
-        )
-    inspect_path.write_text("\n".join(inspect_lines), encoding="utf-8")
+    inspect_path.write_text(record.to_legacy_markdown(), encoding="utf-8")
 
 
 async def aprepare(repo: Path | str | None = None, config: VanerConfig | None = None) -> int:
@@ -55,7 +47,9 @@ async def aquery(
     repo_root = _resolve_repo_root(repo)
     engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
     package = await engine.query(prompt, max_tokens=max_tokens, top_n=top_n)
-    _write_last_context(repo_root, prompt, package)
+    decision_record = engine.get_last_decision_record()
+    if decision_record is not None:
+        _write_last_context(repo_root, decision_record)
     return package
 
 
@@ -135,6 +129,23 @@ def inspect_last(repo: Path | str | None = None) -> str:
     if not path.exists():
         return "No context decisions recorded yet."
     return path.read_text(encoding="utf-8")
+
+
+def inspect_last_decision(repo: Path | str | None = None) -> DecisionRecord | None:
+    repo_root = _resolve_repo_root(repo)
+    return DecisionRecord.read_latest(repo_root)
+
+
+def inspect_decision(repo: Path | str | None = None, decision_id: str | None = None) -> DecisionRecord | None:
+    repo_root = _resolve_repo_root(repo)
+    if decision_id is None:
+        return DecisionRecord.read_latest(repo_root)
+    return DecisionRecord.read_by_id(repo_root, decision_id)
+
+
+def list_decisions(repo: Path | str | None = None, limit: int = 20) -> list[str]:
+    repo_root = _resolve_repo_root(repo)
+    return DecisionRecord.list_recent_ids(repo_root, limit=limit)
 
 
 def forget(repo: Path | str | None = None) -> int:

--- a/tests/test_cli/test_explain.py
+++ b/tests/test_cli/test_explain.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from vaner.broker.selector import select_artefacts
+from vaner.cli.main import app
+from vaner.models.artefact import Artefact, ArtefactKind
+from vaner.models.context import ContextPackage
+from vaner.models.decision import DecisionRecord, PredictionLink, ScoreFactor, SelectionDecision
+
+
+def _sample_record() -> DecisionRecord:
+    record = DecisionRecord(
+        id="ctx_test123",
+        prompt="where is auth enforced?",
+        prompt_hash="abc123",
+        assembled_at=time.time(),
+        cache_tier="partial_hit",
+        partial_similarity=0.78,
+        token_budget=4096,
+        token_used=1200,
+        selections=[
+            SelectionDecision(
+                artefact_key="file_summary:src/auth.py",
+                source_path="src/auth.py",
+                final_score=6.4,
+                token_count=600,
+                stale=False,
+                kept=True,
+                rationale="intent_score+preferred_path",
+                factors=[
+                    ScoreFactor(name="intent_score", contribution=5.1, detail="intent model"),
+                    ScoreFactor(name="preferred_path", contribution=0.8, detail="recent git activity"),
+                ],
+            )
+        ],
+        prediction_links={
+            "file_summary:src/auth.py": PredictionLink(
+                source="frontier/llm_branch",
+                scenario_question="How is auth enforced?",
+                scenario_rationale="fallback_uncovered_path",
+                confidence=0.72,
+            )
+        },
+    )
+    return record
+
+
+def test_selector_capture_respects_privacy_exclusion() -> None:
+    now = time.time()
+    public = Artefact(
+        key="file_summary:public.py",
+        kind=ArtefactKind.FILE_SUMMARY,
+        source_path="public.py",
+        source_mtime=now,
+        generated_at=now,
+        model="test",
+        content="auth token validator",
+        metadata={"privacy_zone": "local"},
+    )
+    private = Artefact(
+        key="file_summary:private.py",
+        kind=ArtefactKind.FILE_SUMMARY,
+        source_path="private.py",
+        source_mtime=now,
+        generated_at=now,
+        model="test",
+        content="auth token validator",
+        metadata={"privacy_zone": "private_local"},
+    )
+    factors: dict[str, list[ScoreFactor]] = {}
+    drop_reasons: dict[str, str] = {}
+    selected = select_artefacts(
+        "where is auth enforced",
+        [public, private],
+        top_n=8,
+        exclude_private=True,
+        capture_factors=factors,
+        capture_drop_reasons=drop_reasons,
+    )
+    assert [item.key for item in selected] == ["file_summary:public.py"]
+    assert "file_summary:public.py" in factors
+    assert drop_reasons["file_summary:private.py"] == "privacy_excluded"
+
+
+def test_query_explain_outputs_decision_block(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".vaner" / "runtime").mkdir(parents=True, exist_ok=True)
+    record = _sample_record()
+
+    def _fake_query(prompt: str, repo_root: Path) -> ContextPackage:  # noqa: ARG001
+        return ContextPackage(
+            id=record.id,
+            prompt_hash=record.prompt_hash,
+            assembled_at=record.assembled_at,
+            token_budget=record.token_budget,
+            token_used=record.token_used,
+            selections=[],
+            injected_context="Injected context",
+        )
+
+    monkeypatch.setattr("vaner.cli.commands.app_legacy.api.query", _fake_query)
+    monkeypatch.setattr("vaner.cli.commands.app_legacy.api.inspect_last_decision", lambda _repo: record)
+    result = runner.invoke(app, ["query", "where is auth enforced?", "--path", str(repo), "--explain"])
+    assert result.exit_code == 0, result.output
+    assert "Injected context" in result.output
+    assert "decision: ctx_test123" in result.output
+    assert "predicted by: frontier/llm_branch" in result.output
+
+    json_result = runner.invoke(app, ["query", "where is auth enforced?", "--path", str(repo), "--explain", "--json"])
+    assert json_result.exit_code == 0, json_result.output
+    json_start = json_result.output.find("{")
+    assert json_start >= 0
+    parsed = DecisionRecord.model_validate_json(json_result.output[json_start:])
+    assert parsed.cache_tier == "partial_hit"
+
+
+def test_why_list_and_json_outputs(tmp_path: Path) -> None:
+    runner = CliRunner()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    record = _sample_record()
+    record.write(repo)
+
+    list_result = runner.invoke(app, ["why", "--list", "--path", str(repo)])
+    assert list_result.exit_code == 0, list_result.output
+    assert "ctx_test123" in list_result.output
+
+    json_result = runner.invoke(app, ["why", "ctx_test123", "--json", "--path", str(repo)])
+    assert json_result.exit_code == 0, json_result.output
+    payload = json.loads(json_result.output)
+    assert payload["id"] == "ctx_test123"


### PR DESCRIPTION
## Summary
- fix Scorecard workflow pin to a valid `ossf/scorecard-action` commit and bump `actions/checkout` SHA for Node 24 readiness
- re-enable `zizmor` in Actionlint workflow with offline audits
- attach `dist/*` and `sbom.json` to tag releases, add `CITATION.cff`, and document PyPI trusted-publisher setup

## Test plan
- [x] Run `docker run --rm -v \"$PWD:/repo\" -w /repo rhysd/actionlint:1.7.7`
- [ ] Wait for required GitHub checks on this PR

Made with [Cursor](https://cursor.com)