### PR TITLE
chore(security): gitleaks pre-commit + MCP list_scenarios schema fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,13 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.3
     hooks:
       - id: ruff-check
       - id: ruff-format
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -136,8 +136,11 @@ def build_server(repo_root: Path) -> Server:
                         "properties": {
                             "kind": {
                                 "type": "string",
-                                "enum": ["debug", "explain", "change", "research"],
-                                "description": "Optional filter by scenario kind",
+                                "description": (
+                                    "Optional filter by scenario kind "
+                                    "(debug | explain | change | research). "
+                                    "Unknown values return an empty list."
+                                ),
                             },
                             "limit": {
                                 "type": "integer",


### PR DESCRIPTION
## Summary
- Adds **gitleaks** (v8.30.1) and **detect-private-key** to `.pre-commit-config.yaml`. The existing CI job already runs `pre-commit run --all-files`, so secrets are scanned locally and on every PR.
- **MCP:** Removes the strict JSON Schema `enum` on `list_scenarios` `kind` so unknown values reach the handler and return JSON `{"count": 0, ...}` instead of an MCP input-validation error string (fixes `test_mcp_tools_list_and_scenario_flow` for `kind=bogus`).

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `pre-commit run --all-files`
- [x] `mypy` (CI subset)
- [x] `pytest tests -m "not slow and not integration" --cov=src/vaner --cov-fail-under=70`
- [x] `pip-audit -r requirements/ci.txt`
- [x] `shellcheck scripts/install.sh` + install dry-run

Made with [Cursor](https://cursor.com)