### PR TITLE
chore(community): add .github security policy entry point

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Policy
+
+Canonical security policy lives in [`SECURITY.md`](../SECURITY.md).
+Use the reporting channel there for private vulnerability disclosure.


### PR DESCRIPTION
## Summary
- add `.github/SECURITY.md` so GitHub community profile reliably detects a security policy
- point it to the canonical root `SECURITY.md`

## Test plan
- [x] file present at `.github/SECURITY.md`
- [ ] community profile health check after merge

Made with [Cursor](https://cursor.com)