### PR TITLE
feat(mcp): friendly backend guard + installer runtime cap UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ The installer:
 Non-interactive example (CI, Dockerfile):
 
 ```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh \
-  | bash -s -- --yes --backend-preset openai \
-      --backend-api-key-env OPENAI_API_KEY \
-      --backend-model gpt-4o \
-      --compute-preset background \
-      --max-session-minutes 30
+VANER_YES=1 \
+VANER_BACKEND_PRESET=openai \
+VANER_BACKEND_API_KEY_ENV=OPENAI_API_KEY \
+VANER_BACKEND_MODEL=gpt-4o \
+VANER_COMPUTE_PRESET=background \
+VANER_MAX_SESSION_MINUTES=30 \
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
 ```
 
 From source (no installer):

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -709,6 +709,8 @@ print_install_plan() {
   fi
   if [[ -n "$VANER_MAX_SESSION_MINUTES" ]]; then
     printf '  max-session-minutes: %s\n' "$VANER_MAX_SESSION_MINUTES"
+  else
+    printf '  max-session-minutes: unbounded\n'
   fi
 }
 
@@ -813,6 +815,45 @@ collect_backend_details() {
   esac
 }
 
+resolve_compute_preferences() {
+  if [[ -z "$VANER_COMPUTE_PRESET" ]]; then
+    if is_promptable; then
+      {
+        printf '\n'
+        printf 'Pick a compute budget:\n'
+        printf '  1) background — idle-first and battery-safe (recommended)\n'
+        printf '  2) balanced   — available while you work, still bounded\n'
+        printf '  3) dedicated  — aggressive use for dedicated hardware\n'
+      } > /dev/tty
+      local preset_choice
+      preset_choice="$(prompt_line "Choice" "1")"
+      case "$preset_choice" in
+        1|background|"") VANER_COMPUTE_PRESET="background" ;;
+        2|balanced) VANER_COMPUTE_PRESET="balanced" ;;
+        3|dedicated) VANER_COMPUTE_PRESET="dedicated" ;;
+        *)
+          ui_warn "Unrecognized compute preset '$preset_choice'; defaulting to background."
+          VANER_COMPUTE_PRESET="background"
+          ;;
+      esac
+    else
+      VANER_COMPUTE_PRESET="${VANER_COMPUTE_PRESET:-background}"
+    fi
+  fi
+
+  if [[ -z "$VANER_MAX_SESSION_MINUTES" ]] && is_promptable; then
+    local minutes
+    minutes="$(prompt_line "Cap a continuous vaner daemon session (blank for unlimited, minutes)" "")"
+    if [[ -n "$minutes" ]]; then
+      if [[ "$minutes" =~ ^[0-9]+$ ]] && [[ "$minutes" -gt 0 ]]; then
+        VANER_MAX_SESSION_MINUTES="$minutes"
+      else
+        ui_warn "Ignoring invalid max-session-minutes value: '$minutes' (must be a positive integer)."
+      fi
+    fi
+  fi
+}
+
 configure_backend_and_compute() {
   if [[ "$VANER_DRY_RUN" == "1" ]]; then
     ui_info "Dry-run: skipping backend/compute configuration."
@@ -878,6 +919,7 @@ main() {
     VANER_WITH_OLLAMA=1
   fi
   collect_backend_details
+  resolve_compute_preferences
   if [[ "$VANER_WITH_OLLAMA" == "1" ]]; then
     INSTALL_STAGE_TOTAL=4
   fi

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -77,6 +77,30 @@ def _make_text(content: str) -> list[TextContent]:
     return [TextContent(type="text", text=content)]
 
 
+BACKEND_NOT_CONFIGURED_MESSAGE = (
+    "No LLM backend configured for Vaner.\n"
+    "Fix it with one command:\n"
+    "  vaner init --backend-preset ollama          # local, free\n"
+    "  vaner init --backend-preset openrouter --backend-api-key-env OPENROUTER_API_KEY\n"
+    "Docs: https://docs.vaner.ai/mcp"
+)
+
+
+class BackendNotConfiguredError(RuntimeError):
+    code = "backend_not_configured"
+
+    def __init__(self) -> None:
+        super().__init__(BACKEND_NOT_CONFIGURED_MESSAGE)
+
+
+def _ensure_backend(config: Any) -> None:
+    backend = getattr(config, "backend", None)
+    base_url = str(getattr(backend, "base_url", "") or "").strip()
+    model = str(getattr(backend, "model", "") or "").strip()
+    if not base_url or not model:
+        raise BackendNotConfiguredError()
+
+
 def _scenario_to_summary(scenario: Scenario) -> dict[str, Any]:
     return {
         "id": scenario.id,
@@ -247,9 +271,18 @@ def build_server(repo_root: Path) -> Server:
                 # Metrics are best-effort; tool execution must remain non-fatal.
                 return
 
-        async def _error(message: str, *, tool_name: str | None = None, scenario_id: str | None = None) -> CallToolResult:
+        async def _error(
+            message: str,
+            *,
+            tool_name: str | None = None,
+            scenario_id: str | None = None,
+            code: str | None = None,
+        ) -> CallToolResult:
             await _record("error", tool_name=tool_name, scenario_id=scenario_id)
-            return CallToolResult(content=_make_text(message), isError=True)
+            structured: dict[str, Any] | None = None
+            if code:
+                structured = {"code": code, "message": message}
+            return CallToolResult(content=_make_text(message), isError=True, structuredContent=structured)
 
         if name == "list_scenarios":
             limit = int(args.get("limit", 10))
@@ -275,6 +308,10 @@ def build_server(repo_root: Path) -> Server:
             scenario_id = str(args.get("id", "")).strip()
             if not scenario_id:
                 return await _error("ERROR: id is required")
+            try:
+                _ensure_backend(config)
+            except BackendNotConfiguredError as exc:
+                return await _error(str(exc), scenario_id=scenario_id, code=exc.code)
             try:
                 await aprecompute(repo_root, config=config)
             except Exception as exc:
@@ -340,6 +377,10 @@ def build_server(repo_root: Path) -> Server:
             top_n = int(args.get("top_n", 8))
             if not prompt:
                 return await _error("ERROR: prompt is required", tool_name="legacy_get_context")
+            try:
+                _ensure_backend(config)
+            except BackendNotConfiguredError as exc:
+                return await _error(str(exc), tool_name="legacy_get_context", code=exc.code)
             try:
                 package = await aquery(prompt, repo_root, config=config, top_n=top_n)
             except Exception as exc:

--- a/tests/test_mcp/test_scenario_tools.py
+++ b/tests/test_mcp/test_scenario_tools.py
@@ -37,7 +37,7 @@ def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
     async def _run() -> None:
         await _seed_scenario(temp_repo)
         (temp_repo / ".vaner" / "config.toml").write_text(
-            "[backend]\nbase_url = \"http://127.0.0.1:11434/v1\"\nmodel = \"llama3.2:3b\"\n",
+            '[backend]\nbase_url = "http://127.0.0.1:11434/v1"\nmodel = "llama3.2:3b"\n',
             encoding="utf-8",
         )
         server = build_server(temp_repo)

--- a/tests/test_mcp/test_scenario_tools.py
+++ b/tests/test_mcp/test_scenario_tools.py
@@ -36,6 +36,10 @@ async def _seed_scenario(repo_root) -> None:
 def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
     async def _run() -> None:
         await _seed_scenario(temp_repo)
+        (temp_repo / ".vaner" / "config.toml").write_text(
+            "[backend]\nbase_url = \"http://127.0.0.1:11434/v1\"\nmodel = \"llama3.2:3b\"\n",
+            encoding="utf-8",
+        )
         server = build_server(temp_repo)
         list_handler = server.request_handlers[ListToolsRequest]
         call_handler = server.request_handlers[CallToolRequest]

--- a/tests/test_mcp_backend_guard.py
+++ b/tests/test_mcp_backend_guard.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("mcp")
+from mcp.types import CallToolRequest
+
+from vaner.mcp.server import build_server
+
+
+def test_mcp_backend_guard_for_query_and_expand(temp_repo):
+    async def _run() -> None:
+        server = build_server(temp_repo)
+        call_handler = server.request_handlers[CallToolRequest]
+
+        query_result = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "legacy_get_context", "arguments": {"prompt": "How does this work?"}},
+            )
+        )
+        assert query_result.root.isError is True
+        assert "vaner init --backend-preset" in query_result.root.content[0].text
+        assert query_result.root.structuredContent["code"] == "backend_not_configured"
+
+        expand_result = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "expand_scenario", "arguments": {"id": "scn_missing"}},
+            )
+        )
+        assert expand_result.root.isError is True
+        assert "vaner init --backend-preset" in expand_result.root.content[0].text
+        assert expand_result.root.structuredContent["code"] == "backend_not_configured"
+
+    asyncio.run(_run())

