### PR TITLE
fix(ci): pin codeql action to real v3 commit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           languages: python
           build-mode: none
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -52,7 +52,7 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload Trivy scan results to Security tab
-        uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: trivy-results.sarif
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,7 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: results.sarif
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- replace `github/codeql-action@865f...` (annotated tag object) with the peeled v3 commit SHA
- update all workflow references (`codeql.yml`, `docker-release.yml`, `scorecard.yml`)

## Test plan
- [x] `git ls-remote https://github.com/github/codeql-action.git refs/tags/v3 refs/tags/v3^{}` confirms peeled commit
- [ ] CI checks on this PR

Made with [Cursor](https://cursor.com)