### PR TITLE
fix(ci): repair labels sync and refresh public badges

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           persist-credentials: false
-      - uses: crazy-max/ghaction-github-labeler@53ca8ce8f58f2f3da03595f5d4f390d05f9dcd17 # v5
+      - uses: crazy-max/ghaction-github-labeler@24d110aa46a59976b8a7f35518cb7f14f434c916 # v5.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,4 @@ Before expecting a tagged release to publish to PyPI:
 3. Verify the GitHub release workflow keeps `id-token: write`.
 
 If this is not configured yet, the `Publish to PyPI` step is non-fatal and can be retried after setup.
+For every release tag, confirm the GitHub Release assets, GHCR image visibility, and cosign verification before announcing.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/Borgels/Vaner/actions/workflows/ci.yml/badge.svg)](https://github.com/Borgels/Vaner/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/Borgels/Vaner/actions/workflows/codeql.yml/badge.svg)](https://github.com/Borgels/Vaner/actions/workflows/codeql.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/Borgels/Vaner?label=GitHub%20Release)](https://github.com/Borgels/Vaner/releases)
+[![Downloads](https://img.shields.io/github/downloads/Borgels/Vaner/total?label=Downloads)](https://github.com/Borgels/Vaner/releases)
 [![PyPI](https://img.shields.io/pypi/v/vaner)](https://pypi.org/project/vaner/)
 [![Python](https://img.shields.io/pypi/pyversions/vaner)](https://pypi.org/project/vaner/)
 [![License](https://img.shields.io/github/license/Borgels/Vaner)](LICENSE)


### PR DESCRIPTION
## Summary
- replace the invalid `crazy-max/ghaction-github-labeler` pin in `labels.yml` with the live `v5.3.0` commit
- add GitHub Release and Downloads badges to `README.md`
- add a one-line release verification reminder to `CONTRIBUTING.md`

## Test plan
- [x] verify workflow pin resolves to an existing commit in upstream repo
- [x] run local diff review for all changed files
- [ ] wait for CI on this PR

Made with [Cursor](https://cursor.com)