### PR TITLE
fix(ci): pin VSCode publish workflow for scorecard

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -12,11 +15,11 @@ jobs:
       run:
         working-directory: ide/vscode
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - name: Package extension
         run: npx @vscode/vsce package


### PR DESCRIPTION
Pin GitHub actions by full SHA and switch to npm ci in VSCode publish workflow to satisfy Scorecard pinned-dependencies checks.

Made with [Cursor](https://cursor.com)