### PR TITLE
chore(security): Scorecard + CodeQL hardening pass

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,14 +5,20 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
       - name: Run actionlint
         run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.7
       - name: Zizmor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,15 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -19,13 +25,15 @@ jobs:
             python-version: "3.12"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade 'pip==24.3.1'
           pip install -e ".[dev]"
       - name: Lint
         run: |
@@ -55,15 +63,20 @@ jobs:
 
   examples-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
       - name: Install Vaner
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade 'pip==24.3.1'
           pip install -e ".[dev]"
       - name: Basic usage smoke-test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           cache: pip
       - name: Install
         run: |
-          python -m pip install --upgrade 'pip==24.3.1'
+          python -m pip install --upgrade 'pip==26.0.1'
           pip install -e ".[dev]"
       - name: Lint
         run: |
@@ -76,7 +76,7 @@ jobs:
           cache: pip
       - name: Install Vaner
         run: |
-          python -m pip install --upgrade 'pip==24.3.1'
+          python -m pip install --upgrade 'pip==26.0.1'
           pip install -e ".[dev]"
       - name: Basic usage smoke-test
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,10 +8,14 @@ on:
   schedule:
     - cron: "30 3 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze Python
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -19,10 +23,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        uses: github/codeql-action/init@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
         with:
           languages: python
           build-mode: none
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        uses: github/codeql-action/analyze@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,9 +6,13 @@ on:
       - "v*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -19,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
@@ -52,7 +58,7 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload Trivy scan results to Security tab
-        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
         with:
           sarif_file: trivy-results.sarif
 
@@ -60,4 +66,6 @@ jobs:
         uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409 # v3.7.0
 
       - name: Sign image with keyless OIDC
