### PR TITLE
chore(security): move zizmor ignore to the on: line

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,10 +1,11 @@
 name: Semantic PR title
 
-# zizmor: ignore[dangerous-triggers]
-# pull_request_target is required here because `amannn/action-semantic-pull-request`
-# reads PR title + labels and needs write-back to the PR. This workflow never
-# checks out PR code; it only inspects `github.event.pull_request.title`.
-on:
+# pull_request_target is required because amannn/action-semantic-pull-request
+# writes a status back to the PR, which needs a write token. This workflow
+# never checks out PR code; it only reads `github.event.pull_request.title`
+# and `.labels`, so the usual untrusted-PR-code risk of pull_request_target
+# does not apply here. Justification reviewed on 2026-04-19.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 


### PR DESCRIPTION
Follow-up to #92: the zizmor suppression comment for `dangerous-triggers` must be on the same line as the flagged construct. Moving the ignore to the `on:` line actually silences the finding.

Made with [Cursor](https://cursor.com)