### PR TITLE
chore(community): add fallback issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+---
+name: General issue
+description: Report a bug, regression, or request an enhancement.
+about: Keep details actionable and reproducible.
+---
+
+## Summary
+
+Describe the problem or request in 1-2 sentences.
+
+## Reproduction (if bug)
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What should happen instead?
+
+## Environment
+
+- Vaner version:
+- OS:
+- Python version:
+
+## Additional context
+
+Any logs, traces, screenshots, or links.


### PR DESCRIPTION
## Summary
- add a fallback `.github/ISSUE_TEMPLATE.md` so community profile checks detect issue templates consistently
- keep existing structured issue forms unchanged

## Test plan
- [ ] Verify community profile health reflects issue template presence

Made with [Cursor](https://cursor.com)