### PR TITLE
fix(ci): restore scorecard workflow_dispatch trigger

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,6 +2,7 @@ name: Scorecard supply-chain security
 
 on:
   branch_protection_rule:
+  workflow_dispatch:
   schedule:
     - cron: "21 5 * * 2"
   push:


### PR DESCRIPTION
Restore the  trigger in  so Scorecard can be manually rerun on demand.

Made with [Cursor](https://cursor.com)