### PR TITLE
chore(community): expand .github security policy content

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,4 +1,24 @@
 # Security Policy
 
-Canonical security policy lives in [`SECURITY.md`](../SECURITY.md).
-Use the reporting channel there for private vulnerability disclosure.
+## Supported Versions
+
+Security fixes are applied to the latest release line.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately to:
+
+- security@vaner.ai
+
+Do not open public issues for security disclosures.
+
+## Response Targets
+
+- Initial acknowledgment within 48 hours
+- Triage and severity assessment within 7 days
+- Coordinated disclosure timeline agreed with reporter
+
+## Security Documentation
+
+Public-facing security and privacy guidance is published at
+[docs.vaner.ai/security](https://docs.vaner.ai/security).


### PR DESCRIPTION
## Summary
- replace the thin `.github/SECURITY.md` pointer with a full policy document
- keep reporting channel and response targets explicit for community-profile detection

## Test plan
- [x] policy file exists at `.github/SECURITY.md`
- [ ] re-check community profile API after merge

Made with [Cursor](https://cursor.com)