### PR TITLE
feat: ship local-first gateway and cockpit surfaces

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -1,0 +1,32 @@
+name: publish-vscode-extension
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ide/vscode
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install
+      - run: npm run build
+      - name: Package extension
+        run: npx @vscode/vsce package
+      - name: Publish to VS Code Marketplace
+        if: ${{ secrets.VSCE_PAT != '' }}
+        run: npx @vscode/vsce publish --packagePath *.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      - name: Publish to Open VSX
+        if: ${{ secrets.OVSX_PAT != '' }}
+        run: npx ovsx publish *.vsix -p "$OVSX_PAT"
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Package extension
         run: npx @vscode/vsce package
       - name: Publish to VS Code Marketplace
-        if: ${{ secrets.VSCE_PAT != '' }}
-        run: npx @vscode/vsce publish --packagePath *.vsix
+        if: ${{ env.VSCE_PAT != '' }}
+        run: npx @vscode/vsce publish --packagePath ./*.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
       - name: Publish to Open VSX
-        if: ${{ secrets.OVSX_PAT != '' }}
-        run: npx ovsx publish *.vsix -p "$OVSX_PAT"
+        if: ${{ env.OVSX_PAT != '' }}
+        run: npx ovsx publish ./*.vsix -p "$OVSX_PAT"
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -1,0 +1,28 @@
+# Vaner VS Code/Cursor Extension
+
+Local cockpit extension for Vaner.
+
+## Features
+
+- Status bar indicator that tracks live decision stream from `GET /decisions/stream`.
+- Command palette actions:
+  - `Vaner: Open Cockpit`
+  - `Vaner: Configure OPENAI_BASE_URL`
+- Side panel webview showing:
+  - latest decision payload
+  - detected compute devices from `GET /compute/devices`
+
+## Development
+
+```bash
+cd ide/vscode
+npm install
+npm run build
+```
+
+Then open this folder in VS Code and press `F5`.
+
+## Publishing
+
+- VS Code Marketplace (`vsce`) and Open VSX (`ovsx`) are both supported.
+- Provide `VSCE_PAT` and `OVSX_PAT` to the publish workflow.

--- a/ide/vscode/package-lock.json
+++ b/ide/vscode/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "vaner-cockpit",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vaner-cockpit",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.14.12",
+        "@types/vscode": "^1.92.0",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "vscode": "^1.92.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "vaner-cockpit",
+  "displayName": "Vaner Cockpit",
+  "description": "Local Vaner cockpit for VS Code and Cursor.",
+  "version": "0.1.0",
+  "publisher": "borgels",
+  "engines": {
+    "vscode": "^1.92.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onStartupFinished",
+    "onCommand:vaner.openCockpit",
+    "onCommand:vaner.configureOpenAIBaseUrl"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "vaner.openCockpit",
+        "title": "Vaner: Open Cockpit"
+      },
+      {
+        "command": "vaner.configureOpenAIBaseUrl",
+        "title": "Vaner: Configure OPENAI_BASE_URL"
+      }
+    ],
+    "configuration": {
+      "title": "Vaner",
+      "properties": {
+        "vaner.proxyUrl": {
+          "type": "string",
+          "default": "http://127.0.0.1:8471",
+          "description": "Local Vaner proxy base URL."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsc -p ./",
+    "watch": "tsc -w -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.12",
+    "@types/vscode": "^1.92.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/ide/vscode/src/extension.ts
+++ b/ide/vscode/src/extension.ts
@@ -1,0 +1,173 @@
+import * as vscode from "vscode";
+
+type DecisionEvent = {
+  id: string;
+  cache_tier: string;
+  token_used: number;
+  selection_count: number;
+};
+
+export function activate(context: vscode.ExtensionContext): void {
+  const state: {
+    panel: vscode.WebviewPanel | null;
+    status: vscode.StatusBarItem;
+    streamAbort: AbortController | null;
+    lastDecision: DecisionEvent | null;
+  } = {
+    panel: null,
+    status: vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100),
+    streamAbort: null,
+    lastDecision: null,
+  };
+
+  state.status.text = "Vaner • starting";
+  state.status.command = "vaner.openCockpit";
+  state.status.tooltip = "Open Vaner cockpit";
+  state.status.show();
+
+  const openCockpit = vscode.commands.registerCommand("vaner.openCockpit", () => {
+    if (state.panel) {
+      state.panel.reveal(vscode.ViewColumn.Beside);
+      return;
+    }
+    state.panel = vscode.window.createWebviewPanel(
+      "vanerCockpit",
+      "Vaner Cockpit",
+      vscode.ViewColumn.Beside,
+      { enableScripts: true }
+    );
+    state.panel.webview.html = renderCockpitHtml(proxyBaseUrl());
+    state.panel.onDidDispose(() => {
+      state.panel = null;
+    });
+  });
+
+  const configureOpenAIBaseUrl = vscode.commands.registerCommand(
+    "vaner.configureOpenAIBaseUrl",
+    async () => {
+      const value = await vscode.window.showInputBox({
+        prompt: "OPENAI_BASE_URL",
+        value: `${proxyBaseUrl().replace(/\/$/, "")}/v1`,
+      });
+      if (!value) {
+        return;
+      }
+      const terminal = vscode.window.createTerminal("Vaner Configure");
+      terminal.show();
+      terminal.sendText(`export OPENAI_BASE_URL="${value}"`);
+      vscode.window.showInformationMessage("OPENAI_BASE_URL exported in terminal session.");
+    }
+  );
+
+  context.subscriptions.push(openCockpit, configureOpenAIBaseUrl, state.status);
+
+  void startDecisionStream(state);
+}
+
+export function deactivate(): void {}
+
+function proxyBaseUrl(): string {
+  const cfg = vscode.workspace.getConfiguration("vaner");
+  return cfg.get<string>("proxyUrl", "http://127.0.0.1:8471");
+}
+
+async function startDecisionStream(state: {
+  panel: vscode.WebviewPanel | null;
+  status: vscode.StatusBarItem;
+  streamAbort: AbortController | null;
+  lastDecision: DecisionEvent | null;
+}): Promise<void> {
+  state.streamAbort?.abort();
+  state.streamAbort = new AbortController();
+  const streamUrl = `${proxyBaseUrl().replace(/\/$/, "")}/decisions/stream`;
+  try {
+    const response = await fetch(streamUrl, {
+      headers: { Accept: "text/event-stream" },
+      signal: state.streamAbort.signal,
+    });
+    if (!response.ok || !response.body) {
+      state.status.text = `Vaner • offline (${response.status})`;
+      return;
+    }
+    state.status.text = "Vaner • connected";
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      const chunks = buffer.split("\n\n");
+      buffer = chunks.pop() ?? "";
+      for (const chunk of chunks) {
+        const line = chunk.trim();
+        if (!line.startsWith("data: ")) {
+          continue;
+        }
+        const payload = line.slice(6);
+        const event = JSON.parse(payload) as DecisionEvent;
+        state.lastDecision = event;
+        state.status.text = `Vaner • ${event.cache_tier} • ${event.token_used} tok`;
+        state.panel?.webview.postMessage({ type: "decision", payload: event });
+      }
+    }
+  } catch {
+    state.status.text = "Vaner • offline";
+  } finally {
+    setTimeout(() => {
+      void startDecisionStream(state);
+    }, 3000);
+  }
+}
+
+function renderCockpitHtml(proxyUrl: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vaner Cockpit</title>
+  <style>
+    body { font-family: var(--vscode-font-family); padding: 12px; color: var(--vscode-foreground); }
+    .muted { opacity: 0.75; }
+    .row { margin: 8px 0; }
+    pre { background: var(--vscode-editor-background); padding: 8px; border-radius: 4px; overflow-x: auto; }
+    button { background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: 0; padding: 6px 10px; border-radius: 4px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <h2>Vaner Cockpit</h2>
+  <div class="row muted">Proxy: ${proxyUrl}</div>
+  <div class="row">
+    <button id="refreshDevices">Refresh compute devices</button>
+  </div>
+  <div class="row"><strong>Last decision</strong></div>
+  <pre id="decision">{}</pre>
+  <div class="row"><strong>Compute devices</strong></div>
+  <pre id="devices">loading…</pre>
+  <script>
+    const vscode = acquireVsCodeApi();
+    const decisionEl = document.getElementById("decision");
+    const devicesEl = document.getElementById("devices");
+    window.addEventListener("message", (event) => {
+      if (event.data?.type === "decision") {
+        decisionEl.textContent = JSON.stringify(event.data.payload, null, 2);
+      }
+    });
+    async function refreshDevices() {
+      try {
+        const res = await fetch("${proxyUrl.replace(/\/$/, "")}/compute/devices");
+        const data = await res.json();
+        devicesEl.textContent = JSON.stringify(data, null, 2);
+      } catch (err) {
+        devicesEl.textContent = "failed to fetch /compute/devices";
+      }
+    }
+    document.getElementById("refreshDevices").addEventListener("click", refreshDevices);
+    refreshDevices();
+  </script>
+</body>
+</html>`;
+}

--- a/ide/vscode/tsconfig.json
+++ b/ide/vscode/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,6 +24,7 @@ VANER_BACKEND="${VANER_BACKEND:-}"
 VANER_VERSION="${VANER_VERSION:-}"
 VANER_NO_MODIFY_PATH="${VANER_NO_MODIFY_PATH:-0}"
 VANER_VERBOSE="${VANER_VERBOSE:-0}"
+VANER_WITH_OLLAMA="${VANER_WITH_OLLAMA:-0}"
 HELP=0
 
 INSTALL_STAGE_TOTAL=3
@@ -88,6 +89,7 @@ Options:
   --version VERSION        Install a specific PyPI version (e.g. 0.1.0)
   --no-modify-path         Do not run ensurepath/path integration steps
   --verbose                Print executed commands
+  --with-ollama            Install/start Ollama and pull qwen2.5-coder:7b
   --help, -h               Show help
 
 Environment variable mirrors:
@@ -98,6 +100,7 @@ Environment variable mirrors:
   VANER_VERSION=<version>
   VANER_NO_MODIFY_PATH=0|1
   VANER_VERBOSE=0|1
+  VANER_WITH_OLLAMA=0|1
 
 Examples:
   curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
@@ -135,6 +138,10 @@ parse_args() {
         ;;
       --verbose)
         VANER_VERBOSE=1
+        shift
+        ;;
+      --with-ollama)
+        VANER_WITH_OLLAMA=1
         shift
         ;;
       --help|-h)
@@ -445,6 +452,57 @@ ensure_uv() {
   ui_success "uv installed"
 }
 
+ensure_ollama() {
+  if command -v ollama >/dev/null 2>&1; then
+    ui_success "Ollama already available"
+    return 0
+  fi
+
+  confirm "Ollama is missing. Install Ollama now?" || return 1
+  case "$OS" in
+    macos)
+      if [[ "$PKG_MGR" == "brew" ]]; then
+        run_cmd brew install ollama
+      else
+        local tmp
+        tmp="$(mktempfile)"
+        download_file "https://ollama.com/install.sh" "$tmp"
+        run_cmd sh "$tmp"
+      fi
+      ;;
+    linux)
+      local tmp
+      tmp="$(mktempfile)"
+      download_file "https://ollama.com/install.sh" "$tmp"
+      run_cmd sh "$tmp"
+      ;;
+    *)
+      ui_warn "Automatic Ollama install is unsupported on this OS."
+      return 1
+      ;;
+  esac
+
+  if [[ "$VANER_DRY_RUN" == "1" ]]; then
+    ui_success "Dry-run: assumed Ollama installed"
+    return 0
+  fi
+
+  if ! command -v ollama >/dev/null 2>&1; then
+    ui_error "Ollama installation did not provide `ollama` on PATH."
+    return 1
+  fi
+  ui_success "Ollama installed"
+}
+
+ensure_ollama_model() {
+  if [[ "$VANER_WITH_OLLAMA" != "1" ]]; then
+    return 0
+  fi
+  ensure_ollama || return 1
+  ui_stage "Preparing local model"
+  run_cmd ollama pull qwen2.5-coder:7b
+}
+
 pick_backend() {
   if [[ -n "$VANER_BACKEND" ]]; then
     case "$VANER_BACKEND" in
@@ -546,6 +604,7 @@ print_install_plan() {
   fi
   printf '  dry-run: %s\n' "$VANER_DRY_RUN"
   printf '  verify: %s\n' "$VANER_VERIFY"
+  printf '  with-ollama: %s\n' "$VANER_WITH_OLLAMA"
 }
 
 print_footer() {
@@ -571,6 +630,9 @@ main() {
   fi
 
   ui_section "Vaner Installer"
+  if [[ "$VANER_WITH_OLLAMA" == "1" ]]; then
+    INSTALL_STAGE_TOTAL=4
+  fi
   detect_os_or_die
   detect_pkg_mgr
   check_existing_vaner || true
@@ -619,6 +681,10 @@ main() {
 
   if [[ "$VANER_VERIFY" == "1" ]]; then
     verify_installation
+  fi
+
+  if [[ "$VANER_WITH_OLLAMA" == "1" ]]; then
+    ensure_ollama_model
   fi
 
   print_footer

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -488,7 +488,7 @@ ensure_ollama() {
   fi
 
   if ! command -v ollama >/dev/null 2>&1; then
-    ui_error "Ollama installation did not provide `ollama` on PATH."
+    ui_error "Ollama installation did not provide 'ollama' on PATH."
     return 1
   fi
   ui_success "Ollama installed"

--- a/src/vaner/cli/commands/app_legacy.py
+++ b/src/vaner/cli/commands/app_legacy.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import json
+import os
 import traceback
+from datetime import UTC, datetime
 from pathlib import Path
+from time import perf_counter
 
 import aiosqlite
 import httpx
 import typer
 
 from vaner import api
-from vaner.cli.commands.config import load_config
+from vaner.cli.commands.config import load_config, set_compute_value
 from vaner.cli.commands.daemon import daemon_status, run_daemon_forever, start_daemon, stop_daemon
 from vaner.cli.commands.explain import render_human, render_json
 from vaner.cli.commands.init import init_repo
@@ -21,6 +24,7 @@ from vaner.cli.commands.inspect import list_decisions as list_decisions_output
 from vaner.cli.commands.profile import export_pins, import_pins, pin_fact, profile_show, unpin_fact
 from vaner.daemon.runner import VanerDaemon
 from vaner.eval import evaluate_repo, run_eval
+from vaner.router.backends import forward_chat_completion_with_request
 from vaner.router.proxy import create_app
 
 app = typer.Typer(help="Vaner CLI")
@@ -46,6 +50,40 @@ def _friendly_error_message(exc: Exception) -> str:
     return f"Vaner failed: {exc}"
 
 
+def _detect_local_runtime() -> dict[str, object]:
+    probes = [
+        ("ollama", "http://127.0.0.1:11434/api/tags"),
+        ("lmstudio", "http://127.0.0.1:1234/v1/models"),
+        ("openai-compatible", "http://127.0.0.1:8000/v1/models"),
+    ]
+    for name, url in probes:
+        try:
+            response = httpx.get(url, timeout=1.2)
+            if response.status_code < 400:
+                return {"detected": True, "name": name, "url": url}
+        except Exception:
+            continue
+    return {"detected": False}
+
+
+def _detect_hardware_profile() -> dict[str, object]:
+    profile: dict[str, object] = {"device": "cpu", "gpu_count": 0, "vram_gb": 0}
+    try:  # pragma: no cover - torch/cuda depends on environment
+        import torch
+
+        if torch.cuda.is_available():
+            profile["device"] = "cuda"
+            profile["gpu_count"] = torch.cuda.device_count()
+            if torch.cuda.device_count() > 0:
+                props = torch.cuda.get_device_properties(0)
+                profile["vram_gb"] = round(props.total_memory / (1024**3), 1)
+        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            profile["device"] = "mps"
+    except Exception:
+        pass
+    return profile
+
+
 @app.callback()
 def app_callback(
     verbose: bool = typer.Option(False, "--verbose", help="Show full traceback on errors"),
@@ -56,8 +94,25 @@ def app_callback(
 
 @app.command("init")
 def init(path: str | None = typer.Option(None, help="Repository root")) -> None:
-    config_path = init_repo(_repo_root(path))
+    repo_root = _repo_root(path)
+    config_path = init_repo(repo_root)
     typer.echo(f"Initialized Vaner at {config_path}")
+    runtime = _detect_local_runtime()
+    hardware = _detect_hardware_profile()
+    if runtime.get("detected"):
+        typer.echo(f"Detected local runtime: {runtime['name']} ({runtime['url']})")
+    else:
+        typer.echo("No local runtime detected on localhost ports (11434/1234/8000).")
+        typer.echo("Recommended: curl -fsSL https://vaner.ai/install.sh | bash -s -- --with-ollama")
+    typer.echo(
+        f"Hardware profile: device={hardware['device']} gpu_count={hardware['gpu_count']} vram_gb={hardware['vram_gb']}"
+    )
+    has_vscode = (repo_root / ".vscode").exists() or os.environ.get("TERM_PROGRAM") == "vscode"
+    has_cursor = os.environ.get("CURSOR_TRACE_ID") is not None or os.environ.get("CURSOR_AGENT") is not None
+    if has_vscode or has_cursor:
+        typer.echo("Detected VS Code/Cursor environment.")
+        typer.echo("Install extension: cd ide/vscode && npm install && npm run build")
+        typer.echo("Then load the extension and run `Vaner: Open Cockpit`.")
 
 
 @daemon_app.command("start")
@@ -169,6 +224,43 @@ def forget(path: str | None = typer.Option(None, help="Repository root")) -> Non
 def config_show(path: str | None = typer.Option(None, help="Repository root")) -> None:
     config = load_config(_repo_root(path))
     typer.echo(config.model_dump_json(indent=2))
+
+
+@config_app.command("set")
+def config_set(
+    key: str = typer.Argument(..., help="Setting path, currently supports compute.*"),
+    value: str = typer.Argument(..., help="Setting value"),
+    path: str | None = typer.Option(None, help="Repository root"),
+) -> None:
+    if not key.startswith("compute."):
+        typer.secho("Only compute.* settings are supported by `vaner config set` for now.", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    compute_key = key.split(".", 1)[1]
+    converters = {
+        "device": str,
+        "embedding_device": str,
+        "cpu_fraction": float,
+        "gpu_memory_fraction": float,
+        "idle_only": lambda raw: str(raw).lower() in {"1", "true", "yes", "on"},
+        "idle_cpu_threshold": float,
+        "idle_gpu_threshold": float,
+        "exploration_concurrency": int,
+        "max_parallel_precompute": int,
+    }
+    parser = converters.get(compute_key)
+    if parser is None:
+        typer.secho(f"Unsupported compute setting: {compute_key}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    try:
+        parsed_value = parser(value)
+    except ValueError as exc:
+        typer.secho(f"Invalid value for {key}: {value}", fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    config_path = set_compute_value(_repo_root(path), compute_key, parsed_value)
+    typer.echo(f"Updated {key} in {config_path}")
 
 
 @profile_app.command("show")
@@ -317,12 +409,13 @@ def metrics_cmd(
         await store.initialize()
         summary = await store.summary(last_n=last)
         rows = await store.recent(limit=last)
-        return summary, rows
+        usage = await store.mode_usage_summary()
+        return summary, rows, usage
 
-    summary, rows = asyncio.run(_load())
+    summary, rows, usage = asyncio.run(_load())
 
     if output == "json":
-        typer.echo(json.dumps({"summary": summary, "requests": rows}, indent=2))
+        typer.echo(json.dumps({"summary": summary, "requests": rows, "usage_by_mode": usage}, indent=2))
         return
 
     if output == "csv":
@@ -365,7 +458,325 @@ def metrics_cmd(
             typer.echo(f"  {label}  avg={avg:>8.1f}  p95={p95:>8.1f}")
 
     typer.echo(f"\n  Avg context tokens:  {summary.get('avg_context_tokens', 0):.0f}")
+    if usage:
+        typer.echo("\nIntegration usage:")
+        for mode, count in usage.items():
+            typer.echo(f"  {mode:<14} {count:>5}")
     typer.echo("")
+
+
+@app.command("impact")
+def impact(
+    path: str | None = typer.Option(None, help="Repository root"),
+    last: int = typer.Option(500, "--last", "-n", help="Number of shadow pairs to aggregate"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show before/after impact from sampled shadow runs."""
+    import asyncio
+
+    from vaner.telemetry.metrics import MetricsStore
+
+    repo_root = _repo_root(path)
+    db_path = repo_root / ".vaner" / "metrics.db"
+    if not db_path.exists():
+        typer.secho("No metrics database found yet.", fg=typer.colors.YELLOW)
+        raise typer.Exit(code=1)
+
+    store = MetricsStore(db_path)
+
+    async def _load():
+        await store.initialize()
+        return await store.shadow_summary(last_n=last)
+
+    summary = asyncio.run(_load())
+    idle_path = repo_root / ".vaner" / "runtime" / "idle_usage.json"
+    idle_seconds = 0.0
+    if idle_path.exists():
+        try:
+            parsed = json.loads(idle_path.read_text(encoding="utf-8"))
+            idle_seconds = float(parsed.get("idle_seconds_used", 0.0))
+        except Exception:
+            idle_seconds = 0.0
+    summary["idle_seconds_used"] = round(idle_seconds, 3)
+    if as_json:
+        typer.echo(json.dumps(summary, indent=2))
+        return
+    if summary.get("count", 0) == 0:
+        typer.echo("No shadow comparisons recorded yet. Set [gateway.shadow] rate > 0 and send traffic through `vaner proxy`.")
+        return
+    typer.echo("Vaner impact")
+    typer.echo("=" * 40)
+    typer.echo(f"pairs:            {summary['count']}")
+    typer.echo(f"win rate:         {summary['win_rate'] * 100:.1f}%")
+    typer.echo(f"avg latency gain: {summary['avg_latency_gain_ms']:.2f} ms")
+    typer.echo(f"avg token delta:  {summary['avg_token_delta']:.2f}")
+    typer.echo(f"idle seconds used:{summary['idle_seconds_used']:.2f}")
+
+
+@app.command("compare")
+def compare(
+    prompt: str = typer.Argument(..., help="Prompt to compare with and without Vaner context"),
+    path: str | None = typer.Option(None, help="Repository root"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Run the same prompt with and without context and print deltas."""
+    import asyncio
+
+    repo_root = _repo_root(path)
+    config = load_config(repo_root)
+
+    async def _run() -> dict[str, object]:
+        base_payload = {"messages": [{"role": "user", "content": prompt}], "stream": False}
+        started_plain = perf_counter()
+        plain = await forward_chat_completion_with_request(config, base_payload, authorization_header=None)
+        plain_ms = (perf_counter() - started_plain) * 1000.0
+
+        package = await api.aquery(prompt, repo_root, config=config, top_n=6)
+        enriched_payload = {
+            "messages": [
+                {"role": "system", "content": "Use provided context when relevant.\n\n" + package.injected_context},
+                {"role": "user", "content": prompt},
+            ],
+            "stream": False,
+        }
+        started_enriched = perf_counter()
+        enriched = await forward_chat_completion_with_request(config, enriched_payload, authorization_header=None)
+        enriched_ms = (perf_counter() - started_enriched) * 1000.0
+
+        def _assistant_text(result: dict[str, object]) -> str:
+            choices = result.get("choices", [])
+            if not isinstance(choices, list) or not choices:
+                return ""
+            first = choices[0]
+            if not isinstance(first, dict):
+                return ""
+            message = first.get("message", {})
+            if isinstance(message, dict):
+                content = message.get("content", "")
+                return content if isinstance(content, str) else ""
+            return ""
+
+        enriched_text = _assistant_text(enriched)
+        plain_text = _assistant_text(plain)
+        return {
+            "prompt": prompt,
+            "context_tokens": package.token_used,
+            "with_context_ms": round(enriched_ms, 2),
+            "without_context_ms": round(plain_ms, 2),
+            "latency_gain_ms": round(plain_ms - enriched_ms, 2),
+            "with_context_chars": len(enriched_text),
+            "without_context_chars": len(plain_text),
+            "char_delta": len(enriched_text) - len(plain_text),
+        }
+
+    result = asyncio.run(_run())
+    if as_json:
+        typer.echo(json.dumps(result, indent=2))
+        return
+    typer.echo("Vaner compare")
+    typer.echo("=" * 40)
+    typer.echo(f"context tokens:   {result['context_tokens']}")
+    typer.echo(f"with context:     {result['with_context_ms']} ms")
+    typer.echo(f"without context:  {result['without_context_ms']} ms")
+    typer.echo(f"latency gain:     {result['latency_gain_ms']} ms")
+    typer.echo(f"response chars Δ: {result['char_delta']}")
+
+
+@app.command("watch")
+def watch(
+    proxy_url: str = typer.Option("http://127.0.0.1:8471", "--proxy-url", help="Vaner proxy URL"),
+    as_json: bool = typer.Option(False, "--json", help="Emit raw decision events as JSON"),
+    contains: str | None = typer.Option(None, "--filter", help="Substring filter against serialized decision payload"),
+    limit: int | None = typer.Option(None, "--limit", min=1, help="Stop after N matching events"),
+) -> None:
+    """Tail live decision events from the proxy SSE stream."""
+    stream_url = f"{proxy_url.rstrip('/')}/decisions/stream"
+    matched = 0
+    typer.echo(f"Watching decisions on {stream_url} ... (Ctrl+C to stop)")
+    with httpx.Client(timeout=None) as client:
+        with client.stream("GET", stream_url, headers={"Accept": "text/event-stream"}) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if not line or not line.startswith("data: "):
+                    continue
+                payload = line[6:]
+                if contains and contains not in payload:
+                    continue
+                event = json.loads(payload)
+                if as_json:
+                    typer.echo(json.dumps(event))
+                else:
+                    decision_id = event.get("id", "unknown")
+                    tier = event.get("cache_tier", "unknown")
+                    tokens = event.get("token_used", 0)
+                    selections = event.get("selection_count", 0)
+                    typer.echo(f"[{tier}] {tokens} tok • {selections} files • decision {decision_id}")
+                matched += 1
+                if limit is not None and matched >= limit:
+                    return
+
+
+@app.command("show")
+def show(
+    proxy_url: str = typer.Option("http://127.0.0.1:8471", "--proxy-url", help="Vaner proxy URL"),
+) -> None:
+    """Open the local web cockpit in the default browser."""
+    import webbrowser
+
+    cockpit_url = f"{proxy_url.rstrip('/')}/ui"
+    opened = webbrowser.open(cockpit_url)
+    if opened:
+        typer.echo(f"Opened {cockpit_url}")
+    else:
+        typer.echo(f"Open this URL manually: {cockpit_url}")
+
+
+@app.command("status")
+def status(
+    path: str | None = typer.Option(None, help="Repository root"),
+    proxy_url: str = typer.Option("http://127.0.0.1:8471", "--proxy-url", help="Vaner proxy URL"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show one-screen Vaner health and compute status."""
+    repo_root = _repo_root(path)
+    config = load_config(repo_root)
+    daemon = daemon_status(repo_root)
+    latest = api.inspect_last_decision(repo_root)
+
+    proxy_health = {"reachable": False, "detail": ""}
+    try:
+        response = httpx.get(f"{proxy_url.rstrip('/')}/health", timeout=2.0)
+        proxy_health["reachable"] = response.status_code == 200
+        proxy_health["detail"] = response.text
+    except Exception as exc:
+        proxy_health["detail"] = str(exc)
+
+    payload = {
+        "repo_root": str(repo_root),
+        "daemon": daemon,
+        "proxy_url": proxy_url,
+        "proxy": proxy_health,
+        "compute": config.compute.model_dump(mode="json"),
+        "backend": {
+            "base_url": config.backend.base_url,
+            "model": config.backend.model,
+            "gateway_passthrough": config.gateway.passthrough_enabled,
+        },
+        "last_decision": latest.id if latest else None,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    if as_json:
+        typer.echo(json.dumps(payload, indent=2))
+        return
+
+    typer.echo("Vaner status")
+    typer.echo("=" * 40)
+    typer.echo(f"repo:     {payload['repo_root']}")
+    typer.echo(f"daemon:   {payload['daemon']}")
+    typer.echo(f"proxy:    {'ok' if proxy_health['reachable'] else 'down'} ({proxy_url})")
+    typer.echo(f"backend:  {config.backend.base_url or '(unset)'} [{config.backend.model or '(unset)'}]")
+    typer.echo(
+        "compute:  "
+        f"device={config.compute.device} "
+        f"cpu_fraction={config.compute.cpu_fraction} "
+        f"gpu_fraction={config.compute.gpu_memory_fraction}"
+    )
+    typer.echo(f"decision: {payload['last_decision'] or 'none'}")
+
+
+@app.command("doctor")
+def doctor(
+    path: str | None = typer.Option(None, help="Repository root"),
+    proxy_url: str = typer.Option("http://127.0.0.1:8471", "--proxy-url", help="Vaner proxy URL"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Run local diagnostics and print actionable fixes."""
+    repo_root = _repo_root(path)
+    checks: list[dict[str, object]] = []
+    config_path = repo_root / ".vaner" / "config.toml"
+    checks.append(
+        {
+            "name": "config_exists",
+            "ok": config_path.exists(),
+            "detail": str(config_path),
+            "fix": "Run `vaner init` in your repository." if not config_path.exists() else "",
+        }
+    )
+
+    config = load_config(repo_root) if config_path.exists() else None
+    if config is not None:
+        has_backend = bool(config.backend.base_url.strip() and config.backend.model.strip())
+        has_routes = bool(config.gateway.routes)
+        checks.append(
+            {
+                "name": "backend_configured",
+                "ok": has_backend or has_routes,
+                "detail": "backend/base_url+model or gateway/routes must be set",
+                "fix": "Set [backend] base_url/model or add [gateway.routes] entries in .vaner/config.toml.",
+            }
+        )
+        checks.append(
+            {
+                "name": "compute_fraction_valid",
+                "ok": 0.0 < config.compute.cpu_fraction <= 1.0 and 0.0 < config.compute.gpu_memory_fraction <= 1.0,
+                "detail": f"cpu_fraction={config.compute.cpu_fraction}, gpu_memory_fraction={config.compute.gpu_memory_fraction}",
+                "fix": "Use `vaner config set compute.cpu_fraction 0.2` and `vaner config set compute.gpu_memory_fraction 0.5`.",
+            }
+        )
+        runtime = _detect_local_runtime()
+        checks.append(
+            {
+                "name": "local_runtime_detected",
+                "ok": bool(runtime.get("detected")),
+                "detail": runtime.get("url", "No local runtime on 11434/1234/8000"),
+                "fix": "Install local runtime: curl -fsSL https://vaner.ai/install.sh | bash -s -- --with-ollama",
+            }
+        )
+        is_cloud_backend = config.backend.base_url.startswith("https://")
+        if is_cloud_backend and not runtime.get("detected"):
+            checks.append(
+                {
+                    "name": "cloud_only_advisory",
+                    "ok": False,
+                    "detail": "Backend is remote and no local runtime detected.",
+                    "fix": "Point [backend] to local Ollama/LM Studio/vLLM to use existing hardware.",
+                }
+            )
+
+    try:
+        health = httpx.get(f"{proxy_url.rstrip('/')}/health", timeout=2.0)
+        checks.append(
+            {
+                "name": "proxy_reachable",
+                "ok": health.status_code == 200,
+                "detail": f"status={health.status_code}",
+                "fix": "Start the proxy with `vaner proxy`.",
+            }
+        )
+    except Exception as exc:
+        checks.append(
+            {
+                "name": "proxy_reachable",
+                "ok": False,
+                "detail": str(exc),
+                "fix": "Start the proxy with `vaner proxy`.",
+            }
+        )
+
+    overall_ok = all(bool(item["ok"]) for item in checks)
+    payload = {"ok": overall_ok, "checks": checks}
+    if as_json:
+        typer.echo(json.dumps(payload, indent=2))
+        raise typer.Exit(code=0 if overall_ok else 1)
+
+    typer.echo("Vaner doctor")
+    typer.echo("=" * 40)
+    for check in checks:
+        mark = "PASS" if check["ok"] else "FAIL"
+        typer.echo(f"[{mark}] {check['name']}: {check['detail']}")
+        if not check["ok"] and check["fix"]:
+            typer.echo(f"       fix: {check['fix']}")
+    raise typer.Exit(code=0 if overall_ok else 1)
 
 
 app.add_typer(daemon_app, name="daemon")

--- a/src/vaner/cli/commands/app_legacy.py
+++ b/src/vaner/cli/commands/app_legacy.py
@@ -104,9 +104,7 @@ def init(path: str | None = typer.Option(None, help="Repository root")) -> None:
     else:
         typer.echo("No local runtime detected on localhost ports (11434/1234/8000).")
         typer.echo("Recommended: curl -fsSL https://vaner.ai/install.sh | bash -s -- --with-ollama")
-    typer.echo(
-        f"Hardware profile: device={hardware['device']} gpu_count={hardware['gpu_count']} vram_gb={hardware['vram_gb']}"
-    )
+    typer.echo(f"Hardware profile: device={hardware['device']} gpu_count={hardware['gpu_count']} vram_gb={hardware['vram_gb']}")
     has_vscode = (repo_root / ".vscode").exists() or os.environ.get("TERM_PROGRAM") == "vscode"
     has_cursor = os.environ.get("CURSOR_TRACE_ID") is not None or os.environ.get("CURSOR_AGENT") is not None
     if has_vscode or has_cursor:

--- a/src/vaner/cli/commands/config.py
+++ b/src/vaner/cli/commands/config.py
@@ -33,16 +33,12 @@ def load_config(repo_root: Path) -> VanerConfig:
         shadow_section = gateway_section.get("shadow", {})
         routes_section = gateway_section.get("routes", {})
         gateway = GatewayConfig(
-            passthrough_enabled=bool(passthrough_section.get("enabled", True))
-            if isinstance(passthrough_section, dict)
-            else True,
+            passthrough_enabled=bool(passthrough_section.get("enabled", True)) if isinstance(passthrough_section, dict) else True,
             routes={str(key): str(value) for key, value in routes_section.items()} if isinstance(routes_section, dict) else {},
             annotate_response_trailer=bool(annotate_section.get("response_trailer", False))
             if isinstance(annotate_section, dict)
             else False,
-            annotate_system_note=str(annotate_section.get("system_note", "off"))
-            if isinstance(annotate_section, dict)
-            else "off",
+            annotate_system_note=str(annotate_section.get("system_note", "off")) if isinstance(annotate_section, dict) else "off",
             shadow_rate=float(shadow_section.get("rate", 0.0)) if isinstance(shadow_section, dict) else 0.0,
         )
     else:

--- a/src/vaner/cli/commands/config.py
+++ b/src/vaner/cli/commands/config.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
+from typing import Any
 
-from vaner.models.config import BackendConfig, GenerationConfig, PrivacyConfig, ProxyConfig, VanerConfig
+from vaner.models.config import BackendConfig, ComputeConfig, GatewayConfig, GenerationConfig, PrivacyConfig, ProxyConfig, VanerConfig
 
 
 def load_config(repo_root: Path) -> VanerConfig:
@@ -18,12 +19,35 @@ def load_config(repo_root: Path) -> VanerConfig:
     generation_section = parsed.get("generation", {})
     privacy_section = parsed.get("privacy", {})
     proxy_section = parsed.get("proxy", {})
+    gateway_section = parsed.get("gateway", {})
+    compute_section = parsed.get("compute", {})
     limits_section = parsed.get("limits", {})
 
     backend = BackendConfig(**backend_section) if isinstance(backend_section, dict) else BackendConfig()
     privacy = PrivacyConfig(**privacy_section) if isinstance(privacy_section, dict) else PrivacyConfig()
     generation = GenerationConfig(**generation_section) if isinstance(generation_section, dict) else GenerationConfig()
     proxy = ProxyConfig(**proxy_section) if isinstance(proxy_section, dict) else ProxyConfig()
+    if isinstance(gateway_section, dict):
+        passthrough_section = gateway_section.get("passthrough", {})
+        annotate_section = gateway_section.get("annotate", {})
+        shadow_section = gateway_section.get("shadow", {})
+        routes_section = gateway_section.get("routes", {})
+        gateway = GatewayConfig(
+            passthrough_enabled=bool(passthrough_section.get("enabled", True))
+            if isinstance(passthrough_section, dict)
+            else True,
+            routes={str(key): str(value) for key, value in routes_section.items()} if isinstance(routes_section, dict) else {},
+            annotate_response_trailer=bool(annotate_section.get("response_trailer", False))
+            if isinstance(annotate_section, dict)
+            else False,
+            annotate_system_note=str(annotate_section.get("system_note", "off"))
+            if isinstance(annotate_section, dict)
+            else "off",
+            shadow_rate=float(shadow_section.get("rate", 0.0)) if isinstance(shadow_section, dict) else 0.0,
+        )
+    else:
+        gateway = GatewayConfig()
+    compute = ComputeConfig(**compute_section) if isinstance(compute_section, dict) else ComputeConfig()
 
     max_age_seconds = int(limits_section.get("max_age_seconds", 3600)) if isinstance(limits_section, dict) else 3600
     max_context_tokens = int(limits_section.get("max_context_tokens", 4096)) if isinstance(limits_section, dict) else 4096
@@ -40,4 +64,55 @@ def load_config(repo_root: Path) -> VanerConfig:
         privacy=privacy,
         generation=generation,
         proxy=proxy,
+        gateway=gateway,
+        compute=compute,
     )
+
+
+def _toml_literal(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    escaped = str(value).replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def set_compute_value(repo_root: Path, key: str, value: Any) -> Path:
+    config_path = repo_root / ".vaner" / "config.toml"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    lines = config_path.read_text(encoding="utf-8").splitlines()
+    section_start = None
+    section_end = len(lines)
+    for idx, line in enumerate(lines):
+        if line.strip() == "[compute]":
+            section_start = idx
+            break
+
+    if section_start is not None:
+        for idx in range(section_start + 1, len(lines)):
+            stripped = lines[idx].strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                section_end = idx
+                break
+        key_written = False
+        for idx in range(section_start + 1, section_end):
+            stripped = lines[idx].strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.split("=", 1)[0].strip() == key:
+                lines[idx] = f"{key} = {_toml_literal(value)}"
+                key_written = True
+                break
+        if not key_written:
+            lines.insert(section_end, f"{key} = {_toml_literal(value)}")
+    else:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append("[compute]")
+        lines.append(f"{key} = {_toml_literal(value)}")
+
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return config_path

--- a/src/vaner/cli/commands/init.py
+++ b/src/vaner/cli/commands/init.py
@@ -53,6 +53,33 @@ max_requests_per_minute = 120
 ssl_certfile = ""
 ssl_keyfile = ""
 
+[gateway.passthrough]
+enabled = true
+
+[gateway.routes]
+# Route model prefixes to providers while keeping IDE model picker intact.
+# gpt- = "https://api.openai.com/v1"
+# claude- = "https://api.anthropic.com/v1"
+# gemini- = "https://generativelanguage.googleapis.com/v1beta/openai"
+
+[gateway.annotate]
+response_trailer = false
+system_note = "off"
+
+[gateway.shadow]
+rate = 0.0
+
+[compute]
+device = "auto"
+cpu_fraction = 0.2
+gpu_memory_fraction = 0.5
+idle_only = true
+idle_cpu_threshold = 0.6
+idle_gpu_threshold = 0.7
+embedding_device = "cpu"
+exploration_concurrency = 4
+max_parallel_precompute = 1
+
 [privacy]
 allowed_paths = ["."]
 excluded_patterns = ["*.env", "*.key", "*.pem", "credentials*", "secrets*"]

--- a/src/vaner/engine_legacy.py
+++ b/src/vaner/engine_legacy.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import math
 import os
+import subprocess
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -34,7 +36,7 @@ from vaner.intent.trainer import IntentTrainer
 from vaner.intent.transfer import bootstrap_transfer_priors
 from vaner.learning.reward import RewardInput, compute_reward
 from vaner.models.artefact import Artefact, ArtefactKind
-from vaner.models.config import ExplorationConfig, VanerConfig
+from vaner.models.config import ComputeConfig, ExplorationConfig, VanerConfig
 from vaner.models.context import ContextPackage
 from vaner.models.decision import DecisionRecord, PredictionLink, ScoreFactor
 from vaner.models.signal import SignalEvent
@@ -641,7 +643,15 @@ class VanerEngine:
         (everything reachable has been explored or coverage exceeds the configured
         threshold).
         """
+        cycle_started = time.monotonic()
         await self.initialize()
+        compute = self.config.compute
+        if compute.idle_only:
+            cpu_load = _cpu_load_fraction()
+            gpu_load = _gpu_load_fraction()
+            if cpu_load > compute.idle_cpu_threshold or gpu_load > compute.idle_gpu_threshold:
+                self._last_explored_scenarios = []
+                return 0
         governor = governor or PredictionGovernor()
         governor.reset()
         self._precompute_cycles += 1
@@ -844,6 +854,7 @@ class VanerEngine:
         await self.store.purge_expired_prediction_cache()
         await self.store.purge_stale_patterns(max_age_seconds=retention_seconds)
         await self._persist_learning_state()
+        _record_idle_usage_seconds(self.config, time.monotonic() - cycle_started)
         return full_packages
 
     def get_explored_scenarios(self) -> list[ExploredScenario]:
@@ -2292,6 +2303,88 @@ def _build_embed_callable(ecfg: ExplorationConfig) -> EmbedCallable | None:
         return None
 
 
+def _apply_compute_settings(compute: ComputeConfig) -> None:
+    cpu_fraction = max(0.01, min(compute.cpu_fraction, 1.0))
+    cpu_count = os.cpu_count() or 1
+    capped_threads = max(1, int(round(cpu_count * cpu_fraction)))
+    os.environ["OMP_NUM_THREADS"] = str(capped_threads)
+    os.environ["MKL_NUM_THREADS"] = str(capped_threads)
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+    if not compute.device.startswith("cuda"):
+        return
+
+    try:  # pragma: no cover - torch/cuda may be unavailable in test env
+        import torch
+
+        if not torch.cuda.is_available():
+            return
+        fraction = max(0.05, min(compute.gpu_memory_fraction, 1.0))
+        if ":" in compute.device:
+            device_index = int(compute.device.split(":", 1)[1])
+        else:
+            device_index = torch.cuda.current_device()
+        torch.cuda.set_per_process_memory_fraction(fraction, device=device_index)
+    except Exception:
+        return
+
+
+def _embedding_device_from_compute(config: VanerConfig) -> str:
+    compute_device = (config.compute.embedding_device or config.compute.device).strip().lower()
+    if not compute_device or compute_device == "auto":
+        return config.exploration.embedding_device
+    if compute_device.startswith("cuda"):
+        return "cuda"
+    if compute_device in {"cpu", "mps"}:
+        return compute_device
+    return config.exploration.embedding_device
+
+
+def _cpu_load_fraction() -> float:
+    try:
+        cpu_count = os.cpu_count() or 1
+        one_min, _, _ = os.getloadavg()
+        return max(0.0, one_min / cpu_count)
+    except Exception:
+        return 0.0
+
+
+def _gpu_load_fraction() -> float:
+    try:
+        output = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=utilization.gpu",
+                "--format=csv,noheader,nounits",
+            ],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1.0,
+        ).strip()
+        if not output:
+            return 0.0
+        values = [float(item.strip()) / 100.0 for item in output.splitlines() if item.strip()]
+        return max(values) if values else 0.0
+    except Exception:
+        return 0.0
+
+
+def _record_idle_usage_seconds(config: VanerConfig, seconds: float) -> None:
+    runtime_dir = config.repo_root / ".vaner" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    path = runtime_dir / "idle_usage.json"
+    payload = {"idle_seconds_used": 0.0}
+    if path.exists():
+        try:
+            parsed = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(parsed, dict):
+                payload["idle_seconds_used"] = float(parsed.get("idle_seconds_used", 0.0))
+        except Exception:
+            pass
+    payload["idle_seconds_used"] = round(payload["idle_seconds_used"] + max(0.0, seconds), 3)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
 def build_default_engine(repo: Path | str | None = None, config: VanerConfig | None = None) -> VanerEngine:
     """Build a VanerEngine with auto-detected exploration LLM and embeddings.
 
@@ -2306,6 +2399,9 @@ def build_default_engine(repo: Path | str | None = None, config: VanerConfig | N
     root = Path(repo).resolve() if repo is not None else Path.cwd().resolve()
     adapter = CodeRepoAdapter(root)
     resolved = config if config is not None else load_config(root)
+    _apply_compute_settings(resolved.compute)
+
+    resolved.exploration.embedding_device = _embedding_device_from_compute(resolved)
 
     exploration_llm = _build_exploration_llm(resolved.exploration)
     embed = _build_embed_callable(resolved.exploration)

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -67,6 +67,7 @@ from mcp.types import (
 
 from vaner.api import aprecompute, aquery
 from vaner.cli.commands.config import load_config
+from vaner.telemetry.metrics import MetricsStore
 
 
 def _make_text(content: str) -> list[TextContent]:
@@ -76,6 +77,7 @@ def _make_text(content: str) -> list[TextContent]:
 def build_server(repo_root: Path) -> Server:
     """Build and return the Vaner MCP Server instance."""
     config = load_config(repo_root)
+    metrics_store = MetricsStore(repo_root / ".vaner" / "metrics.db")
     server: Server = Server("vaner")
 
     @server.list_tools()
@@ -138,6 +140,11 @@ def build_server(repo_root: Path) -> Server:
     @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any] | None) -> CallToolResult:
         args = arguments or {}
+        try:
+            await metrics_store.initialize()
+            await metrics_store.increment_mode_usage("mcp")
+        except Exception:
+            pass
 
         if name == "get_context":
             prompt = str(args.get("prompt", ""))
@@ -177,8 +184,6 @@ def build_server(repo_root: Path) -> Server:
         if name == "get_metrics":
             last_n = int(args.get("last_n", 100))
             try:
-                from vaner.telemetry.metrics import MetricsStore
-
                 metrics_db = repo_root / ".vaner" / "metrics.db"
                 if not metrics_db.exists():
                     return CallToolResult(content=_make_text("No metrics yet. Run `vaner proxy` and make some requests first."))

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -85,7 +85,7 @@ class ComputeConfig(BaseModel):
     device: str = "auto"
     cpu_fraction: float = 0.2
     gpu_memory_fraction: float = 0.5
-    idle_only: bool = True
+    idle_only: bool = False
     idle_cpu_threshold: float = 0.6
     idle_gpu_threshold: float = 0.7
     embedding_device: str | None = None

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -73,6 +73,26 @@ class ProxyConfig(BaseModel):
     ssl_keyfile: str | None = None
 
 
+class GatewayConfig(BaseModel):
+    passthrough_enabled: bool = True
+    routes: dict[str, str] = Field(default_factory=dict)
+    annotate_response_trailer: bool = False
+    annotate_system_note: Literal["off", "min", "full"] = "off"
+    shadow_rate: float = 0.0
+
+
+class ComputeConfig(BaseModel):
+    device: str = "auto"
+    cpu_fraction: float = 0.2
+    gpu_memory_fraction: float = 0.5
+    idle_only: bool = True
+    idle_cpu_threshold: float = 0.6
+    idle_gpu_threshold: float = 0.7
+    embedding_device: str | None = None
+    exploration_concurrency: int = 4
+    max_parallel_precompute: int = 1
+
+
 class ExplorationConfig(BaseModel):
     """Controls how aggressively Vaner explores the scenario space.
 
@@ -215,4 +235,6 @@ class VanerConfig(BaseModel):
     privacy: PrivacyConfig = Field(default_factory=PrivacyConfig)
     generation: GenerationConfig = Field(default_factory=GenerationConfig)
     proxy: ProxyConfig = Field(default_factory=ProxyConfig)
+    gateway: GatewayConfig = Field(default_factory=GatewayConfig)
+    compute: ComputeConfig = Field(default_factory=ComputeConfig)
     exploration: ExplorationConfig = Field(default_factory=ExplorationConfig)

--- a/src/vaner/router/backends.py
+++ b/src/vaner/router/backends.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,13 @@ from vaner.models.config import BackendConfig, VanerConfig
 from vaner.router.translate import detect_format, translate_request, translate_response, translate_sse_chunk
 
 
+@dataclass(frozen=True)
+class RoutingTarget:
+    base_url: str
+    model: str
+    api_key_env: str
+
+
 def validate_backend_config(config: VanerConfig) -> None:
     """Raise a clear ``ValueError`` if the backend is not configured.
 
@@ -21,6 +29,8 @@ def validate_backend_config(config: VanerConfig) -> None:
     confusing network failure when they forget to fill in ``vaner.toml``.
     """
     backend = config.backend
+    if config.gateway.passthrough_enabled and config.gateway.routes:
+        return
     if not backend.base_url.strip():
         raise ValueError(
             "Vaner proxy requires [backend] base_url to be set in .vaner/config.toml\n"
@@ -36,7 +46,18 @@ def validate_backend_config(config: VanerConfig) -> None:
         )
 
 
-def _headers(backend: BackendConfig, *, use_fallback: bool = False, backend_format: str = "openai") -> dict[str, str]:
+def _headers(
+    backend: BackendConfig,
+    *,
+    use_fallback: bool = False,
+    backend_format: str = "openai",
+    passthrough_authorization: str | None = None,
+) -> dict[str, str]:
+    if passthrough_authorization:
+        return {
+            "Content-Type": "application/json",
+            "Authorization": passthrough_authorization,
+        }
     key_env = backend.fallback_api_key_env if use_fallback else backend.api_key_env
     api_key = os.getenv(key_env, "")
     headers = {"Content-Type": "application/json"}
@@ -112,6 +133,66 @@ async def _post_chat(backend: BackendConfig, payload: dict[str, Any], *, use_fal
         return translate_response(raw, backend_format=backend_format, model=model_name)
 
 
+def _resolve_route_base_url(config: VanerConfig, model_name: str | None) -> str | None:
+    if not model_name:
+        return None
+    match_prefix = ""
+    match_url: str | None = None
+    for prefix, base_url in config.gateway.routes.items():
+        if model_name.startswith(prefix) and len(prefix) > len(match_prefix):
+            match_prefix = prefix
+            match_url = base_url
+    if match_url:
+        return match_url.rstrip("/")
+    return None
+
+
+def _resolve_target(config: VanerConfig, payload: dict[str, Any]) -> RoutingTarget:
+    model_name = payload.get("model")
+    if isinstance(model_name, str):
+        routed = _resolve_route_base_url(config, model_name)
+        if routed:
+            return RoutingTarget(base_url=routed, model=model_name, api_key_env=config.backend.api_key_env)
+    return RoutingTarget(
+        base_url=config.backend.base_url.rstrip("/"),
+        model=model_name if isinstance(model_name, str) and model_name.strip() else config.backend.model,
+        api_key_env=config.backend.api_key_env,
+    )
+
+
+async def _post_chat_passthrough(
+    config: VanerConfig,
+    payload: dict[str, Any],
+    *,
+    authorization_header: str | None = None,
+) -> dict[str, Any]:
+    target = _resolve_target(config, payload)
+    backend_format = detect_format(target.base_url)
+    endpoint, translated = translate_request(payload, backend_format=backend_format, model=target.model)
+    temp_backend = config.backend.model_copy(
+        update={
+            "base_url": target.base_url,
+            "model": target.model,
+            "api_key_env": target.api_key_env,
+        }
+    )
+    headers = _headers(
+        temp_backend,
+        use_fallback=False,
+        backend_format=backend_format,
+        passthrough_authorization=authorization_header,
+    )
+    async with httpx.AsyncClient(timeout=60) as client:
+        response = await client.post(
+            f"{target.base_url}{endpoint}",
+            json=translated,
+            headers=headers,
+        )
+        response.raise_for_status()
+        raw = response.json()
+        return translate_response(raw, backend_format=backend_format, model=target.model)
+
+
 def _should_use_fallback(config: VanerConfig, primary_failed: bool) -> bool:
     backend = config.backend
     has_fallback = bool(backend.fallback_base_url)
@@ -124,6 +205,17 @@ def _should_use_fallback(config: VanerConfig, primary_failed: bool) -> bool:
 
 
 async def forward_chat_completion(config: VanerConfig, payload: dict[str, Any]) -> dict[str, Any]:
+    return await forward_chat_completion_with_request(config, payload, authorization_header=None)
+
+
+async def forward_chat_completion_with_request(
+    config: VanerConfig,
+    payload: dict[str, Any],
+    *,
+    authorization_header: str | None,
+) -> dict[str, Any]:
+    if config.gateway.passthrough_enabled and authorization_header:
+        return await _post_chat_passthrough(config, payload, authorization_header=authorization_header)
     backend = config.backend
     primary_error: Exception | None = None
 
@@ -165,7 +257,56 @@ async def _stream_chat(backend: BackendConfig, payload: dict[str, Any], *, use_f
                     yield translate_sse_chunk(chunk, backend_format=backend_format)
 
 
+async def _stream_chat_passthrough(
+    config: VanerConfig,
+    payload: dict[str, Any],
+    *,
+    authorization_header: str | None = None,
+):
+    target = _resolve_target(config, payload)
+    backend_format = detect_format(target.base_url)
+    endpoint, translated = translate_request(payload, backend_format=backend_format, model=target.model)
+    temp_backend = config.backend.model_copy(
+        update={
+            "base_url": target.base_url,
+            "model": target.model,
+            "api_key_env": target.api_key_env,
+        }
+    )
+    headers = _headers(
+        temp_backend,
+        use_fallback=False,
+        backend_format=backend_format,
+        passthrough_authorization=authorization_header,
+    )
+    async with httpx.AsyncClient(timeout=60) as client:
+        async with client.stream(
+            "POST",
+            f"{target.base_url}{endpoint}",
+            json=translated,
+            headers=headers,
+        ) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes():
+                if chunk:
+                    yield translate_sse_chunk(chunk, backend_format=backend_format)
+
+
 async def stream_chat_completion(config: VanerConfig, payload: dict[str, Any]):
+    async for chunk in stream_chat_completion_with_request(config, payload, authorization_header=None):
+        yield chunk
+
+
+async def stream_chat_completion_with_request(
+    config: VanerConfig,
+    payload: dict[str, Any],
+    *,
+    authorization_header: str | None,
+):
+    if config.gateway.passthrough_enabled and authorization_header:
+        async for chunk in _stream_chat_passthrough(config, payload, authorization_header=authorization_header):
+            yield chunk
+        return
     backend = config.backend
     api_key = os.getenv(backend.api_key_env, "")
     try:

--- a/src/vaner/router/proxy.py
+++ b/src/vaner/router/proxy.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import random
 import signal
 import time
 from collections import deque
@@ -10,12 +12,18 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import PlainTextResponse, StreamingResponse
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, StreamingResponse
 
 from vaner.api import aquery
+from vaner.cli.commands.config import load_config, set_compute_value
 from vaner.models.config import VanerConfig
-from vaner.router.backends import forward_chat_completion, stream_chat_completion, validate_backend_config
+from vaner.models.decision import DecisionRecord
+from vaner.router.backends import (
+    forward_chat_completion_with_request,
+    stream_chat_completion_with_request,
+    validate_backend_config,
+)
 from vaner.store.artefacts import ArtefactStore
 from vaner.telemetry.metrics import MetricsStore, RequestMetrics
 
@@ -147,6 +155,9 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
     app = FastAPI(title="Vaner Proxy", version="0.1.0", lifespan=lifespan)
     limiter = _RateLimiter(config.proxy.max_requests_per_minute)
     required_token = (config.proxy.proxy_token or "").strip()
+    shadow_rate = max(0.0, min(config.gateway.shadow_rate, 1.0))
+    decision_stream_subscribers: set[asyncio.Queue[dict[str, Any] | None]] = set()
+    gateway_enabled = True
 
     @app.get("/health")
     async def health() -> dict[str, str]:
@@ -169,6 +180,223 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
         """Prometheus-compatible metrics endpoint."""
         return prom.render()
 
+    @app.get("/compute/devices")
+    async def compute_devices() -> JSONResponse:
+        devices: list[dict[str, Any]] = [{"id": "cpu", "label": "CPU", "kind": "cpu"}]
+        try:  # pragma: no cover - GPU visibility depends on environment
+            import torch
+
+            if torch.cuda.is_available():
+                for idx in range(torch.cuda.device_count()):
+                    props = torch.cuda.get_device_properties(idx)
+                    devices.append(
+                        {
+                            "id": f"cuda:{idx}",
+                            "label": props.name,
+                            "kind": "cuda",
+                            "total_memory_bytes": props.total_memory,
+                        }
+                    )
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                devices.append({"id": "mps", "label": "Apple Metal (MPS)", "kind": "mps"})
+        except Exception:
+            pass
+        return JSONResponse({"devices": devices, "selected": config.compute.device})
+
+    @app.get("/impact/summary")
+    async def impact_summary(last: int = 500) -> JSONResponse:
+        summary = await metrics_store.shadow_summary(last_n=max(1, min(last, 2000)))
+        idle_path = config.repo_root / ".vaner" / "runtime" / "idle_usage.json"
+        idle_seconds = 0.0
+        if idle_path.exists():
+            try:
+                parsed = json.loads(idle_path.read_text(encoding="utf-8"))
+                idle_seconds = float(parsed.get("idle_seconds_used", 0.0))
+            except Exception:
+                idle_seconds = 0.0
+        summary["idle_seconds_used"] = round(idle_seconds, 3)
+        return JSONResponse(summary)
+
+    @app.get("/status")
+    async def cockpit_status() -> JSONResponse:
+        return JSONResponse(
+            {
+                "health": "ok",
+                "gateway_enabled": gateway_enabled,
+                "compute": config.compute.model_dump(mode="json"),
+                "backend": {
+                    "base_url": config.backend.base_url,
+                    "model": config.backend.model,
+                },
+            }
+        )
+
+    @app.post("/compute")
+    async def update_compute(payload: dict[str, Any]) -> JSONResponse:
+        allowed_keys = {
+            "device",
+            "cpu_fraction",
+            "gpu_memory_fraction",
+            "idle_only",
+            "idle_cpu_threshold",
+            "idle_gpu_threshold",
+            "embedding_device",
+            "exploration_concurrency",
+            "max_parallel_precompute",
+        }
+        for key, value in payload.items():
+            if key not in allowed_keys:
+                raise HTTPException(status_code=400, detail=f"Unsupported compute key: {key}")
+            set_compute_value(config.repo_root, key, value)
+        refreshed = load_config(config.repo_root)
+        config.compute = refreshed.compute
+        return JSONResponse({"ok": True, "compute": config.compute.model_dump(mode="json")})
+
+    @app.post("/gateway/toggle")
+    async def toggle_gateway(payload: dict[str, Any]) -> JSONResponse:
+        nonlocal gateway_enabled
+        gateway_enabled = bool(payload.get("enabled", True))
+        return JSONResponse({"ok": True, "gateway_enabled": gateway_enabled})
+
+    @app.get("/ui", response_class=HTMLResponse)
+    async def cockpit_ui() -> str:
+        return """<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Vaner Cockpit</title>
+    <style>
+      body { font-family: sans-serif; margin: 20px; background: #0f1117; color: #e8e8e8; }
+      .card { background: #171a22; border: 1px solid #2a2f3b; border-radius: 8px; padding: 12px; margin: 12px 0; }
+      button { background: #3a7afe; color: white; border: 0; border-radius: 6px; padding: 6px 10px; cursor: pointer; }
+      pre { background: #10131a; border-radius: 6px; padding: 10px; overflow-x: auto; }
+      input { padding: 6px 8px; border-radius: 6px; border: 1px solid #2a2f3b; background: #10131a; color: #e8e8e8; }
+    </style>
+  </head>
+  <body>
+    <h2>Vaner Cockpit</h2>
+    <div class="card"><strong>Status</strong><pre id="status">loading…</pre></div>
+    <div class="card"><strong>Impact</strong><pre id="impact">loading…</pre></div>
+    <div class="card"><strong>Last decision</strong><pre id="decision">waiting…</pre></div>
+    <div class="card">
+      <strong>Compute controls</strong><br/>
+      <label>CPU fraction <input id="cpu" value="0.2"/></label>
+      <button id="applyCompute">Apply</button>
+      <pre id="computeResult"></pre>
+    </div>
+    <div class="card">
+      <strong>Gateway toggle</strong><br/>
+      <button id="disable">Disable enrichment</button>
+      <button id="enable">Enable enrichment</button>
+    </div>
+    <script>
+      async function refresh() {
+        const status = await fetch('/status').then(r => r.json());
+        const impact = await fetch('/impact/summary').then(r => r.json());
+        document.getElementById('status').textContent = JSON.stringify(status, null, 2);
+        document.getElementById('impact').textContent = JSON.stringify(impact, null, 2);
+      }
+      const stream = new EventSource('/decisions/stream');
+      stream.onmessage = (event) => {
+        document.getElementById('decision').textContent = JSON.stringify(JSON.parse(event.data), null, 2);
+      };
+      document.getElementById('applyCompute').onclick = async () => {
+        const cpu = parseFloat(document.getElementById('cpu').value);
+        const result = await fetch('/compute', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({cpu_fraction: cpu}),
+        }).then(r => r.json());
+        document.getElementById('computeResult').textContent = JSON.stringify(result, null, 2);
+        refresh();
+      };
+      document.getElementById('disable').onclick = async () => {
+        await fetch('/gateway/toggle', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({enabled: false}),
+        });
+        refresh();
+      };
+      document.getElementById('enable').onclick = async () => {
+        await fetch('/gateway/toggle', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({enabled: true}),
+        });
+        refresh();
+      };
+      refresh();
+    </script>
+  </body>
+</html>"""
+
+    async def _publish_decision_event(event: dict[str, Any]) -> None:
+        if not decision_stream_subscribers:
+            return
+        stale_subscribers: list[asyncio.Queue[dict[str, Any] | None]] = []
+        for subscriber in decision_stream_subscribers:
+            try:
+                subscriber.put_nowait(event)
+            except asyncio.QueueFull:
+                stale_subscribers.append(subscriber)
+        for stale in stale_subscribers:
+            decision_stream_subscribers.discard(stale)
+
+    def _serialize_decision(record: DecisionRecord) -> dict[str, Any]:
+        payload = record.model_dump(mode="json")
+        payload["selection_count"] = len(record.selections)
+        return payload
+
+    def _load_recent_decisions(repo_root: Path, limit: int) -> list[dict[str, Any]]:
+        ids = DecisionRecord.list_recent_ids(repo_root, limit=limit)
+        items: list[dict[str, Any]] = []
+        for decision_id in ids:
+            record = DecisionRecord.read_by_id(repo_root, decision_id)
+            if record is None:
+                continue
+            items.append(_serialize_decision(record))
+        return items
+
+    @app.get("/decisions")
+    async def list_decisions(request: Request, limit: int = 200) -> JSONResponse:
+        repo_root = _resolve_repo_root(request)
+        bounded_limit = max(1, min(limit, 500))
+        return JSONResponse({"items": _load_recent_decisions(repo_root, bounded_limit)})
+
+    @app.get("/decisions/stream")
+    async def stream_decisions() -> StreamingResponse:
+        queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(maxsize=200)
+        decision_stream_subscribers.add(queue)
+
+        async def _event_stream():
+            try:
+                while True:
+                    event = await queue.get()
+                    if event is None:
+                        break
+                    yield f"data: {json.dumps(event)}\n\n"
+            finally:
+                decision_stream_subscribers.discard(queue)
+
+        return StreamingResponse(_event_stream(), media_type="text/event-stream")
+
+    @app.websocket("/decisions")
+    async def websocket_decisions(websocket: WebSocket) -> None:
+        await websocket.accept()
+        queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(maxsize=200)
+        decision_stream_subscribers.add(queue)
+        try:
+            while True:
+                event = await queue.get()
+                if event is None:
+                    break
+                await websocket.send_json(event)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            decision_stream_subscribers.discard(queue)
+
     def _resolve_repo_root(request: Request) -> Path:
         """Determine which repo root to use for a request.
 
@@ -189,7 +417,8 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
             raise HTTPException(status_code=503, detail="Shutting down, please retry.")
         if required_token:
             auth_header = request.headers.get("Authorization", "")
-            if auth_header != f"Bearer {required_token}":
+            token_header = request.headers.get("X-Vaner-Proxy-Token", "")
+            if token_header != required_token and auth_header != f"Bearer {required_token}":
                 raise HTTPException(status_code=401, detail="Missing or invalid proxy token.")
         if not limiter.allow():
             raise HTTPException(status_code=429, detail="Rate limit exceeded.")
@@ -202,24 +431,67 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
         user_messages = [msg for msg in payload.get("messages", []) if msg.get("role") == "user"]
         prompt = _normalize_message_content(user_messages[-1].get("content")) if user_messages else ""
         metrics.prompt_tokens = len(prompt.split())
-
-        context_package = await aquery(prompt, repo_root, config=config, top_n=6)
-
-        metrics.t1_context_ready = time.monotonic()
-        metrics.cache_tier = context_package.cache_tier
-        metrics.partial_similarity = context_package.partial_similarity
-        metrics.context_tokens = context_package.token_used
-
-        enriched = _inject_context(payload, context_package.injected_context)
+        if gateway_enabled:
+            context_package = await aquery(prompt, repo_root, config=config, top_n=6)
+            metrics.t1_context_ready = time.monotonic()
+            metrics.cache_tier = context_package.cache_tier
+            metrics.partial_similarity = context_package.partial_similarity
+            metrics.context_tokens = context_package.token_used
+            enriched = _inject_context(payload, context_package.injected_context)
+        else:
+            context_package = type("Package", (), {"cache_tier": "disabled", "partial_similarity": 0.0, "token_used": 0})()
+            metrics.t1_context_ready = time.monotonic()
+            metrics.cache_tier = "disabled"
+            metrics.partial_similarity = 0.0
+            metrics.context_tokens = 0
+            enriched = payload
         metrics.t2_forwarded = time.monotonic()
+        decision_record = DecisionRecord.read_latest(repo_root)
+        decision_id = decision_record.id if decision_record is not None else "unknown"
+        request_authorization = request.headers.get("Authorization")
 
         async def _finalize_metrics() -> None:
             metrics.finalize()
             prom.record(metrics)
             try:
                 await metrics_store.record(metrics)
+                await metrics_store.increment_mode_usage("proxy")
             except Exception:
                 pass
+
+        response_headers = {
+            "X-Vaner-Decision": decision_id,
+            "X-Vaner-Context-Tokens": str(context_package.token_used),
+            "X-Vaner-Hit-Tier": context_package.cache_tier,
+        }
+
+        if decision_record is not None:
+            await _publish_decision_event(_serialize_decision(decision_record))
+
+        async def _run_shadow_sample(with_context_ms: float) -> None:
+            if shadow_rate <= 0.0:
+                return
+            if metrics.is_stream:
+                return
+            if random.random() > shadow_rate:
+                return
+            started = time.monotonic()
+            try:
+                await forward_chat_completion_with_request(
+                    config,
+                    payload,
+                    authorization_header=request_authorization,
+                )
+            except Exception:
+                return
+            without_context_ms = (time.monotonic() - started) * 1000.0
+            await metrics_store.record_shadow_pair(
+                request_id=metrics.request_id,
+                with_context_total_ms=with_context_ms,
+                without_context_total_ms=without_context_ms,
+                with_context_tokens=context_package.token_used,
+                without_context_tokens=0,
+            )
 
         try:
             if metrics.is_stream:
@@ -227,7 +499,11 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
                 async def _instrumented_stream():
                     first_token_set = False
                     try:
-                        async for chunk in stream_chat_completion(config, enriched):
+                        async for chunk in stream_chat_completion_with_request(
+                            config,
+                            enriched,
+                            authorization_header=request.headers.get("Authorization"),
+                        ):
                             if not first_token_set and chunk:
                                 metrics.t3_first_token = time.monotonic()
                                 first_token_set = True
@@ -236,12 +512,22 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
                         metrics.t4_complete = time.monotonic()
                         await _finalize_metrics()
 
-                return StreamingResponse(_instrumented_stream(), media_type="text/event-stream")
+                return StreamingResponse(
+                    _instrumented_stream(),
+                    media_type="text/event-stream",
+                    headers=response_headers,
+                )
             else:
-                result = await forward_chat_completion(config, enriched)
+                result = await forward_chat_completion_with_request(
+                    config,
+                    enriched,
+                    authorization_header=request_authorization,
+                )
                 metrics.t4_complete = time.monotonic()
                 await _finalize_metrics()
-                return result
+                await _run_shadow_sample(metrics.total_e2e_ms)
+                response_headers["X-Vaner-Latency-Ms"] = f"{metrics.total_e2e_ms:.2f}"
+                return JSONResponse(result, headers=response_headers)
         except Exception as exc:  # pragma: no cover - network errors
             metrics.t4_complete = time.monotonic()
             await _finalize_metrics()

--- a/src/vaner/server_legacy.py
+++ b/src/vaner/server_legacy.py
@@ -10,6 +10,7 @@ from vaner.engine import build_default_engine
 from vaner.models.config import VanerConfig
 from vaner.models.context import ContextPackage
 from vaner.models.decision import DecisionRecord
+from vaner.telemetry.metrics import MetricsStore
 
 
 def _resolve_repo_root(repo: Path | str | None) -> Path:
@@ -45,6 +46,12 @@ async def aquery(
     top_n: int = 8,
 ) -> ContextPackage:
     repo_root = _resolve_repo_root(repo)
+    try:
+        store = MetricsStore(repo_root / ".vaner" / "metrics.db")
+        await store.initialize()
+        await store.increment_mode_usage("sdk")
+    except Exception:
+        pass
     engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
     package = await engine.query(prompt, max_tokens=max_tokens, top_n=top_n)
     decision_record = engine.get_last_decision_record()
@@ -71,6 +78,12 @@ async def aprecompute(
     config: VanerConfig | None = None,
 ) -> int:
     repo_root = _resolve_repo_root(repo)
+    try:
+        store = MetricsStore(repo_root / ".vaner" / "metrics.db")
+        await store.initialize()
+        await store.increment_mode_usage("precompute")
+    except Exception:
+        pass
     engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
     return await engine.precompute_cycle()
 

--- a/src/vaner/telemetry/metrics.py
+++ b/src/vaner/telemetry/metrics.py
@@ -108,6 +108,31 @@ class MetricsStore:
                 )
                 """
             )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS shadow_comparisons (
+                    shadow_pair_id TEXT PRIMARY KEY,
+                    request_id TEXT NOT NULL,
+                    timestamp REAL NOT NULL,
+                    with_context_total_ms REAL NOT NULL,
+                    without_context_total_ms REAL NOT NULL,
+                    with_context_tokens INTEGER NOT NULL,
+                    without_context_tokens INTEGER NOT NULL,
+                    latency_delta_ms REAL NOT NULL,
+                    token_delta INTEGER NOT NULL,
+                    metadata_json TEXT NOT NULL DEFAULT '{}'
+                )
+                """
+            )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS integration_usage (
+                    mode TEXT PRIMARY KEY,
+                    count INTEGER NOT NULL DEFAULT 0,
+                    updated_at REAL NOT NULL
+                )
+                """
+            )
             await db.commit()
 
     async def record(self, m: RequestMetrics) -> None:
@@ -178,3 +203,89 @@ class MetricsStore:
             "total_e2e_ms": {"avg": _avg("total_e2e_ms"), "p95": _p95("total_e2e_ms")},
             "avg_context_tokens": _avg("context_tokens"),
         }
+
+    async def record_shadow_pair(
+        self,
+        *,
+        request_id: str,
+        with_context_total_ms: float,
+        without_context_total_ms: float,
+        with_context_tokens: int,
+        without_context_tokens: int,
+    ) -> None:
+        latency_delta = without_context_total_ms - with_context_total_ms
+        token_delta = with_context_tokens - without_context_tokens
+        payload = {
+            "request_id": request_id,
+            "with_context_total_ms": with_context_total_ms,
+            "without_context_total_ms": without_context_total_ms,
+            "with_context_tokens": with_context_tokens,
+            "without_context_tokens": without_context_tokens,
+            "latency_delta_ms": latency_delta,
+            "token_delta": token_delta,
+        }
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT OR REPLACE INTO shadow_comparisons
+                    (shadow_pair_id, request_id, timestamp, with_context_total_ms,
+                     without_context_total_ms, with_context_tokens, without_context_tokens,
+                     latency_delta_ms, token_delta, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(uuid.uuid4()),
+                    request_id,
+                    time.time(),
+                    with_context_total_ms,
+                    without_context_total_ms,
+                    with_context_tokens,
+                    without_context_tokens,
+                    latency_delta,
+                    token_delta,
+                    json.dumps(payload),
+                ),
+            )
+            await db.commit()
+
+    async def shadow_summary(self, last_n: int = 500) -> dict:
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM shadow_comparisons ORDER BY timestamp DESC LIMIT ?",
+                (last_n,),
+            )
+            rows = await cursor.fetchall()
+        if not rows:
+            return {"count": 0}
+        pairs = [dict(row) for row in rows]
+        wins = [row for row in pairs if row["latency_delta_ms"] > 0]
+        avg_latency_gain = round(sum(row["latency_delta_ms"] for row in pairs) / len(pairs), 2)
+        avg_token_delta = round(sum(row["token_delta"] for row in pairs) / len(pairs), 2)
+        return {
+            "count": len(pairs),
+            "win_rate": round(len(wins) / len(pairs), 3),
+            "avg_latency_gain_ms": avg_latency_gain,
+            "avg_token_delta": avg_token_delta,
+        }
+
+    async def increment_mode_usage(self, mode: str) -> None:
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO integration_usage (mode, count, updated_at)
+                VALUES (?, 1, ?)
+                ON CONFLICT(mode) DO UPDATE SET
+                    count = count + 1,
+                    updated_at = excluded.updated_at
+                """,
+                (mode, time.time()),
+            )
+            await db.commit()
+
+    async def mode_usage_summary(self) -> dict[str, int]:
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute("SELECT mode, count FROM integration_usage ORDER BY count DESC")
+            rows = await cursor.fetchall()
+        return {str(row["mode"]): int(row["count"]) for row in rows}

--- a/tests/test_cli/test_cockpit_commands.py
+++ b/tests/test_cli/test_cockpit_commands.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands import app_legacy
+
+runner = CliRunner()
+
+
+def test_status_json_output(temp_repo, capsys, monkeypatch):
+    (temp_repo / ".vaner").mkdir(parents=True, exist_ok=True)
+    (temp_repo / ".vaner" / "config.toml").write_text(
+        """
+[backend]
+base_url = "http://127.0.0.1:11434/v1"
+model = "qwen2.5-coder:7b"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    class _Resp:
+        status_code = 200
+        text = "ok"
+
+    monkeypatch.setattr(app_legacy.httpx, "get", lambda *args, **kwargs: _Resp())
+    result = runner.invoke(app_legacy.app, ["status", "--path", str(temp_repo), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["proxy"]["reachable"] is True
+    assert payload["backend"]["model"] == "qwen2.5-coder:7b"
+
+
+def test_doctor_fails_when_config_missing(temp_repo):
+    result = runner.invoke(app_legacy.app, ["doctor", "--path", str(temp_repo), "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert any(item["name"] == "config_exists" for item in payload["checks"])
+
+
+def test_watch_renders_compact_line(capsys, monkeypatch):
+    payload = {"id": "abc123", "cache_tier": "hit", "token_used": 128, "selection_count": 3}
+
+    class _FakeStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            yield f"data: {json.dumps(payload)}"
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def stream(self, *args, **kwargs):
+            return _FakeStream()
+
+    monkeypatch.setattr(app_legacy.httpx, "Client", lambda *args, **kwargs: _FakeClient())
+    result = runner.invoke(app_legacy.app, ["watch", "--limit", "1"])
+    assert result.exit_code == 0
+    assert "[hit] 128 tok • 3 files • decision abc123" in result.stdout

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from vaner.cli.commands.config import load_config
+from vaner.cli.commands.config import load_config, set_compute_value
 
 
 def test_load_config_reads_toml_values(temp_repo):
@@ -36,6 +36,19 @@ max_requests_per_minute = 10
 ssl_certfile = "/tmp/test-cert.pem"
 ssl_keyfile = "/tmp/test-key.pem"
 
+[gateway.passthrough]
+enabled = true
+
+[gateway.routes]
+gpt- = "https://api.openai.com/v1"
+
+[gateway.annotate]
+response_trailer = false
+system_note = "off"
+
+[gateway.shadow]
+rate = 0.15
+
 [privacy]
 allowed_paths = ["src/**"]
 excluded_patterns = ["*.env"]
@@ -45,6 +58,17 @@ telemetry = "local"
 [limits]
 max_age_seconds = 120
 max_context_tokens = 2048
+
+[compute]
+device = "cuda:1"
+cpu_fraction = 0.4
+gpu_memory_fraction = 0.7
+idle_only = true
+idle_cpu_threshold = 0.55
+idle_gpu_threshold = 0.8
+embedding_device = "cuda"
+exploration_concurrency = 6
+max_parallel_precompute = 2
 """.strip(),
         encoding="utf-8",
     )
@@ -60,6 +84,32 @@ max_context_tokens = 2048
     assert config.generation.max_generations_per_cycle == 15
     assert config.proxy.proxy_token == "token"
     assert config.proxy.ssl_certfile == "/tmp/test-cert.pem"
+    assert config.gateway.passthrough_enabled is True
+    assert config.gateway.routes["gpt-"] == "https://api.openai.com/v1"
+    assert config.gateway.shadow_rate == 0.15
     assert config.privacy.allowed_paths == ["src/**"]
     assert config.max_age_seconds == 120
     assert config.max_context_tokens == 2048
+    assert config.compute.device == "cuda:1"
+    assert config.compute.cpu_fraction == 0.4
+    assert config.compute.gpu_memory_fraction == 0.7
+    assert config.compute.idle_only is True
+    assert config.compute.idle_cpu_threshold == 0.55
+    assert config.compute.idle_gpu_threshold == 0.8
+    assert config.compute.embedding_device == "cuda"
+    assert config.compute.exploration_concurrency == 6
+    assert config.compute.max_parallel_precompute == 2
+
+
+def test_set_compute_value_updates_existing_section(temp_repo):
+    vaner_dir = temp_repo / ".vaner"
+    vaner_dir.mkdir(parents=True, exist_ok=True)
+    config_path = vaner_dir / "config.toml"
+    config_path.write_text("[compute]\ncpu_fraction = 0.2\n", encoding="utf-8")
+
+    set_compute_value(temp_repo, "cpu_fraction", 0.5)
+    set_compute_value(temp_repo, "device", "cuda:0")
+
+    config = load_config(temp_repo)
+    assert config.compute.cpu_fraction == 0.5
+    assert config.compute.device == "cuda:0"

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -8,3 +8,7 @@ from vaner.cli.commands.init import init_repo
 def test_init_creates_config(temp_repo):
     config_path = init_repo(temp_repo)
     assert config_path.exists()
+    content = config_path.read_text(encoding="utf-8")
+    assert "[gateway.passthrough]" in content
+    assert "[compute]" in content
+    assert "idle_only = true" in content

--- a/tests/test_router/test_backends.py
+++ b/tests/test_router/test_backends.py
@@ -52,3 +52,24 @@ def test_forward_chat_completion_uses_fallback_when_primary_fails(temp_repo, mon
     result = asyncio.run(backends.forward_chat_completion(config, {"messages": []}))
     assert result["id"] == "ok"
     assert calls == [False, True]
+
+
+def test_resolve_target_uses_model_prefix_routes(temp_repo):
+    config = _config(
+        temp_repo,
+        base_url="http://localhost:11434/v1",
+        model="qwen2.5-coder:7b",
+    )
+    config.gateway.routes = {
+        "gpt-": "https://api.openai.com/v1",
+        "claude-": "https://api.anthropic.com/v1",
+    }
+    target = backends._resolve_target(config, {"model": "gpt-4.1-mini", "messages": []})
+    assert target.base_url == "https://api.openai.com/v1"
+    assert target.model == "gpt-4.1-mini"
+
+
+def test_headers_prefer_passthrough_authorization():
+    backend = BackendConfig(base_url="https://api.openai.com/v1", model="gpt-4o")
+    headers = backends._headers(backend, passthrough_authorization="Bearer passthrough-key")
+    assert headers["Authorization"] == "Bearer passthrough-key"

--- a/tests/test_router/test_proxy_app.py
+++ b/tests/test_router/test_proxy_app.py
@@ -38,11 +38,11 @@ def test_proxy_requires_token_when_configured(temp_repo, monkeypatch):
     async def _fake_aquery(prompt, repo_root, config=None, top_n=6):
         return _Package()
 
-    async def _fake_forward_chat_completion(config, payload):
+    async def _fake_forward_chat_completion(config, payload, *, authorization_header=None):
         return {"id": "ok"}
 
     monkeypatch.setattr(proxy_module, "aquery", _fake_aquery)
-    monkeypatch.setattr(proxy_module, "forward_chat_completion", _fake_forward_chat_completion)
+    monkeypatch.setattr(proxy_module, "forward_chat_completion_with_request", _fake_forward_chat_completion)
     config = _make_config(temp_repo, proxy=ProxyConfig(proxy_token="abc123", max_requests_per_minute=10))
     app = create_app(config, ArtefactStore(config.store_path))
     client = TestClient(app)
@@ -68,11 +68,11 @@ def test_proxy_rate_limits_requests(temp_repo, monkeypatch):
     async def _fake_aquery(prompt, repo_root, config=None, top_n=6):
         return _Package()
 
-    async def _fake_forward_chat_completion(config, payload):
+    async def _fake_forward_chat_completion(config, payload, *, authorization_header=None):
         return {"id": "ok"}
 
     monkeypatch.setattr(proxy_module, "aquery", _fake_aquery)
-    monkeypatch.setattr(proxy_module, "forward_chat_completion", _fake_forward_chat_completion)
+    monkeypatch.setattr(proxy_module, "forward_chat_completion_with_request", _fake_forward_chat_completion)
     config = _make_config(temp_repo, proxy=ProxyConfig(max_requests_per_minute=1))
     app = create_app(config, ArtefactStore(config.store_path))
     client = TestClient(app)
@@ -81,3 +81,84 @@ def test_proxy_rate_limits_requests(temp_repo, monkeypatch):
     second = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]})
     assert first.status_code == 200
     assert second.status_code == 429
+
+
+def test_proxy_preserves_authorization_header_in_passthrough(temp_repo, monkeypatch):
+    class _Package:
+        injected_context = "context"
+        cache_tier = "miss"
+        partial_similarity = 0.0
+        token_used = 5
+
+    captured_authorization = {}
+
+    async def _fake_aquery(prompt, repo_root, config=None, top_n=6):
+        return _Package()
+
+    async def _fake_forward_chat_completion(config, payload, *, authorization_header=None):
+        captured_authorization["value"] = authorization_header
+        return {"id": "ok"}
+
+    monkeypatch.setattr(proxy_module, "aquery", _fake_aquery)
+    monkeypatch.setattr(proxy_module, "forward_chat_completion_with_request", _fake_forward_chat_completion)
+    config = _make_config(temp_repo)
+    app = create_app(config, ArtefactStore(config.store_path))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer upstream-key"},
+    )
+
+    assert response.status_code == 200
+    assert captured_authorization["value"] == "Bearer upstream-key"
+    assert response.headers["X-Vaner-Context-Tokens"] == "5"
+    assert "X-Vaner-Decision" in response.headers
+
+
+def test_cockpit_endpoints(temp_repo, monkeypatch):
+    vaner_dir = temp_repo / ".vaner"
+    vaner_dir.mkdir(parents=True, exist_ok=True)
+    (vaner_dir / "config.toml").write_text(
+        """
+[backend]
+base_url = "http://127.0.0.1:11434/v1"
+model = "test-model"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    class _Package:
+        injected_context = "context"
+        cache_tier = "miss"
+        partial_similarity = 0.0
+        token_used = 1
+
+    async def _fake_aquery(prompt, repo_root, config=None, top_n=6):
+        return _Package()
+
+    async def _fake_forward_chat_completion(config, payload, *, authorization_header=None):
+        return {"id": "ok", "choices": [{"message": {"content": "done"}}]}
+
+    monkeypatch.setattr(proxy_module, "aquery", _fake_aquery)
+    monkeypatch.setattr(proxy_module, "forward_chat_completion_with_request", _fake_forward_chat_completion)
+    config = _make_config(temp_repo)
+    app = create_app(config, ArtefactStore(config.store_path))
+    client = TestClient(app)
+
+    status = client.get("/status")
+    assert status.status_code == 200
+    assert status.json()["health"] == "ok"
+
+    html = client.get("/ui")
+    assert html.status_code == 200
+    assert "Vaner Cockpit" in html.text
+
+    updated = client.post("/compute", json={"cpu_fraction": 0.3})
+    assert updated.status_code == 200
+    assert updated.json()["compute"]["cpu_fraction"] == 0.3
+
+    toggled = client.post("/gateway/toggle", json={"enabled": False})
+    assert toggled.status_code == 200
+    assert toggled.json()["gateway_enabled"] is False

--- a/tests/test_telemetry/test_metrics_shadow.py
+++ b/tests/test_telemetry/test_metrics_shadow.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+
+from vaner.telemetry.metrics import MetricsStore
+
+
+def test_shadow_summary_aggregates_pairs(temp_repo):
+    db_path = temp_repo / ".vaner" / "metrics.db"
+    store = MetricsStore(db_path)
+
+    async def _run() -> dict:
+        await store.initialize()
+        await store.record_shadow_pair(
+            request_id="r1",
+            with_context_total_ms=100.0,
+            without_context_total_ms=140.0,
+            with_context_tokens=120,
+            without_context_tokens=90,
+        )
+        await store.record_shadow_pair(
+            request_id="r2",
+            with_context_total_ms=200.0,
+            without_context_total_ms=150.0,
+            with_context_tokens=150,
+            without_context_tokens=130,
+        )
+        return await store.shadow_summary(last_n=10)
+
+    summary = asyncio.run(_run())
+    assert summary["count"] == 2
+    assert 0.0 <= summary["win_rate"] <= 1.0
+    assert "avg_latency_gain_ms" in summary
+
+
+def test_mode_usage_counts(temp_repo):
+    db_path = temp_repo / ".vaner" / "metrics.db"
+    store = MetricsStore(db_path)
+
+    async def _run() -> dict[str, int]:
+        await store.initialize()
+        await store.increment_mode_usage("proxy")
+        await store.increment_mode_usage("proxy")
+        await store.increment_mode_usage("mcp")
+        return await store.mode_usage_summary()
+
+    usage = asyncio.run(_run())
+    assert usage["proxy"] == 2
+    assert usage["mcp"] == 1


### PR DESCRIPTION
## Summary
- implement passthrough-first gateway behavior with model/auth preservation, model-prefix routing, decision stream endpoints, response metadata headers, and shadow comparison telemetry
- add cockpit surfaces across CLI (`watch`, `show`, `status`, `doctor`, `impact`, `compare`), lightweight local web UI (`/ui`), and a first-party VS Code/Cursor extension scaffold with publish workflow
- wire compute and onboarding controls end-to-end (`[compute]` config parsing + engine application, `/compute/devices`, local runtime/hardware detection, idle-only gating, installer `--with-ollama`)

## Test plan
- [x] `pytest`
- [x] `ruff check src tests`
- [x] `bash scripts/install.sh --dry-run --yes --backend uv --with-ollama`
- [x] `npm run build` (in `ide/vscode`)

Made with [Cursor](https://cursor.com)