-        run: cosign sign --yes "${IMAGE_NAME}@${{ steps.build_push.outputs.digest }}"
+        env:
+          IMAGE_DIGEST: ${{ steps.build_push.outputs.digest }}
+        run: cosign sign --yes "${IMAGE_NAME}@${IMAGE_DIGEST}"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,46 @@
+name: Fuzz
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tests/fuzz/**"
+      - "src/vaner/router/translate.py"
+      - ".github/workflows/fuzz.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  atheris:
+    name: Atheris fuzz (60s per target)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install system toolchain
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq clang
+      - name: Install Vaner + Atheris
+        run: |
+          python -m pip install --upgrade 'pip==24.3.1'
+          pip install -e "."
+          pip install 'atheris==2.3.0'
+      - name: Fuzz translate.detect_format for 60 seconds
+        run: |
+          python tests/fuzz/fuzz_translate.py \
+            -atheris_runs=0 \
+            -max_total_time=60 \
+            -timeout=10 \
+            -print_final_stats=1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,7 +26,10 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.12"
+          # Atheris 2.3.0 (latest) is pinned to CPython <=3.11 because it
+          # relies on pre-PEP 659 bytecode opcodes (PRECALL etc.) removed
+          # in 3.12. Pin until Atheris ships 3.12+ support.
+          python-version: "3.11"
           cache: pip
       - name: Install system toolchain
         run: |
@@ -34,7 +37,7 @@ jobs:
           sudo apt-get install -y -qq clang
       - name: Install Vaner + Atheris
         run: |
-          python -m pip install --upgrade 'pip==24.3.1'
+          python -m pip install --upgrade 'pip==26.0.1'
           pip install -e "."
           pip install 'atheris==2.3.0'
       - name: Fuzz translate.detect_format for 60 seconds

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -8,11 +8,21 @@ on:
       - ".github/workflows/labels.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
       - uses: crazy-max/ghaction-github-labeler@53ca8ce8f58f2f3da03595f5d4f390d05f9dcd17 # v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -5,9 +5,17 @@ on:
     - cron: "30 5 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lock:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: dessant/lock-threads@fce16d66c31f0f997db74f2a2fcb8f6f3fb6a74d # v5
         with:

--- a/.github/workflows/moat-guard.yml
+++ b/.github/workflows/moat-guard.yml
@@ -5,11 +5,19 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   no-moat-paths:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
       - name: Block forbidden directories
         run: |
           for p in eval infra scripts/data scripts/remote; do

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,12 +7,15 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: release-drafter/release-drafter@67e173cadb2fbd3de94f4a861e0c48c913b462ae # v6
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.11"
       - name: Build
         run: |
-          python -m pip install --upgrade 'pip==24.3.1' 'build==1.2.2.post1' 'cyclonedx-bom==4.6.1'
+          python -m pip install --upgrade 'pip==26.0.1' 'build==1.2.2.post1' 'cyclonedx-bom==4.6.1'
           python -m build
       - name: Generate SBOM
         run: cyclonedx-py environment --output-format json --output-file sbom.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,21 +5,27 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       attestations: write
       id-token: write
       contents: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - name: Build
         run: |
-          python -m pip install --upgrade pip build cyclonedx-bom
+          python -m pip install --upgrade 'pip==24.3.1' 'build==1.2.2.post1' 'cyclonedx-bom==4.6.1'
           python -m build
       - name: Generate SBOM
         run: cyclonedx-py environment --output-format json --output-file sbom.json
@@ -38,9 +44,14 @@ jobs:
       - name: Publish to PyPI
         continue-on-error: true
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-      - name: Attach release assets
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          files: |
-            dist/*
-            sbom.json
+      - name: Attach artifacts to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Ensure the release exists (tag push normally creates it via release-drafter; be idempotent).
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --generate-notes
+          fi
+          gh release upload "$TAG" dist/* sbom.json --clobber

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,15 +1,23 @@
 name: Semantic PR title
 
+# zizmor: ignore[dangerous-triggers]
+# pull_request_target is required here because `amannn/action-semantic-pull-request`
+# reads PR title + labels and needs write-back to the PR. This workflow never
+# checks out PR code; it only inspects `github.event.pull_request.title`.
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
   semantic-pull-request:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+      statuses: write
     steps:
       - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,9 +5,17 @@ on:
     - cron: "0 5 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@5be6feced9cbd229e42a451745f8e9c7fb8fefe1 # v9
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ __pycache__/
 *.egg-info/
 dist/
 build/
-.env
-.env.local
-.env.*
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
@@ -17,10 +14,19 @@ htmlcov/
 .vaner/
 .vaner_data/
 
-# Training pipeline lives in Borgels/Vaner-train (private repo)
+# Secrets: ignore every .env variant, globally and under subtrees.
+# Only sanitized *.env.sample templates are allowed to be committed.
+.env
+.env.*
+**/.env
+**/.env.*
+!**/.env.sample
+
+# Private moat repos and infra (see Borgels/Vaner-train, Borgels/vaner-infra)
 eval/
 !src/vaner/eval/
 !src/vaner/eval/**
 scripts/*
 !scripts/install.sh
 infra/
+apps/vaner-daemon/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY pyproject.toml ./
 COPY README.md ./
 COPY src/ ./src/
 
-RUN python -m pip install --no-cache-dir --upgrade 'pip==24.3.1' \
+RUN python -m pip install --no-cache-dir --upgrade 'pip==26.0.1' \
     && pip install --no-cache-dir -e ".[all]"
 
 RUN mkdir -p /repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 
-# Install Vaner with all optional dependencies
 COPY pyproject.toml ./
 COPY README.md ./
 COPY src/ ./src/
 
-RUN pip install --no-cache-dir -e ".[all]"
+RUN python -m pip install --no-cache-dir --upgrade 'pip==24.3.1' \
+    && pip install --no-cache-dir -e ".[all]"
 
-# Default repo is mounted at /repo; users can override via X-Vaner-Repo header
 RUN mkdir -p /repo
 
 EXPOSE 8471

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ src = ["src", "tests"]
 select = ["E", "F", "I", "UP", "B", "T20"]
 
 [tool.pytest.ini_options]
-addopts = "-ra --strict-markers --strict-config"
+addopts = "-ra --strict-markers --strict-config --ignore=tests/fuzz"
 markers = [
   "slow: long-running integration tests",
   "integration: tests that hit external systems",

--- a/src/vaner/router/translate.py
+++ b/src/vaner/router/translate.py
@@ -39,8 +39,17 @@ def detect_format(base_url: str) -> str:
 
     Matches on the parsed hostname (never the path) to avoid confusable URLs
     like ``https://evil.example/anthropic.com`` being classified as Anthropic.
+    Malformed inputs are tolerated: any parsing error falls back to the
+    default ``"openai"`` label.
     """
-    host = (urlparse(base_url).hostname or "").lower().rstrip(".")
+    try:
+        parsed_host = urlparse(base_url).hostname
+    except ValueError:
+        # urlparse raises on a few pathological inputs (e.g. invalid IPv6
+        # brackets). We are not in a position to classify these; caller
+        # should treat unknown URLs as the OpenAI-compatible default.
+        return "openai"
+    host = (parsed_host or "").lower().rstrip(".")
     if not host:
         return "openai"
     if host in _ANTHROPIC_HOSTS or host.endswith(_ANTHROPIC_SUFFIXES):

--- a/src/vaner/router/translate.py
+++ b/src/vaner/router/translate.py
@@ -17,6 +17,18 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from urllib.parse import urlparse
+
+_ANTHROPIC_HOSTS = ("api.anthropic.com",)
+_ANTHROPIC_SUFFIXES = (".anthropic.com",)
+_GOOGLE_HOSTS = (
+    "generativelanguage.googleapis.com",
+    "aiplatform.googleapis.com",
+)
+_GOOGLE_SUFFIXES = (
+    ".googleapis.com",
+    ".aiplatform.googleapis.com",
+)
 
 
 def detect_format(base_url: str) -> str:
@@ -24,11 +36,16 @@ def detect_format(base_url: str) -> str:
 
     Returns one of ``"openai"``, ``"anthropic"``, or ``"google"``.
     Defaults to ``"openai"`` for unknown URLs (covers vLLM, LM Studio, Ollama /v1, etc.).
+
+    Matches on the parsed hostname (never the path) to avoid confusable URLs
+    like ``https://evil.example/anthropic.com`` being classified as Anthropic.
     """
-    url = base_url.lower()
-    if "anthropic.com" in url:
+    host = (urlparse(base_url).hostname or "").lower().rstrip(".")
+    if not host:
+        return "openai"
+    if host in _ANTHROPIC_HOSTS or host.endswith(_ANTHROPIC_SUFFIXES):
         return "anthropic"
-    if "googleapis.com" in url or "generativelanguage" in url or "aiplatform.google" in url:
+    if host in _GOOGLE_HOSTS or host.endswith(_GOOGLE_SUFFIXES):
         return "google"
     return "openai"
 

--- a/tests/fuzz/__init__.py
+++ b/tests/fuzz/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fuzz targets for Vaner. Executed by the nightly ``fuzz.yml`` workflow."""

--- a/tests/fuzz/fuzz_translate.py
+++ b/tests/fuzz/fuzz_translate.py
@@ -47,9 +47,7 @@ def TestOneInput(data: bytes) -> None:
     if result in ("anthropic", "google"):
         host = (urlparse(url).hostname or "").lower().rstrip(".")
         if result == "anthropic":
-            assert host == "api.anthropic.com" or host.endswith(
-                ".anthropic.com"
-            ), f"false-positive anthropic for host={host!r} url={url!r}"
+            assert host == "api.anthropic.com" or host.endswith(".anthropic.com"), f"false-positive anthropic for host={host!r} url={url!r}"
         else:
             assert host.endswith(".googleapis.com") or host in {
                 "generativelanguage.googleapis.com",

--- a/tests/fuzz/fuzz_translate.py
+++ b/tests/fuzz/fuzz_translate.py
@@ -23,8 +23,12 @@ from urllib.parse import urlparse
 
 import atheris
 
-with atheris.instrument_imports():
-    from vaner.router.translate import detect_format
+# NOTE: Do not call `atheris.instrument_imports()` around vaner imports.
+# Atheris instruments every transitively imported module; vaner pulls in
+# fastapi, pydantic, numpy, lightgbm, etc., which segfaults the instrumenter.
+# The target (`detect_format`) is small and pure, so Atheris's fuzzer driver
+# alone (mutation over bytes) is sufficient to hit every branch.
+from vaner.router.translate import detect_format
 
 _VALID = frozenset({"openai", "anthropic", "google"})
 
@@ -43,7 +47,9 @@ def TestOneInput(data: bytes) -> None:
     if result in ("anthropic", "google"):
         host = (urlparse(url).hostname or "").lower().rstrip(".")
         if result == "anthropic":
-            assert host == "api.anthropic.com" or host.endswith(".anthropic.com"), f"false-positive anthropic for host={host!r} url={url!r}"
+            assert host == "api.anthropic.com" or host.endswith(
+                ".anthropic.com"
+            ), f"false-positive anthropic for host={host!r} url={url!r}"
         else:
             assert host.endswith(".googleapis.com") or host in {
                 "generativelanguage.googleapis.com",

--- a/tests/fuzz/fuzz_translate.py
+++ b/tests/fuzz/fuzz_translate.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Atheris fuzz target for :func:`vaner.router.translate.detect_format`.
+
+Run locally::
+
+    pip install atheris
+    python tests/fuzz/fuzz_translate.py -atheris_runs=100000
+
+Invariants asserted:
+
+- ``detect_format`` always returns one of the three known labels.
+- It never raises on any bytes/str input.
+- It never classifies a URL as ``"anthropic"`` or ``"google"`` unless the
+  parsed hostname actually matches those providers (guards against the
+  CodeQL ``py/incomplete-url-substring-sanitization`` class).
+"""
+
+from __future__ import annotations
+
+import sys
+from urllib.parse import urlparse
+
+import atheris
+
+with atheris.instrument_imports():
+    from vaner.router.translate import detect_format
+
+_VALID = frozenset({"openai", "anthropic", "google"})
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    url = fdp.ConsumeUnicodeNoSurrogates(512)
+
+    try:
+        result = detect_format(url)
+    except Exception as exc:  # pragma: no cover - must never raise
+        raise AssertionError(f"detect_format raised on input {url!r}: {exc!r}") from exc
+
+    assert result in _VALID, f"unexpected label {result!r} for {url!r}"
+
+    if result in ("anthropic", "google"):
+        host = (urlparse(url).hostname or "").lower().rstrip(".")
+        if result == "anthropic":
+            assert host == "api.anthropic.com" or host.endswith(".anthropic.com"), f"false-positive anthropic for host={host!r} url={url!r}"
+        else:
+            assert host.endswith(".googleapis.com") or host in {
+                "generativelanguage.googleapis.com",
+                "aiplatform.googleapis.com",
+            }, f"false-positive google for host={host!r} url={url!r}"
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_router/test_translate.py
+++ b/tests/test_router/test_translate.py
@@ -69,6 +69,19 @@ def test_detect_format_resists_substring_confusion(url: str) -> None:
     assert detect_format(url) == "openai"
 
 
-@pytest.mark.parametrize("url", ["", "not a url", "://", "ftp://"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "not a url",
+        "://",
+        "ftp://",
+        # Fuzz-discovered: urlparse raises ValueError on malformed IPv6 brackets
+        # like "//[//////...". detect_format must swallow it and default to "openai".
+        "//[/////////////////////////////////\n",
+        "http://[::1:bad",
+        "http://[gggg::1]/",
+    ],
+)
 def test_detect_format_handles_malformed_inputs(url: str) -> None:
     assert detect_format(url) == "openai"

--- a/tests/test_router/test_translate.py
+++ b/tests/test_router/test_translate.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`vaner.router.translate.detect_format`.
+
+These guard against the CodeQL ``py/incomplete-url-substring-sanitization``
+class of bugs where a host is inferred from a substring match on the full URL
+instead of the parsed hostname.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vaner.router.translate import detect_format
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.anthropic.com/v1/messages",
+        "https://API.Anthropic.Com/v1/messages",
+        "https://subdomain.anthropic.com/v1/messages",
+    ],
+)
+def test_detect_format_anthropic_hostnames(url: str) -> None:
+    assert detect_format(url) == "anthropic"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://generativelanguage.googleapis.com/v1beta",
+        "https://aiplatform.googleapis.com/v1",
+        "https://us-central1-aiplatform.googleapis.com/v1",
+    ],
+)
+def test_detect_format_google_hostnames(url: str) -> None:
+    assert detect_format(url) == "google"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.openai.com/v1",
+        "http://localhost:11434/v1",
+        "http://127.0.0.1:8080",
+        "https://vllm.internal:8000/v1",
+    ],
+)
+def test_detect_format_defaults_to_openai(url: str) -> None:
+    assert detect_format(url) == "openai"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Substring attacks: path or userinfo containing anthropic.com / googleapis.com
+        "https://evil.example.com/anthropic.com",
+        "https://anthropic.com.evil.test/v1",
+        "https://user:pass@evil.example.com/anthropic.com/v1",
+        "https://evil.example/?redirect=https://api.anthropic.com",
+        "https://anthropic-com.evil/v1",
+        "https://googleapis.com.evil.test/v1",
+        "https://evil.example/generativelanguage.googleapis.com",
+    ],
+)
+def test_detect_format_resists_substring_confusion(url: str) -> None:
+    """Confusable URLs must fall back to the ``openai`` default."""
+
+    assert detect_format(url) == "openai"
+
+
+@pytest.mark.parametrize("url", ["", "not a url", "://", "ftp://"])
+def test_detect_format_handles_malformed_inputs(url: str) -> None:
+    assert detect_format(url) == "openai"


### PR DESCRIPTION
## Summary

Close every fixable code-scanning alert on the repo; complement the secret-scanning history purge (alert #1 Supabase PAT, alert #2 LangSmith PAT) that landed out-of-band via git-filter-repo.

### Workflow hardening

- Add top-level `permissions: contents: read` to every workflow; scope per-job writes to the minimum needed (TokenPermissionsID — alerts 30, 32–40, 45–46).
- Add `persist-credentials: false` to checkout steps that don't push (zizmor/artipacked — alerts 1, 3, 4, 8, 9, 11, 14, 16).
- Move excessive workflow-wide permissions to per-job minimums (zizmor/excessive-permissions — alerts 5, 7, 12, 13, 15, 19, 22).
- Move `${{ steps.build_push.outputs.digest }}` into `env` in the cosign step (zizmor/template-injection — alert 10).
- Drop redundant `softprops/action-gh-release`; attach artifacts via `gh release upload` (zizmor/superfluous-actions — alert 17).
- Annotate `semantic-pr.yml` `pull_request_target` with zizmor suppression + justification — we never check out PR code; only read the title (zizmor/dangerous-triggers — alert 18).

### Dependency pinning

- Pin `python:3.11-slim` base image by multi-arch digest; pin `pip==24.3.1`, `build==1.2.2.post1`, `cyclonedx-bom==4.6.1` in CI/release (PinnedDependenciesID — alerts 23–29).

### CodeQL `py/incomplete-url-substring-sanitization`

- Rewrite `vaner.router.translate.detect_format()` to parse the hostname with `urlparse()` and match exact hosts / domain suffixes instead of raw substring checks (alerts 20, 21).
- Add `tests/test_router/test_translate.py` — 21 regression tests covering the classification matrix and substring-confusion attacks like `https://evil/anthropic.com`.

### Fuzzing

- Add `tests/fuzz/fuzz_translate.py` (Atheris harness, asserts invariants: always returns one of three labels, never raises, and never classifies a URL as anthropic/google unless the parsed hostname actually matches).
- Add `.github/workflows/fuzz.yml` — nightly + PR-touching 60s fuzz job. Satisfies Scorecard's Fuzzing signal (alert 43).

### Hygiene

- Tighten `.gitignore` to cover `**/.env*` globally, allow `**/.env.sample`, gitignore `apps/vaner-daemon/` (moved to its own product), and keep `eval/` ignored.

### Out of scope / dismissed with justification

- Scorecard meta alerts **#41 CIIBestPractices** (external enrollment at bestpractices.coreinfrastructure.org) and **#44 Maintained** (rolling activity window, repo was just made public) dismissed as `won't fix` with commented justification; re-evaluate post-1.0.
- **#42 CodeReview** left open; will auto-clear as reviewed PRs accrue on main.

## Test plan

- [x] `pytest tests -m "not slow and not integration"` — 164 passed
- [x] `ruff check .` + `ruff format --check .`
- [x] `actionlint` — all checks passed (local docker run)
- [x] Workflows manually diffed for minimum-viable permission sets
- [ ] CI verify (all matrix OS/Python)
- [ ] CodeQL re-run on main after merge — `translate.py` alerts 20, 21 must clear
- [ ] Scorecard re-run on main after merge — TokenPermissions / Pinned / artipacked / excessive-permissions / template-injection / Fuzzing alerts must clear

Made with [Cursor](https://cursor.com)