--- a/tests/test_ponder_cap.py
+++ b/tests/test_ponder_cap.py
@@ -44,7 +44,7 @@ async def test_precompute_cycle_respects_max_cycle_seconds(temp_repo) -> None:
             return base[0]
         return base[0] + 1000.0
 
-    with patch("vaner.engine_legacy.time.monotonic", side_effect=fake_monotonic):
+    with patch("vaner.engine.time.monotonic", side_effect=fake_monotonic):
         full_packages = await engine.precompute_cycle()
 
     assert isinstance(full_packages, int)


### PR DESCRIPTION
## Summary
- return structured `backend_not_configured` MCP errors for backend-dependent tools with a clear `vaner init --backend-preset ...` fix command
- add installer compute/runtime prompt improvements, including default compute preset resolution and explicit `max-session-minutes` plan output
- update README non-interactive installer example to use env var mirrors including `VANER_MAX_SESSION_MINUTES`

## Test plan
- [x] `pytest -q tests/test_mcp_backend_guard.py tests/test_mcp/test_scenario_tools.py`
- [x] `bash scripts/install.sh --help`
- [x] `VANER_YES=1 VANER_DRY_RUN=1 VANER_BACKEND_PRESET=skip bash scripts/install.sh`


Made with [Cursor](https://cursor.com)