### PR TITLE
fix(ci): grant security-events permission to actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   actionlint:
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4


### PR DESCRIPTION
## Summary
- add explicit workflow permissions for the actionlint job
- grant `security-events: write` so zizmor can upload SARIF without integration access errors

## Test plan
- [ ] Actionlint workflow on this PR passes

Made with [Cursor](https://cursor.com)