### PR TITLE
feat(cli)!: polish UX, schema cleanup, and skills-loop hardening

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,6 +25,14 @@ Vaner is a local-first predictive context engine for coding assistants.
 - Safety and privacy policy modules gate what leaves local storage.
 - Training and moat-sensitive workflows are intentionally isolated to private repos.
 
+## Agent skills loop
+
+- Vaner discovers workspace `SKILL.md` files and emits `skill_loaded` intent signals.
+- Skills seed tactical frontier candidates through trigger/path matching and optional `vaner.kind`.
+- MCP tools accept an optional `skill` label so outcomes are attributed to the active skill.
+- Feedback is fed back into source multipliers, reinforcing successful frontier sources.
+- `vaner distill-skill` converts successful decision records into managed reusable skills.
+
 ## Decision transparency
 
 - Every `query` writes a structured decision record to `.vaner/runtime/decisions/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - Initial public project scaffolding and documentation split to `docs.vaner.ai`.
+- Agent Skills closed loop integration:
+  - skill discovery and intent seeding
+  - MCP skill attribution on scenario tools and outcome reporting
+  - scenario feedback queue for adaptive frontier weighting
+  - managed bundled `vaner-feedback` skill installation in `vaner init`
+  - `vaner distill-skill` for converting decision records into reusable `SKILL.md`
+
+### Changed
+
+- CLI UX polish:
+  - added `vaner --version`, grouped help panels, and command aliases (`ls`, `ps`, `logs`)
+  - added `config get`, `config keys`, and `config edit`
+  - improved `config show` and `doctor` terminal output with richer formatting
+  - added `vaner upgrade` helper
+  - `vaner init` now applies detected compute defaults and offers shell-completion install
+  - MCP config scaffolding now prefers the absolute `vaner` binary path and only falls back to `uvx`
+
+### Breaking changes
+
+- `exploration.exploration_model` renamed to `exploration.model`.
+- `exploration.exploration_endpoint` renamed to `exploration.endpoint`.
+- `exploration.exploration_backend` renamed to `exploration.backend`.
+- `exploration.exploration_api_key` renamed to `exploration.api_key`.
+- `exploration.embedding_device` removed; `compute.embedding_device` is now authoritative.
+- `intent.skills_loop.enabled` defaults to `true`.
 
 ## [0.2.0] - 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Vaner exposes context to your agent over [MCP](https://modelcontextprotocol.io/)
 | --- | --- |
 | Claude Code | `claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .` |
 | Codex CLI   | `codex mcp add vaner -- vaner mcp --path .` |
-| Cursor / VS Code / Zed / Windsurf / Continue / Claude Desktop / Cline / Roo | see [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp) |
+| Cursor / VS Code / Zed / Windsurf / Continue / Claude Desktop / Cline / Roo | see [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp) (client setup guides) |
 
 Or let Vaner write the config file for you:
 
@@ -88,6 +88,7 @@ Most documentation lives at [docs.vaner.ai](https://docs.vaner.ai):
 - Security: [docs.vaner.ai/security](https://docs.vaner.ai/security)
 - CLI reference: [docs.vaner.ai/cli](https://docs.vaner.ai/cli)
 - Examples: [docs.vaner.ai/examples](https://docs.vaner.ai/examples)
+- Agent skills loop (repo docs): [`docs/skills-integration.md`](docs/skills-integration.md)
 
 ## Community
 

--- a/docs/skills-integration.md
+++ b/docs/skills-integration.md
@@ -1,0 +1,144 @@
+# Agent Skills Integration
+
+Vaner supports a closed loop with agent `SKILL.md` files:
+
+1. **Skills as prior**: Vaner discovers workspace skills and emits `skill_loaded` signals.
+2. **Skill-aware exploration**: the exploration frontier seeds extra scenarios from skill triggers.
+3. **Feedback closure**: MCP `report_outcome` accepts optional `skill`, which is persisted for attribution.
+4. **Distillation**: `vaner distill-skill <decision-id>` converts successful decision records into reusable skills.
+
+## Discovery roots
+
+By default, Vaner scans:
+
+- `.cursor/skills`
+- `.claude/skills`
+- `skills`
+
+These can be configured through `.vaner/config.toml` under `[intent]`.
+
+## Skill frontmatter
+
+Vaner consumes optional frontmatter keys:
+
+- `name`
+- `description`
+- `tags`
+- `triggers`
+- `vaner.kind`
+
+`triggers` are used to match likely file paths and seed tactical frontier scenarios.
+
+## Feedback loop
+
+When agents call `report_outcome` with `skill`, Vaner records:
+
+- scenario result (`useful` / `partial` / `irrelevant`)
+- source attribution (`skill` or fallback)
+- skill label
+
+The exploration policy consumes this feedback in future precompute cycles.
+# Agent Skills Integration
+
+Vaner supports a closed loop between skill files and predictive context:
+
+1. Discover skill files (`SKILL.md`) from configured roots.
+2. Feed those skills into intent features and frontier seeding.
+3. Attribute scenario outcomes with a skill name.
+4. Apply feedback to future scenario ranking.
+5. Distill successful decision records into managed skills.
+
+## Supported roots
+
+- `.cursor/skills/**/SKILL.md`
+- `.claude/skills/**/SKILL.md`
+- `skills/**/SKILL.md`
+
+By default, only repo-local roots are persisted. Set `intent.include_global_skills = true` to include absolute/global roots.
+
+## Frontmatter
+
+```yaml
+---
+name: vaner-predictive-debug
+description: Use when diagnosing failing tests.
+tags: [debug, tests]
+triggers:
+  - "tests/**"
+  - "pytest"
+vaner:
+  kind: debug
+  expand_depth: 2
+  feedback: auto
+---
+```
+
+## Distill from decisions
+
+```bash
+vaner distill-skill --path . --name "repo-debug-playbook"
+```
+
+Without an explicit id, the latest decision record is used.
+# Agent Skills Integration
+
+Vaner can read and produce `SKILL.md` files to create a closed feedback loop for predictive context.
+
+## How the loop works
+
+1. Skill files are discovered from configured roots (`intent.skill_roots`).
+2. Discovery emits `skill_loaded` signal events.
+3. Intent features and frontier seeding use those signals as a prior.
+4. Agents call `report_outcome` with optional `skill` attribution.
+5. Feedback updates future frontier multipliers.
+6. `vaner distill-skill` can generate reusable SKILL.md files from successful decisions.
+
+## Supported roots
+
+- `.cursor/skills/**/SKILL.md`
+- `.claude/skills/**/SKILL.md`
+- `skills/**/SKILL.md`
+
+By default, Vaner only scans roots inside the repository. Set `intent.include_global_skills = true` to include absolute/global roots.
+
+## Frontmatter schema
+
+```yaml
+---
+name: vaner-predictive-debug
+description: Use when diagnosing failing tests.
+tags: [debug, tests]
+triggers:
+  - "tests/**"
+  - "pytest"
+vaner:
+  kind: debug
+  expand_depth: 2
+  feedback: auto
+x-vaner-managed: true
+x-vaner-source-decision: d_abc123
+---
+```
+
+## CLI
+
+Generate a managed skill from a decision:
+
+```bash
+vaner distill-skill --path . --name "repo-debug-playbook"
+```
+
+If no decision id is provided, Vaner uses the latest decision record.
+
+## MCP outcome attribution
+
+When calling `report_outcome`, include `skill` to attribute outcomes:
+
+```json
+{
+  "id": "scn_123",
+  "result": "useful",
+  "skill": "vaner-feedback",
+  "note": "helped narrow failing module"
+}
+```

--- a/examples/skills-loop/README.md
+++ b/examples/skills-loop/README.md
@@ -1,0 +1,92 @@
+# Vaner Skills Loop Example
+
+This example shows the full closed loop between Agent Skills and Vaner MCP tools.
+
+## 1) Initialize Vaner and managed feedback skill
+
+```bash
+vaner init --path .
+```
+
+This writes MCP config and installs the managed `vaner-feedback` skill in compatible client skill folders.
+
+## 2) Discover scenarios in your agent
+
+Use MCP tools:
+
+- `list_scenarios`
+- `get_scenario`
+- `expand_scenario`
+
+Pass the active skill name through the optional `skill` argument where possible.
+
+## 3) Report outcome
+
+After task completion:
+
+```json
+{
+  "id": "scn_123",
+  "result": "useful",
+  "note": "included relevant tests",
+  "skill": "vaner-feedback"
+}
+```
+
+Submit through MCP `report_outcome`.
+
+## 4) Distill proven decisions into reusable skills
+
+```bash
+vaner why --list --path .
+vaner distill-skill <decision-id> --path .
+```
+
+The generated `SKILL.md` can be reused in future tasks.
+# Skills Loop Example
+
+1. Initialize Vaner and MCP configs:
+
+```bash
+vaner init --path .
+```
+
+2. Run an agent session using Vaner MCP tools.
+3. Review the decision:
+
+```bash
+vaner why --path .
+```
+
+4. Distill a reusable skill:
+
+```bash
+vaner distill-skill --path . --name "repo-playbook"
+```
+
+5. In later sessions, the distilled skill is discovered and used as a prediction prior.
+# Skills Loop Example
+
+This example shows Vaner's Agent Skills closed loop:
+
+1. Initialize the repo and MCP configs:
+
+```bash
+vaner init --path .
+```
+
+2. Run an agent session using Vaner MCP tools (`list_scenarios`, `get_scenario`, `report_outcome`).
+
+3. Inspect why Vaner chose a package:
+
+```bash
+vaner why --path .
+```
+
+4. Distill the latest decision into a reusable skill:
+
+```bash
+vaner distill-skill --path . --name "repo-playbook"
+```
+
+5. In future sessions, the distilled skill contributes signals and frontier seeds.

--- a/src/vaner/__init__.py
+++ b/src/vaner/__init__.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from importlib.metadata import PackageNotFoundError, version
+
 from vaner._version import VERSION
 from vaner.api import forget, inspect, inspect_last, precompute, predict, prepare, query
 from vaner.engine import VanerEngine
@@ -7,6 +9,7 @@ from vaner.intent.adapter import CodeRepoAdapter, CorpusAdapter
 
 __all__ = [
     "VERSION",
+    "__version__",
     "prepare",
     "query",
     "predict",
@@ -18,3 +21,8 @@ __all__ = [
     "CorpusAdapter",
     "CodeRepoAdapter",
 ]
+
+try:
+    __version__ = version("vaner")
+except PackageNotFoundError:  # pragma: no cover - editable installs fallback
+    __version__ = VERSION

--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -6,18 +6,29 @@ from __future__ import annotations
 import ipaddress
 import json
 import os
+import shutil
+import subprocess
+import sys
+import tomllib
 import traceback
 from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
+from typing import Any, get_origin
 
 import aiosqlite
 import httpx
 import typer
+from pydantic import TypeAdapter
+from pydantic_core import to_jsonable_python
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.table import Table
 
-from vaner import api
+from vaner import __version__, api
 from vaner.cli.commands.config import load_config, set_compute_value, set_config_value
 from vaner.cli.commands.daemon import daemon_status, run_daemon_forever, start_daemon, stop_daemon
+from vaner.cli.commands.distill import distill_skill_file
 from vaner.cli.commands.explain import render_human, render_json
 from vaner.cli.commands.init import (
     BACKEND_PRESETS,
@@ -36,21 +47,74 @@ from vaner.cli.commands.profile import export_pins, import_pins, pin_fact, profi
 from vaner.daemon.http import create_daemon_http_app
 from vaner.daemon.runner import VanerDaemon
 from vaner.eval import evaluate_repo, run_eval
+from vaner.models.config import VanerConfig
 from vaner.router.backends import forward_chat_completion_with_request
 from vaner.router.proxy import create_app
 from vaner.store.scenarios import ScenarioStore
 from vaner.telemetry.metrics import MetricsStore
 
-app = typer.Typer(help="Vaner CLI")
+app = typer.Typer(help="Vaner CLI", invoke_without_command=True)
 daemon_app = typer.Typer(help="Daemon controls")
 config_app = typer.Typer(help="Show config")
 profile_app = typer.Typer(help="Profile memory controls")
 scenarios_app = typer.Typer(help="Scenario cockpit commands")
 _VERBOSE = False
+_console = Console()
 
 
 def _repo_root(path: str | None) -> Path:
-    return Path(path).resolve() if path else Path.cwd()
+    if path:
+        return Path(path).resolve()
+    env_path = os.environ.get("VANER_PATH", "").strip()
+    return Path(env_path).resolve() if env_path else Path.cwd()
+
+
+def _fail(message: str, *, hint: str | None = None, code: int = 1) -> None:
+    typer.secho(message, fg=typer.colors.RED, err=True)
+    if hint:
+        typer.secho(f"hint: {hint}", fg=typer.colors.YELLOW, err=True)
+    raise typer.Exit(code=code)
+
+
+def _annotation_name(annotation: Any) -> str:
+    origin = get_origin(annotation)
+    if origin is None:
+        return getattr(annotation, "__name__", str(annotation))
+    if origin is list:
+        args = getattr(annotation, "__args__", ())
+        inner = _annotation_name(args[0]) if args else "Any"
+        return f"list[{inner}]"
+    if origin is dict:
+        args = getattr(annotation, "__args__", ())
+        if len(args) == 2:
+            return f"dict[{_annotation_name(args[0])}, {_annotation_name(args[1])}]"
+        return "dict[Any, Any]"
+    if origin is tuple:
+        args = getattr(annotation, "__args__", ())
+        return f"tuple[{', '.join(_annotation_name(arg) for arg in args)}]"
+    if origin is type(None):
+        return "None"
+    if str(origin).endswith("Literal"):
+        args = getattr(annotation, "__args__", ())
+        return f"Literal[{', '.join(repr(arg) for arg in args)}]"
+    return str(annotation).replace("typing.", "")
+
+
+def _display_value(value: Any) -> str:
+    jsonable = to_jsonable_python(value)
+    if isinstance(jsonable, bool):
+        return "true" if jsonable else "false"
+    if isinstance(jsonable, str):
+        return jsonable
+    return json.dumps(jsonable, ensure_ascii=True)
+
+
+def _format_fix_hint(fix: str) -> str:
+    if not _console.is_terminal:
+        return fix
+    if "mcp" in fix.lower():
+        return f"{fix} [link=https://docs.vaner.ai/mcp]docs.vaner.ai/mcp[/link]"
+    return fix
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -107,7 +171,16 @@ def _detect_hardware_profile() -> dict[str, object]:
         elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
             profile["device"] = "mps"
     except Exception:
-        pass
+        nvidia_smi = shutil.which("nvidia-smi")
+        if nvidia_smi:
+            try:
+                output = subprocess.check_output([nvidia_smi, "--list-gpus"], text=True, timeout=1.5)
+                lines = [line for line in output.splitlines() if line.strip()]
+                if lines:
+                    profile["device"] = "cuda"
+                    profile["gpu_count"] = len(lines)
+            except Exception:
+                pass
     return profile
 
 
@@ -117,15 +190,169 @@ async def _scenario_store(repo_root: Path) -> ScenarioStore:
     return store
 
 
+def _canon_key(key: str) -> str:
+    normalized = key.strip()
+    if normalized in {"max_age_seconds", "max_context_tokens"}:
+        return f"limits.{normalized}"
+    return normalized
+
+
+def _config_attr_path_for_key(key: str) -> str:
+    if key == "intent.skills_loop.enabled":
+        return "intent.skills_loop_enabled"
+    if key == "intent.skills_loop.max_feedback_events_per_cycle":
+        return "intent.max_feedback_events_per_cycle"
+    if key.startswith("limits."):
+        return key.removeprefix("limits.")
+    return key
+
+
+def _config_write_target_for_key(key: str) -> tuple[str, str]:
+    if key.startswith("limits."):
+        return "limits", key.removeprefix("limits.")
+    parts = key.split(".")
+    if len(parts) < 2:
+        raise ValueError("Key must include a section prefix.")
+    return ".".join(parts[:-1]), parts[-1]
+
+
+def _annotation_for_path(root_model: type[Any], parts: list[str]) -> tuple[Any, str]:
+    if parts and parts[0] == "limits":
+        if len(parts) != 2 or parts[1] not in {"max_age_seconds", "max_context_tokens"}:
+            raise ValueError(f"Unsupported setting: {'.'.join(parts)}")
+        field = VanerConfig.model_fields[parts[1]]
+        return field.annotation, field.description or ""
+    model = root_model
+    breadcrumb: list[str] = []
+    for idx, part in enumerate(parts):
+        fields = getattr(model, "model_fields", {})
+        field = fields.get(part)
+        breadcrumb.append(part)
+        if field is None:
+            if part == "skills_loop" and ".".join(breadcrumb[:-1]) == "intent":
+                continue
+            if len(breadcrumb) >= 3 and ".".join(breadcrumb[:2]) == "gateway.routes":
+                return str, "Dynamic gateway route target URL."
+            raise ValueError(f"Unsupported setting: {'.'.join(parts)}")
+        annotation = field.annotation
+        description = field.description or ""
+        origin = get_origin(annotation)
+        if idx == len(parts) - 1:
+            return annotation, description
+        if origin is dict and len(breadcrumb) >= 2 and ".".join(breadcrumb) == "gateway.routes":
+            return str, "Dynamic gateway route target URL."
+        if isinstance(annotation, type) and hasattr(annotation, "model_fields"):
+            model = annotation
+            continue
+        raise ValueError(f"Unsupported setting: {'.'.join(parts)}")
+    raise ValueError(f"Unsupported setting: {'.'.join(parts)}")
+
+
+def _coerce_value(raw: str, annotation: Any) -> Any:
+    candidate: Any = raw
+    if annotation is bool:
+        lowered = raw.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        raise ValueError(raw)
+    if get_origin(annotation) in {list, dict}:
+        try:
+            candidate = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(raw) from exc
+    adapter = TypeAdapter(annotation)
+    return adapter.validate_python(candidate)
+
+
+def _value_at_path(config: VanerConfig, dotted_path: str) -> Any:
+    current: Any = config
+    for part in dotted_path.split("."):
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            current = getattr(current, part)
+    return current
+
+
+def _iter_config_keys(config: VanerConfig) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for section in ("backend", "generation", "privacy", "proxy", "gateway", "mcp", "intent", "compute", "exploration"):
+        section_model = getattr(config, section)
+        section_fields = section_model.__class__.model_fields
+        for field_name, field in section_fields.items():
+            if section == "intent" and field_name in {"skills_loop_enabled", "max_feedback_events_per_cycle"}:
+                continue
+            key = f"{section}.{field_name}"
+            value = getattr(section_model, field_name)
+            rows.append({"key": key, "value": value, "annotation": field.annotation, "description": field.description or ""})
+            if section == "gateway" and field_name == "routes" and isinstance(value, dict):
+                for route_key, route_value in value.items():
+                    rows.append(
+                        {
+                            "key": f"gateway.routes.{route_key}",
+                            "value": route_value,
+                            "annotation": str,
+                            "description": "Dynamic gateway route target URL.",
+                        }
+                    )
+    rows.append(
+        {
+            "key": "intent.skills_loop.enabled",
+            "value": config.intent.skills_loop_enabled,
+            "annotation": bool,
+            "description": "Enable closed-loop skill attribution feedback.",
+        }
+    )
+    rows.append(
+        {
+            "key": "intent.skills_loop.max_feedback_events_per_cycle",
+            "value": config.intent.max_feedback_events_per_cycle,
+            "annotation": int,
+            "description": "Max feedback events consumed each cycle.",
+        }
+    )
+    rows.append(
+        {
+            "key": "limits.max_age_seconds",
+            "value": config.max_age_seconds,
+            "annotation": int,
+            "description": VanerConfig.model_fields["max_age_seconds"].description or "",
+        }
+    )
+    rows.append(
+        {
+            "key": "limits.max_context_tokens",
+            "value": config.max_context_tokens,
+            "annotation": int,
+            "description": VanerConfig.model_fields["max_context_tokens"].description or "",
+        }
+    )
+    rows.append(
+        {
+            "key": "gateway.routes.<prefix>",
+            "value": "<url>",
+            "annotation": str,
+            "description": "Set prefix route: vaner config set gateway.routes.gpt- https://api.openai.com/v1",
+        }
+    )
+    return sorted(rows, key=lambda row: row["key"])
+
+
 @app.callback()
 def app_callback(
     verbose: bool = typer.Option(False, "--verbose", help="Show full traceback on errors"),
+    version: bool = typer.Option(False, "--version", help="Show installed Vaner version and exit.", is_eager=True),
 ) -> None:
+    if version:
+        typer.echo(f"vaner {__version__}")
+        raise typer.Exit()
     global _VERBOSE
     _VERBOSE = verbose
 
 
-@app.command("init")
+@app.command("init", help="Initialize Vaner config and MCP client wiring.", rich_help_panel="Get started")
 def init(
     path: str | None = typer.Option(None, help="Repository root"),
     backend_preset: str | None = typer.Option(
@@ -164,15 +391,22 @@ def init(
     ``[backend]`` values are preserved unless ``--force`` is passed.
     """
     repo_root = _repo_root(path)
-    config_path = init_repo(repo_root)
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as progress:
+        task = progress.add_task("Initializing repository config...", total=None)
+        config_path = init_repo(repo_root)
+        progress.update(task, description="Initialization complete")
     typer.echo(f"Initialized Vaner at {config_path}")
 
     if not no_mcp:
         try:
-            written = write_mcp_configs(repo_root)
+            with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as progress:
+                task = progress.add_task("Writing MCP client configuration...", total=None)
+                written, launcher_command = write_mcp_configs(repo_root)
+                progress.update(task, description="MCP configuration written")
             typer.echo("Configured MCP clients:")
             for item in written:
                 typer.echo(f"  - {item}")
+            typer.echo(f"Scaffolded MCP client configs using `{launcher_command}`")
         except Exception as exc:
             typer.echo(f"Warning: could not write MCP client configs: {exc}")
 
@@ -210,8 +444,22 @@ def init(
                 + (f" (max_session_minutes={max_session_minutes})" if max_session_minutes else "")
             )
 
-    runtime = _detect_local_runtime()
-    hardware = _detect_hardware_profile()
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as progress:
+        task = progress.add_task("Running local runtime and hardware checks...", total=None)
+        runtime = _detect_local_runtime()
+        hardware = _detect_hardware_profile()
+        progress.update(task, description="Local checks complete")
+    detected_device = "cpu"
+    detected_embedding_device = "cpu"
+    if hardware.get("device") == "cuda":
+        detected_device = "cuda:0"
+        detected_embedding_device = "cuda"
+    elif hardware.get("device") == "mps":
+        detected_device = "mps"
+        detected_embedding_device = "mps"
+    set_compute_value(repo_root, "device", detected_device)
+    set_compute_value(repo_root, "embedding_device", detected_embedding_device)
+    typer.echo(f"Detected compute defaults: device={detected_device}, embedding_device={detected_embedding_device}")
     if runtime.get("detected"):
         typer.echo(f"Detected local runtime: {runtime['name']} ({runtime['url']})")
     else:
@@ -225,6 +473,19 @@ def init(
         typer.echo("Detected VS Code/Cursor environment.")
         typer.echo("Install extension: cd ide/vscode && npm install && npm run build")
         typer.echo("Then load the extension and run `Vaner: Open Cockpit`.")
+    if resolved_interactive and typer.confirm("Install shell completion for current shell?", default=True):
+        vaner_bin = shutil.which("vaner")
+        if vaner_bin:
+            completion_cmd = [vaner_bin, "--install-completion"]
+        else:
+            completion_cmd = [sys.executable, "-m", "vaner.cli.commands.app", "--install-completion"]
+        completed = subprocess.run(completion_cmd, check=False)
+        if completed.returncode == 0:
+            typer.echo("Shell completion installed.")
+        else:
+            typer.echo("Could not install completion automatically. Run `vaner --install-completion` manually.")
+    else:
+        typer.echo("Tip: enable command completion with `vaner --install-completion`.")
 
 
 @daemon_app.command("start")
@@ -270,7 +531,7 @@ def daemon_serve_http(
     uvicorn.run(app_instance, host=host, port=port)
 
 
-@app.command("inspect")
+@app.command("inspect", help="Inspect context decision records.", rich_help_panel="Inspect and debug")
 def inspect(
     path: str | None = typer.Option(None, help="Repository root"),
     last: bool = typer.Option(False, "--last", help="Show last context decision"),
@@ -283,7 +544,7 @@ def inspect(
     typer.echo(api.inspect(_repo_root(path)))
 
 
-@app.command("query")
+@app.command("query", help="Assemble and print context for a prompt.", rich_help_panel="Inspect and debug")
 def query(
     prompt: str,
     path: str | None = typer.Option(None, help="Repository root"),
@@ -303,7 +564,7 @@ def query(
     typer.echo(render_json(decision_record) if as_json else render_human(decision_record, verbose=verbose))
 
 
-@app.command("why")
+@app.command("why", help="Explain why a decision was selected.", rich_help_panel="Inspect and debug")
 def why(
     decision_id: str | None = typer.Argument(None, help="Decision id, defaults to latest"),
     path: str | None = typer.Option(None, help="Repository root"),
@@ -319,13 +580,35 @@ def why(
     typer.echo(inspect_decision_output(repo_root, decision_id, verbose=verbose, as_json=as_json))
 
 
-@app.command("prepare")
+@app.command("distill-skill", help="Convert a decision record into SKILL.md.", rich_help_panel="Use with an agent")
+def distill_skill(
+    decision_id: str = typer.Argument(..., help="Decision id to distill"),
+    name: str | None = typer.Option(None, "--name", help="Optional skill name override"),
+    out_dir: str | None = typer.Option(None, "--out-dir", help="Output directory"),
+    force: bool = typer.Option(False, "--force", help="Overwrite existing SKILL.md"),
+    path: str | None = typer.Option(None, help="Repository root"),
+) -> None:
+    repo_root = _repo_root(path)
+    destination = distill_skill_file(
+        repo_root,
+        decision_id,
+        out_dir=Path(out_dir).resolve() if out_dir else None,
+        skill_name=name,
+        force=force,
+    )
+    typer.echo(f"Wrote distilled skill: {destination}")
+
+
+@app.command("prepare", help="Prepare repository artefacts for retrieval.", rich_help_panel="Background and local")
 def prepare(path: str | None = typer.Option(None, help="Repository root")) -> None:
-    generated = api.prepare(_repo_root(path))
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as progress:
+        task = progress.add_task("Preparing artefacts...", total=None)
+        generated = api.prepare(_repo_root(path))
+        progress.update(task, description="Preparation complete")
     typer.echo(f"Prepared artefacts: {generated}")
 
 
-@app.command("predict")
+@app.command("predict", help="Show top predicted next intents.", rich_help_panel="Benchmark")
 def predict(
     path: str | None = typer.Option(None, help="Repository root"),
     top_k: int = typer.Option(5, "--top-k", help="Number of predictions to return"),
@@ -334,69 +617,119 @@ def predict(
     typer.echo(json.dumps(predictions, indent=2))
 
 
-@app.command("precompute")
+@app.command("precompute", help="Run one precompute cycle.", rich_help_panel="Background and local")
 def precompute(path: str | None = typer.Option(None, help="Repository root")) -> None:
-    produced = api.precompute(_repo_root(path))
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as progress:
+        task = progress.add_task("Running precompute cycle...", total=None)
+        produced = api.precompute(_repo_root(path))
+        progress.update(task, description="Precompute complete")
     typer.echo(f"Precompute cycle completed. Full packages cached: {produced}")
 
 
-@app.command("forget")
+@app.command("forget", help="Delete local Vaner state files.", rich_help_panel="Background and local")
 def forget(path: str | None = typer.Option(None, help="Repository root")) -> None:
     removed = api.forget(_repo_root(path))
     typer.echo(f"Removed {removed} local state files.")
 
 
 @config_app.command("show")
-def config_show(path: str | None = typer.Option(None, help="Repository root")) -> None:
+def config_show(
+    path: str | None = typer.Option(None, help="Repository root"),
+    as_json: bool = typer.Option(False, "--json", help="Print raw JSON payload."),
+) -> None:
     config = load_config(_repo_root(path))
-    typer.echo(config.model_dump_json(indent=2))
+    if as_json:
+        typer.echo(json.dumps(to_jsonable_python(config.model_dump(mode="python")), indent=2))
+        return
+    defaults = VanerConfig(
+        repo_root=config.repo_root,
+        store_path=config.store_path,
+        telemetry_path=config.telemetry_path,
+    )
+    table = Table(title="Vaner configuration", show_lines=False)
+    table.add_column("Key", style="cyan")
+    table.add_column("Value")
+    table.add_column("Status", style="magenta")
+    for row in _iter_config_keys(config):
+        if "<prefix>" in row["key"]:
+            status = "template"
+        else:
+            try:
+                default_value = _value_at_path(defaults, _config_attr_path_for_key(row["key"]))
+            except Exception:
+                default_value = None
+            status = "overridden" if row["value"] != default_value else "default"
+        table.add_row(row["key"], _display_value(row["value"]), status)
+    _console.print(table)
+
+
+@config_app.command("get")
+def config_get(
+    key: str = typer.Argument(..., help="Setting path (for example: backend.model)."),
+    path: str | None = typer.Option(None, help="Repository root"),
+) -> None:
+    canonical = _canon_key(key)
+    config = load_config(_repo_root(path))
+    try:
+        value = _value_at_path(config, _config_attr_path_for_key(canonical))
+    except Exception:
+        _fail(
+            f"Unsupported setting: {canonical}",
+            hint="Run `vaner config keys` to list valid keys.",
+        )
+    typer.echo(json.dumps(value) if not isinstance(value, str) else value)
+
+
+@config_app.command("keys")
+def config_keys(path: str | None = typer.Option(None, help="Repository root")) -> None:
+    rows = _iter_config_keys(load_config(_repo_root(path)))
+    table = Table(title="Settable configuration keys")
+    table.add_column("Key", style="cyan", no_wrap=True)
+    table.add_column("Type", style="green")
+    table.add_column("Current")
+    table.add_column("Description")
+    for row in rows:
+        annotation = row["annotation"]
+        annotation_name = _annotation_name(annotation)
+        current = _display_value(row["value"])
+        table.add_row(row["key"], annotation_name, str(current), row["description"])
+    _console.print(table)
+
+
+@config_app.command("edit")
+def config_edit(path: str | None = typer.Option(None, help="Repository root")) -> None:
+    repo_root = _repo_root(path)
+    config_path = repo_root / ".vaner" / "config.toml"
+    if not config_path.exists():
+        _fail(f"Config file not found: {config_path}", hint="Run `vaner init` first.")
+    editor = os.environ.get("EDITOR", "nano")
+    subprocess.run([editor, str(config_path)], check=False)
 
 
 @config_app.command("set")
 def config_set(
-    key: str = typer.Argument(..., help="Setting path, supports compute.* and exploration.*"),
+    key: str = typer.Argument(..., help="Setting path (for example: backend.model)."),
     value: str = typer.Argument(..., help="Setting value"),
     path: str | None = typer.Option(None, help="Repository root"),
 ) -> None:
-    if "." not in key:
-        typer.secho("Key must include section prefix, e.g. compute.cpu_fraction", fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-    section, field = key.split(".", 1)
-    converters_by_section = {
-        "compute": {
-            "device": str,
-            "embedding_device": str,
-            "cpu_fraction": float,
-            "gpu_memory_fraction": float,
-            "idle_only": lambda raw: str(raw).lower() in {"1", "true", "yes", "on"},
-            "idle_cpu_threshold": float,
-            "idle_gpu_threshold": float,
-            "exploration_concurrency": int,
-            "max_parallel_precompute": int,
-        },
-        "exploration": {
-            "endpoint": str,
-            "model": str,
-            "backend": str,
-            "enabled": lambda raw: str(raw).lower() in {"1", "true", "yes", "on"},
-        },
-    }
-    parser = converters_by_section.get(section, {}).get(field)
-    if parser is None:
-        typer.secho(f"Unsupported setting: {key}", fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-
+    canonical = _canon_key(key)
+    parts = canonical.split(".")
+    if len(parts) < 2:
+        _fail("Key must include section prefix, e.g. compute.cpu_fraction")
     try:
-        parsed_value = parser(value)
-    except ValueError as exc:
-        typer.secho(f"Invalid value for {key}: {value}", fg=typer.colors.RED)
-        raise typer.Exit(code=1) from exc
-
-    if section == "compute":
-        config_path = set_compute_value(_repo_root(path), field, parsed_value)
-    else:
-        config_path = set_config_value(_repo_root(path), section, field, parsed_value)
-    typer.echo(f"Updated {key} in {config_path}")
+        annotation, _ = _annotation_for_path(VanerConfig, parts)
+    except ValueError:
+        _fail(f"Unsupported setting: {canonical}", hint="Run `vaner config keys` to list valid keys.")
+    try:
+        parsed_value = _coerce_value(value, annotation)
+    except Exception:
+        hint = f"Expected type: {_annotation_name(annotation)}"
+        if get_origin(annotation) in {list, dict}:
+            hint = f'{hint}; for list/dict values pass JSON, e.g. \'["a","b"]\''
+        _fail(f"Invalid value for {canonical}: {value}", hint=hint, code=1)
+    section, field = _config_write_target_for_key(canonical)
+    config_path = set_config_value(_repo_root(path), section, field, parsed_value)
+    typer.echo(f"Updated {canonical} in {config_path}")
 
 
 @profile_app.command("show")
@@ -442,13 +775,13 @@ def profile_import_command(
     typer.echo(f"Imported {imported} pins.")
 
 
-@app.command("eval")
+@app.command("eval", help="Evaluate Vaner quality in current repository.", rich_help_panel="Benchmark")
 def eval_repo(path: str | None = typer.Option(None, help="Repository root")) -> None:
     result = evaluate_repo(_repo_root(path))
     typer.echo(result.model_dump_json(indent=2))
 
 
-@app.command("run-eval")
+@app.command("run-eval", help="Run eval suite from custom case file.", rich_help_panel="Benchmark")
 def run_eval_command(
     path: str | None = typer.Option(None, help="Repository root"),
     cases_file: str | None = typer.Option(None, "--cases-file", help="Path to eval cases JSON"),
@@ -463,7 +796,7 @@ def run_eval_command(
     typer.echo(result.model_dump_json(indent=2))
 
 
-@app.command("mcp")
+@app.command("mcp", help="Start Vaner MCP server for IDE clients.", rich_help_panel="Use with an agent")
 def mcp_server(
     path: str | None = typer.Option(None, help="Repository root"),
     transport: str = typer.Option("stdio", "--transport", "-t", help="Transport: stdio | sse"),
@@ -490,8 +823,7 @@ def mcp_server(
     try:
         from vaner.mcp.server import run_sse, run_stdio
     except ImportError as exc:  # pragma: no cover
-        typer.secho(f"MCP not available: {exc}. Install: pip install 'mcp[cli]>=1.0'", fg=typer.colors.RED, err=True)
-        raise typer.Exit(code=1) from exc
+        _fail(f"MCP not available: {exc}", hint="Install optional extras: pip install 'vaner[mcp]'.")
 
     repo_root = _repo_root(path)
 
@@ -502,7 +834,7 @@ def mcp_server(
         _asyncio.run(run_stdio(repo_root))
 
 
-@app.command("proxy")
+@app.command("proxy", help="Start optional OpenAI-compatible proxy gateway.", rich_help_panel="Configure")
 def proxy(
     path: str | None = typer.Option(None, help="Repository root"),
     host: str = "127.0.0.1",
@@ -524,7 +856,7 @@ def proxy(
     )
 
 
-@app.command("metrics")
+@app.command("metrics", rich_help_panel="Inspect and debug")
 def metrics_cmd(
     path: str | None = typer.Option(None, help="Repository root"),
     last: int = typer.Option(100, "--last", "-n", help="Number of recent requests to include"),
@@ -605,7 +937,7 @@ def metrics_cmd(
     typer.echo("")
 
 
-@app.command("impact")
+@app.command("impact", rich_help_panel="Inspect and debug")
 def impact(
     path: str | None = typer.Option(None, help="Repository root"),
     last: int = typer.Option(500, "--last", "-n", help="Number of shadow pairs to aggregate"),
@@ -653,7 +985,7 @@ def impact(
     typer.echo(f"idle seconds used:{summary['idle_seconds_used']:.2f}")
 
 
-@app.command("compare")
+@app.command("compare", rich_help_panel="Inspect and debug")
 def compare(
     prompt: str = typer.Argument(..., help="Prompt to compare with and without Vaner context"),
     path: str | None = typer.Option(None, help="Repository root"),
@@ -746,6 +1078,16 @@ def scenarios_list(
     typer.echo("=" * 40)
     for row in rows:
         typer.echo(f"{row['id']} [{row['kind']}] score={row['score']:.3f} freshness={row['freshness']} entities={len(row['entities'])}")
+
+
+@app.command("ls", help="Alias for `vaner scenarios list`.", rich_help_panel="Use with an agent")
+def ls_alias(
+    path: str | None = typer.Option(None, help="Repository root"),
+    kind: str | None = typer.Option(None, "--kind", help="Filter by kind"),
+    limit: int = typer.Option(10, "--limit", min=1, max=100, help="Maximum scenarios"),
+    as_json: bool = typer.Option(False, "--json", help="Emit JSON"),
+) -> None:
+    scenarios_list(path=path, kind=kind, limit=limit, as_json=as_json)
 
 
 @scenarios_app.command("show")
@@ -842,6 +1184,7 @@ def scenarios_outcome(
     scenario_id: str,
     result: str = typer.Option(..., "--result", help="useful|irrelevant|partial"),
     note: str = typer.Option("", "--note", help="Optional note"),
+    skill: str = typer.Option("", "--skill", help="Optional skill attribution"),
     path: str | None = typer.Option(None, help="Repository root"),
 ) -> None:
     import asyncio
@@ -854,16 +1197,17 @@ def scenarios_outcome(
 
     async def _run() -> None:
         store = await _scenario_store(repo_root)
-        await store.record_outcome(scenario_id, result)
+        skill_name = skill.strip() or None
+        await store.record_outcome(scenario_id, result, skill=skill_name, source="skill" if skill_name else None)
         metrics = MetricsStore(repo_root / ".vaner" / "metrics.db")
         await metrics.initialize()
-        await metrics.record_scenario_outcome(scenario_id=scenario_id, result=result, note=note)
+        await metrics.record_scenario_outcome(scenario_id=scenario_id, result=result, note=note, skill=skill_name)
 
     asyncio.run(_run())
     typer.echo(f"Recorded outcome for {scenario_id}: {result}")
 
 
-@app.command("watch")
+@app.command("watch", rich_help_panel="Use with an agent")
 def watch(
     cockpit_url: str = typer.Option("http://127.0.0.1:8473", "--cockpit-url", help="Vaner cockpit URL"),
     as_json: bool = typer.Option(False, "--json", help="Emit raw decision events as JSON"),
@@ -897,7 +1241,7 @@ def watch(
                     return
 
 
-@app.command("show")
+@app.command("show", rich_help_panel="Use with an agent")
 def show(
     cockpit_url: str = typer.Option("http://127.0.0.1:8473", "--cockpit-url", help="Vaner cockpit URL"),
 ) -> None:
@@ -912,7 +1256,26 @@ def show(
         typer.echo(f"Open this URL manually: {target_url}")
 
 
-@app.command("status")
+@app.command("logs", help="Alias for `vaner watch`.", rich_help_panel="Use with an agent")
+def logs_alias(
+    cockpit_url: str = typer.Option("http://127.0.0.1:8473", "--cockpit-url", help="Vaner cockpit URL"),
+    as_json: bool = typer.Option(False, "--json", help="Emit raw decision events as JSON"),
+    contains: str | None = typer.Option(None, "--filter", help="Substring filter against serialized decision payload"),
+    limit: int | None = typer.Option(None, "--limit", min=1, help="Stop after N matching events"),
+) -> None:
+    watch(cockpit_url=cockpit_url, as_json=as_json, contains=contains, limit=limit)
+
+
+@app.command("ps", help="Alias for `vaner status`.", rich_help_panel="Get started")
+def ps_alias(
+    path: str | None = typer.Option(None, help="Repository root"),
+    cockpit_url: str = typer.Option("http://127.0.0.1:8473", "--cockpit-url", help="Vaner cockpit URL"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    status(path=path, cockpit_url=cockpit_url, as_json=as_json)
+
+
+@app.command("status", rich_help_panel="Get started")
 def status(
     path: str | None = typer.Option(None, help="Repository root"),
     cockpit_url: str = typer.Option("http://127.0.0.1:8473", "--cockpit-url", help="Vaner cockpit URL"),
@@ -984,7 +1347,7 @@ def status(
     typer.echo(f"freshness: fresh={scenario_counts['fresh']} recent={scenario_counts['recent']} stale={scenario_counts['stale']}")
 
 
-@app.command("doctor")
+@app.command("doctor", rich_help_panel="Get started")
 def doctor(
     path: str | None = typer.Option(None, help="Repository root"),
     cockpit_url: str = typer.Option("http://127.0.0.1:8473", "--cockpit-url", help="Vaner cockpit URL"),
@@ -1081,6 +1444,106 @@ def doctor(
             "fix": "Run `vaner init` to scaffold MCP client configuration files.",
         }
     )
+    mcp_commands: list[str] = []
+    for path_candidate in (cursor_mcp_path, claude_mcp_path):
+        if not path_candidate.exists():
+            continue
+        try:
+            payload = json.loads(path_candidate.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        servers = payload.get("mcpServers", {})
+        if isinstance(servers, dict):
+            for server_payload in servers.values():
+                if isinstance(server_payload, dict):
+                    command = str(server_payload.get("command", "")).strip()
+                    if command:
+                        mcp_commands.append(command)
+    all_commands_exist = bool(mcp_commands) and all(shutil.which(command) for command in mcp_commands)
+    checks.append(
+        {
+            "name": "mcp_command_exists",
+            "ok": all_commands_exist,
+            "detail": ", ".join(mcp_commands) if mcp_commands else "No MCP commands found in client config",
+            "fix": "Use `vaner init` to rewrite MCP configs with a valid command path.",
+        }
+    )
+    if config is not None:
+        config_text = config_path.read_text(encoding="utf-8")
+        stale_keys = [key for key in ("exploration_model", "exploration_endpoint", "exploration_backend") if key in config_text]
+        try:
+            parsed = tomllib.loads(config_text)
+            exploration_section = parsed.get("exploration", {})
+            if isinstance(exploration_section, dict) and "embedding_device" in exploration_section:
+                stale_keys.append("exploration.embedding_device")
+        except Exception:
+            pass
+        checks.append(
+            {
+                "name": "config_drift",
+                "ok": not stale_keys,
+                "detail": "none" if not stale_keys else f"legacy keys present: {', '.join(stale_keys)}",
+                "fix": "Update .vaner/config.toml to use exploration.model/endpoint/backend and compute.embedding_device.",
+            }
+        )
+        if os.environ.get("VANER_SKIP_MCP_BOOT_PROBE", "").strip() == "1":
+            checks.append(
+                {
+                    "name": "mcp_server_boots",
+                    "ok": True,
+                    "detail": "skipped (VANER_SKIP_MCP_BOOT_PROBE=1)",
+                    "fix": "",
+                }
+            )
+        else:
+            try:
+                boot_cmd = [shutil.which("vaner") or "vaner", "mcp", "--path", str(repo_root)]
+                proc = subprocess.Popen(boot_cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                try:
+                    proc.wait(timeout=1.5)
+                    boot_ok = proc.returncode == 0
+                except subprocess.TimeoutExpired:
+                    boot_ok = True
+                    proc.terminate()
+                    proc.wait(timeout=1.0)
+                checks.append(
+                    {
+                        "name": "mcp_server_boots",
+                        "ok": boot_ok,
+                        "detail": "startup probe completed",
+                        "fix": "Run `vaner mcp --path .` manually to inspect startup errors.",
+                    }
+                )
+            except Exception as exc:
+                checks.append(
+                    {
+                        "name": "mcp_server_boots",
+                        "ok": False,
+                        "detail": str(exc),
+                        "fix": "Run `vaner mcp --path .` manually to inspect startup errors.",
+                    }
+                )
+    if os.environ.get("VANER_DOCTOR_CHECK_UPDATES", "").strip() == "1":
+        try:
+            response = httpx.get("https://pypi.org/pypi/vaner/json", timeout=1.5)
+            latest = str(response.json().get("info", {}).get("version", "")).strip()
+            checks.append(
+                {
+                    "name": "vaner_release_probe",
+                    "ok": (not latest) or latest == __version__,
+                    "detail": f"installed={__version__} latest={latest or 'unknown'}",
+                    "fix": "Run `vaner upgrade` to install the latest release.",
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {
+                    "name": "vaner_release_probe",
+                    "ok": False,
+                    "detail": str(exc),
+                    "fix": "Run `vaner upgrade` to install the latest release.",
+                }
+            )
     try:
         import asyncio
 
@@ -1115,20 +1578,35 @@ def doctor(
         typer.echo(json.dumps(payload, indent=2))
         raise typer.Exit(code=0 if overall_ok else 1)
 
-    typer.echo("Vaner doctor")
-    typer.echo("=" * 40)
+    _console.print("[bold]Vaner doctor[/bold]")
+    _console.print("=" * 40)
     for check in checks:
-        mark = "PASS" if check["ok"] else "FAIL"
-        typer.echo(f"[{mark}] {check['name']}: {check['detail']}")
+        mark = "[green]PASS[/green]" if check["ok"] else "[red]FAIL[/red]"
+        _console.print(f"{mark} {check['name']}: {check['detail']}")
         if not check["ok"] and check["fix"]:
-            typer.echo(f"       fix: {check['fix']}")
+            _console.print(f"       fix: {_format_fix_hint(str(check['fix']))}")
     raise typer.Exit(code=0 if overall_ok else 1)
 
 
-app.add_typer(daemon_app, name="daemon")
-app.add_typer(config_app, name="config")
-app.add_typer(profile_app, name="profile")
-app.add_typer(scenarios_app, name="scenarios")
+@app.command("upgrade", help="Upgrade Vaner using pipx or pip.", rich_help_panel="Configure")
+def upgrade() -> None:
+    pipx_bin = shutil.which("pipx")
+    if pipx_bin:
+        cmd = [pipx_bin, "upgrade", "vaner"]
+        typer.echo("Upgrading via pipx...")
+    else:
+        cmd = [sys.executable, "-m", "pip", "install", "-U", "vaner"]
+        typer.echo("Upgrading via pip...")
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        _fail("Upgrade failed.", hint="Run with --verbose and inspect command output.")
+    typer.echo("Upgrade complete.")
+
+
+app.add_typer(daemon_app, name="daemon", rich_help_panel="Background and local")
+app.add_typer(config_app, name="config", rich_help_panel="Configure")
+app.add_typer(profile_app, name="profile", rich_help_panel="Background and local")
+app.add_typer(scenarios_app, name="scenarios", rich_help_panel="Use with an agent")
 
 
 def run() -> None:

--- a/src/vaner/cli/commands/config.py
+++ b/src/vaner/cli/commands/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -12,11 +13,14 @@ from vaner.models.config import (
     ExplorationConfig,
     GatewayConfig,
     GenerationConfig,
+    IntentConfig,
     MCPConfig,
     PrivacyConfig,
     ProxyConfig,
     VanerConfig,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def load_config(repo_root: Path) -> VanerConfig:
@@ -31,6 +35,7 @@ def load_config(repo_root: Path) -> VanerConfig:
     proxy_section = parsed.get("proxy", {})
     gateway_section = parsed.get("gateway", {})
     mcp_section = parsed.get("mcp", {})
+    intent_section = parsed.get("intent", {})
     compute_section = parsed.get("compute", {})
     exploration_section = parsed.get("exploration", {})
     limits_section = parsed.get("limits", {})
@@ -59,14 +64,34 @@ def load_config(repo_root: Path) -> VanerConfig:
     else:
         gateway = GatewayConfig()
     mcp = MCPConfig(**mcp_section) if isinstance(mcp_section, dict) else MCPConfig()
+    if isinstance(intent_section, dict):
+        skills_loop = intent_section.get("skills_loop", {})
+        mapped_intent = dict(intent_section)
+        if isinstance(skills_loop, dict):
+            if "enabled" in skills_loop:
+                mapped_intent["skills_loop_enabled"] = bool(skills_loop["enabled"])
+            if "max_feedback_events_per_cycle" in skills_loop:
+                mapped_intent["max_feedback_events_per_cycle"] = int(skills_loop["max_feedback_events_per_cycle"])
+        mapped_intent.pop("skills_loop", None)
+        intent = IntentConfig(**mapped_intent)
+    else:
+        intent = IntentConfig()
     compute = ComputeConfig(**compute_section) if isinstance(compute_section, dict) else ComputeConfig()
     if isinstance(exploration_section, dict):
+        legacy_keys = sorted(
+            {str(key) for key in exploration_section.keys() if str(key) == "embedding_device" or str(key).startswith("exploration_")}
+        )
+        if legacy_keys:
+            logger.warning(
+                "Legacy exploration config keys detected and ignored: %s",
+                ", ".join(legacy_keys),
+            )
         mapped_exploration = {
-            "exploration_endpoint": exploration_section.get("endpoint", ""),
-            "exploration_model": exploration_section.get("model", ""),
-            "exploration_backend": exploration_section.get("backend", "auto"),
+            "endpoint": exploration_section.get("endpoint", ""),
+            "model": exploration_section.get("model", ""),
+            "backend": exploration_section.get("backend", "auto"),
+            "api_key": exploration_section.get("api_key", ""),
             "embedding_model": exploration_section.get("embedding_model", "all-MiniLM-L6-v2"),
-            "embedding_device": exploration_section.get("embedding_device", "cpu"),
         }
         exploration = ExplorationConfig(**mapped_exploration)
     else:
@@ -89,6 +114,7 @@ def load_config(repo_root: Path) -> VanerConfig:
         proxy=proxy,
         gateway=gateway,
         mcp=mcp,
+        intent=intent,
         compute=compute,
         exploration=exploration,
     )
@@ -99,6 +125,14 @@ def _toml_literal(value: Any) -> str:
         return "true" if value else "false"
     if isinstance(value, (int, float)):
         return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_literal(item) for item in value) + "]"
+    if isinstance(value, dict):
+        chunks: list[str] = []
+        for key, item in value.items():
+            escaped_key = str(key).replace('"', '\\"')
+            chunks.append(f'"{escaped_key}" = {_toml_literal(item)}')
+        return "{ " + ", ".join(chunks) + " }"
     escaped = str(value).replace('"', '\\"')
     return f'"{escaped}"'
 

--- a/src/vaner/cli/commands/distill.py
+++ b/src/vaner/cli/commands/distill.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from vaner.models.decision import DecisionRecord, SelectionDecision
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "skill"
+
+
+def _kept(selections: list[SelectionDecision]) -> list[SelectionDecision]:
+    return [selection for selection in selections if selection.kept]
+
+
+def render_skill_markdown(decision: DecisionRecord, *, name: str) -> str:
+    kept = _kept(decision.selections)
+    tags = sorted({"vaner", "distilled", decision.cache_tier or "miss"})
+    triggers = [entry.source_path for entry in kept[:8] if entry.source_path]
+    lines = [
+        "---",
+        f"name: {name}",
+        f"description: Distilled from Vaner decision {decision.id}.",
+        f"tags: [{', '.join(tags)}]",
+        "vaner:",
+        "  kind: change",
+        "x-vaner-managed: true",
+    ]
+    if triggers:
+        lines.append(f"triggers: [{', '.join(triggers)}]")
+    lines.extend(
+        [
+            "---",
+            "",
+            "Use this skill when a task resembles the original successful Vaner decision.",
+            "",
+            "Procedure:",
+            f"1. Start from the same intent shape as: `{decision.prompt.strip()}`.",
+            "2. Prioritize these artefacts first:",
+        ]
+    )
+    if kept:
+        for selection in kept[:8]:
+            lines.append(f"   - `{selection.source_path or selection.artefact_key}` ({selection.rationale or 'relevant context'})")
+    else:
+        lines.append("   - No explicit artefacts were retained in the decision.")
+    lines.extend(
+        [
+            "3. Query Vaner MCP tools (`list_scenarios` then `get_scenario`) before coding.",
+            "4. Call `report_outcome` after finishing so Vaner can learn from the run.",
+            "",
+            f"Source decision id: `{decision.id}`",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def distill_skill_file(
+    repo_root: Path,
+    decision_id: str,
+    *,
+    out_dir: Path | None = None,
+    skill_name: str | None = None,
+    force: bool = False,
+) -> Path:
+    decision = DecisionRecord.read_by_id(repo_root, decision_id)
+    if decision is None:
+        raise FileNotFoundError(f"Decision not found: {decision_id}")
+    name = skill_name or _slugify(decision.prompt[:80])
+    target_dir = out_dir or (repo_root / ".cursor" / "skills" / "vaner-distilled" / name)
+    target_path = target_dir / "SKILL.md"
+    if target_path.exists() and not force:
+        raise FileExistsError(f"{target_path} already exists; pass --force to overwrite")
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(render_skill_markdown(decision, name=name), encoding="utf-8")
+    return target_path

--- a/src/vaner/cli/commands/init.py
+++ b/src/vaner/cli/commands/init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 import time
 from dataclasses import dataclass
@@ -46,10 +47,10 @@ max_generations_per_cycle = 200
 [exploration]
 # Optional: separate LLM Vaner uses internally for background exploration.
 # Leave endpoint empty to auto-detect a local Ollama or vLLM instance.
-enabled = true
 endpoint = ""      # e.g. "http://127.0.0.1:11434" or "http://127.0.0.1:8000/v1"
 model = ""         # e.g. "qwen2.5-coder:32b" -- leave empty to auto-select
 backend = "auto"   # "auto" | "ollama" | "openai"
+api_key = ""       # optional API key env passthrough for remote exploration endpoints
 
 [proxy]
 proxy_token = ""
@@ -77,6 +78,15 @@ rate = 0.0
 transport = "stdio"
 http_host = "127.0.0.1"
 http_port = 8472
+
+[intent]
+enabled = true
+include_global_skills = false
+skill_roots = [".cursor/skills", ".claude/skills", "skills"]
+
+[intent.skills_loop]
+enabled = true
+max_feedback_events_per_cycle = 200
 
 [compute]
 device = "auto"
@@ -367,8 +377,50 @@ def interactive_compute_choice() -> str | None:
     return {"1": "background", "2": "balanced", "3": "dedicated"}.get(choice, choice if choice in COMPUTE_PRESETS else "background")
 
 
-def write_mcp_configs(repo_root: Path) -> list[Path]:
+def _default_vaner_feedback_skill() -> str:
+    default_path = Path(__file__).resolve().parents[4] / "src" / "vaner" / "defaults" / "skills" / "vaner-feedback" / "SKILL.md"
+    if default_path.exists():
+        return default_path.read_text(encoding="utf-8")
+    return (
+        "---\n"
+        "name: vaner-feedback\n"
+        "description: Report scenario outcomes back to Vaner after completing a task.\n"
+        "tags: [vaner, feedback]\n"
+        "vaner:\n"
+        "  kind: research\n"
+        "  feedback: auto\n"
+        "x-vaner-managed: true\n"
+        "---\n\n"
+        "Use this skill when finishing a task that used Vaner MCP scenarios.\n\n"
+        "1. Keep scenario ids returned by list/get/expand calls.\n"
+        "2. Call report_outcome with id, result (useful|partial|irrelevant), optional note.\n"
+        "3. Set skill to vaner-feedback for attribution.\n"
+    )
+
+
+def _write_managed_skill(path: Path, content: str) -> bool:
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        if "x-vaner-managed: true" not in existing:
+            return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def write_mcp_configs(repo_root: Path) -> tuple[list[Path], str]:
     written: list[Path] = []
+    vaner_command = shutil.which("vaner")
+    uvx_command = shutil.which("uvx")
+    if vaner_command:
+        command = vaner_command
+        args = ["mcp", "--path", "."]
+    elif uvx_command:
+        command = uvx_command
+        args = ["--from", "vaner[mcp]", "vaner", "mcp", "--path", "."]
+    else:
+        command = "vaner"
+        args = ["mcp", "--path", "."]
     cursor_dir = repo_root / ".cursor"
     cursor_dir.mkdir(parents=True, exist_ok=True)
     cursor_path = cursor_dir / "mcp.json"
@@ -380,7 +432,7 @@ def write_mcp_configs(repo_root: Path) -> list[Path]:
             cursor_payload = {"mcpServers": {}}
     servers = cursor_payload.setdefault("mcpServers", {})
     if isinstance(servers, dict):
-        servers["vaner"] = {"command": "vaner", "args": ["mcp", "--path", "."]}
+        servers["vaner"] = {"command": command, "args": args}
     cursor_path.write_text(json.dumps(cursor_payload, indent=2) + "\n", encoding="utf-8")
     written.append(cursor_path)
 
@@ -396,7 +448,19 @@ def write_mcp_configs(repo_root: Path) -> list[Path]:
         backup_path.write_text(json.dumps(claude_payload, indent=2) + "\n", encoding="utf-8")
     claude_servers = claude_payload.setdefault("mcpServers", {})
     if isinstance(claude_servers, dict):
-        claude_servers["vaner"] = {"command": "vaner", "args": ["mcp", "--path", str(repo_root)]}
+        claude_args = list(args)
+        if "--path" in claude_args:
+            idx = claude_args.index("--path")
+            claude_args[idx + 1] = str(repo_root)
+        claude_servers["vaner"] = {"command": command, "args": claude_args}
     claude_path.write_text(json.dumps(claude_payload, indent=2) + "\n", encoding="utf-8")
     written.append(claude_path)
-    return written
+    skill_content = _default_vaner_feedback_skill()
+    managed_targets = [
+        repo_root / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md",
+        Path.home() / ".claude" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md",
+    ]
+    for target in managed_targets:
+        if _write_managed_skill(target, skill_content):
+            written.append(target)
+    return written, command

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -129,10 +129,11 @@ def create_daemon_http_app(config: VanerConfig) -> FastAPI:
             raise HTTPException(status_code=404, detail="Scenario not found")
         result = str(payload.get("result", "")).strip()
         note = str(payload.get("note", "")).strip()
+        skill = str(payload.get("skill", "")).strip() or None
         if result not in {"useful", "partial", "irrelevant"}:
             raise HTTPException(status_code=400, detail="result must be one of useful|partial|irrelevant")
-        await scenario_store.record_outcome(scenario_id, result)
-        await metrics_store.record_scenario_outcome(scenario_id=scenario_id, result=result, note=note)
+        await scenario_store.record_outcome(scenario_id, result, skill=skill, source="skill" if skill else None)
+        await metrics_store.record_scenario_outcome(scenario_id=scenario_id, result=result, note=note, skill=skill)
         refreshed = await scenario_store.get(scenario_id)
         return JSONResponse({"ok": True, "scenario": refreshed.model_dump(mode="json") if refreshed else None})
 

--- a/src/vaner/daemon/runner.py
+++ b/src/vaner/daemon/runner.py
@@ -17,6 +17,7 @@ from vaner.daemon.engine.scenario_builder import build_scenarios
 from vaner.daemon.engine.scorer import score_paths
 from vaner.daemon.signals.fs_watcher import RepoChangeWatcher, scan_repo_files
 from vaner.daemon.signals.git_reader import read_git_diff, read_git_state
+from vaner.intent.skills_discovery import discover_skills
 from vaner.models.artefact import Artefact
 from vaner.models.config import VanerConfig
 from vaner.models.session import WorkingSet
@@ -78,6 +79,22 @@ class VanerDaemon:
             )
             for rel_path in git_paths
         )
+        if self.config.intent.enabled:
+            skills = discover_skills(
+                repo_root,
+                include_global=self.config.intent.include_global_skills,
+                skill_roots=self.config.intent.skill_roots,
+            )
+            signals.extend(
+                SignalEvent(
+                    id=str(uuid.uuid4()),
+                    source="skill_scan",
+                    kind="skill_loaded",
+                    timestamp=time.time(),
+                    payload=skill.as_signal_payload(repo_root),
+                )
+                for skill in skills
+            )
         for signal in signals:
             await self.store.insert_signal_event(signal)
         targets = plan_targets(

--- a/src/vaner/defaults/skills/vaner-feedback/SKILL.md
+++ b/src/vaner/defaults/skills/vaner-feedback/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: vaner-feedback
+description: Report scenario outcomes back to Vaner after completing a task.
+tags: [vaner, feedback]
+vaner:
+  kind: research
+  feedback: auto
+x-vaner-managed: true
+---
+
+Use this skill when finishing a task that used Vaner MCP scenarios.
+
+1. Keep scenario ids returned by `list_scenarios`, `get_scenario`, or `expand_scenario`.
+2. Call `report_outcome` with `id`, `result` (`useful` | `partial` | `irrelevant`), and optional `note`.
+3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and adjust future frontier weights.
+---
+name: vaner-feedback
+description: Report scenario outcomes back to Vaner after completing a task.
+tags: [vaner, feedback]
+vaner:
+  kind: research
+  feedback: auto
+x-vaner-managed: true
+---
+
+Use this skill when finishing a task that used Vaner MCP scenarios.
+
+1. Keep scenario ids returned by `list_scenarios`, `get_scenario`, or `expand_scenario`.
+2. Call `report_outcome` with `id`, `result` (`useful` | `partial` | `irrelevant`), and optional `note`.
+3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and adjust future frontier weights.
+---
+name: vaner-feedback
+description: Report scenario outcomes back to Vaner after completing a task.
+tags: [vaner, feedback]
+vaner:
+  kind: research
+  feedback: auto
+x-vaner-managed: true
+---
+
+Use this skill when finishing a task that used Vaner MCP scenarios.
+
+1. Keep scenario ids returned by `list_scenarios`, `get_scenario`, or `expand_scenario`.
+2. Call `report_outcome` with `id`, `result` (`useful` | `partial` | `irrelevant`), and optional `note`.
+3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and adjust future frontier weights.

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -31,6 +31,7 @@ from vaner.intent.maturity import MaturityTracker
 from vaner.intent.reasoner import CorpusReasoner, PredictionScenario
 from vaner.intent.scorer import IntentScorer
 from vaner.intent.scoring_policy import ScoringPolicy
+from vaner.intent.skills_discovery import discover_skills
 from vaner.intent.trainer import IntentTrainer
 from vaner.intent.transfer import bootstrap_transfer_priors
 from vaner.learning.reward import RewardInput, compute_reward
@@ -40,6 +41,7 @@ from vaner.models.context import ContextPackage
 from vaner.models.decision import DecisionRecord, PredictionLink, ScoreFactor
 from vaner.models.signal import SignalEvent
 from vaner.store.artefacts import ArtefactStore
+from vaner.store.scenarios import ScenarioStore
 
 LLMCallable = Callable[[str], Awaitable[str]]
 EmbedCallable = Callable[[list[str]], Awaitable[list[list[float]]]]
@@ -96,6 +98,7 @@ class VanerEngine:
         repo_root = getattr(adapter, "repo_root", Path.cwd())
         self.config = config if config is not None else load_config(Path(repo_root))
         self.store = ArtefactStore(self.config.store_path)
+        self._scenario_store = ScenarioStore(self.config.repo_root / ".vaner" / "scenarios.db")
         self.llm = self._resolve_llm(llm)
         self.embed = embed
         self._background_task: asyncio.Task[None] | None = None
@@ -140,6 +143,7 @@ class VanerEngine:
 
     async def initialize(self) -> None:
         await self.store.initialize()
+        await self._scenario_store.initialize()
         await self._load_learning_state()
         self._try_load_trained_scorer()
         if not self._arc_loaded:
@@ -689,6 +693,9 @@ class VanerEngine:
             saturation_coverage=ecfg.saturation_coverage,
             scoring_policy=self._scoring_policy,
         )
+        if self.config.intent.skills_loop_enabled:
+            for source, hit in await self._scenario_store.consume_feedback(limit=max(1, self.config.intent.max_feedback_events_per_cycle)):
+                frontier.record_feedback(source, hit=hit)
 
         # Seed the frontier from all sources
         graph = await self._load_graph()
@@ -720,6 +727,13 @@ class VanerEngine:
 
         patterns = await self.store.list_validated_patterns(limit=50)
         frontier.seed_from_patterns(patterns)
+        if self.config.intent.enabled:
+            skills = discover_skills(
+                self.config.repo_root,
+                include_global=self.config.intent.include_global_skills,
+                skill_roots=self.config.intent.skill_roots,
+            )
+            frontier.seed_from_skills(skills, available_paths)
 
         # Seed recovery scenarios for recent cold-miss queries.  These paths
         # clearly weren't precomputed and should be prioritized in this cycle.
@@ -2201,10 +2215,10 @@ def _build_exploration_llm(ecfg: ExplorationConfig) -> LLMCallable | None:
 
     _log = _logging.getLogger(__name__)
 
-    backend = ecfg.exploration_backend  # "auto", "ollama", "openai"
-    endpoint = ecfg.exploration_endpoint.strip()
-    model = ecfg.exploration_model.strip()
-    api_key = ecfg.exploration_api_key.strip() or os.environ.get("VANER_EXPLORATION_API_KEY", "")
+    backend = ecfg.backend  # "auto", "ollama", "openai"
+    endpoint = ecfg.endpoint.strip()
+    model = ecfg.model.strip()
+    api_key = ecfg.api_key.strip() or os.environ.get("VANER_EXPLORATION_API_KEY", "")
 
     def _make_openai(base_url: str, m: str) -> LLMCallable:
         from vaner.clients.openai import openai_llm
@@ -2243,7 +2257,7 @@ def _build_exploration_llm(ecfg: ExplorationConfig) -> LLMCallable | None:
                 if m:
                     return _make_openai(endpoint, m)
         _log.warning(
-            "Vaner: exploration_endpoint=%r is unreachable or has no models; falling back to heuristic-only exploration.",
+            "Vaner: endpoint=%r is unreachable or has no models; falling back to heuristic-only exploration.",
             endpoint,
         )
         return None
@@ -2268,16 +2282,18 @@ def _build_exploration_llm(ecfg: ExplorationConfig) -> LLMCallable | None:
 
     _log.debug(
         "Vaner: no exploration LLM detected on localhost (tried vLLM :8000 and Ollama :11434). "
-        "Set exploration_endpoint in config to enable LLM-powered exploration."
+        "Set exploration.endpoint in config to enable LLM-powered exploration."
     )
     return None
 
 
-def _build_embed_callable(ecfg: ExplorationConfig) -> EmbedCallable | None:
+def _build_embed_callable(config: VanerConfig) -> EmbedCallable | None:
     """Build an embedding callable from ExplorationConfig. Returns None if disabled."""
     import logging as _logging
 
     _log = _logging.getLogger(__name__)
+    ecfg = config.exploration
+    embedding_device = _embedding_device_from_compute(config)
 
     if not ecfg.embedding_model:
         return None
@@ -2287,11 +2303,11 @@ def _build_embed_callable(ecfg: ExplorationConfig) -> EmbedCallable | None:
         _log.info(
             "Vaner embeddings: sentence-transformers model=%s device=%s",
             ecfg.embedding_model,
-            ecfg.embedding_device,
+            embedding_device,
         )
         return sentence_transformer_embed(
             model=ecfg.embedding_model,
-            device=ecfg.embedding_device,
+            device=embedding_device,
         )
     except Exception as exc:
         _log.warning(
@@ -2331,12 +2347,12 @@ def _apply_compute_settings(compute: ComputeConfig) -> None:
 def _embedding_device_from_compute(config: VanerConfig) -> str:
     compute_device = (config.compute.embedding_device or config.compute.device).strip().lower()
     if not compute_device or compute_device == "auto":
-        return config.exploration.embedding_device
+        return "cpu"
     if compute_device.startswith("cuda"):
         return "cuda"
     if compute_device in {"cpu", "mps"}:
         return compute_device
-    return config.exploration.embedding_device
+    return "cpu"
 
 
 def _cpu_load_fraction() -> float:
@@ -2387,12 +2403,12 @@ def _record_idle_usage_seconds(config: VanerConfig, seconds: float) -> None:
 def build_default_engine(repo: Path | str | None = None, config: VanerConfig | None = None) -> VanerEngine:
     """Build a VanerEngine with auto-detected exploration LLM and embeddings.
 
-    Auto-detection order (when ``exploration_endpoint`` is empty):
+    Auto-detection order (when ``endpoint`` is empty):
     1. vLLM / OpenAI-compatible on ``http://127.0.0.1:8000/v1``
     2. Ollama on ``http://127.0.0.1:11434``
     3. Heuristic-only (no LLM) — graceful fallback
 
-    Set ``config.exploration.exploration_endpoint`` to point at a remote
+    Set ``config.exploration.endpoint`` to point at a remote
     OpenAI-compatible endpoint (vLLM, LM Studio, remote Ollama, etc.).
     """
     root = Path(repo).resolve() if repo is not None else Path.cwd().resolve()
@@ -2400,9 +2416,7 @@ def build_default_engine(repo: Path | str | None = None, config: VanerConfig | N
     resolved = config if config is not None else load_config(root)
     _apply_compute_settings(resolved.compute)
 
-    resolved.exploration.embedding_device = _embedding_device_from_compute(resolved)
-
     exploration_llm = _build_exploration_llm(resolved.exploration)
-    embed = _build_embed_callable(resolved.exploration)
+    embed = _build_embed_callable(resolved)
 
     return VanerEngine(adapter=adapter, config=resolved, llm=exploration_llm, embed=embed)

--- a/src/vaner/intent/adapter.py
+++ b/src/vaner/intent/adapter.py
@@ -22,6 +22,7 @@ from typing import Protocol
 
 from vaner.daemon.signals.fs_watcher import scan_repo_files
 from vaner.daemon.signals.git_reader import read_git_state
+from vaner.intent.skills_discovery import discover_skills
 from vaner.models.signal import SignalEvent
 
 
@@ -245,13 +246,20 @@ class CodeRepoAdapter:
 
     async def get_context_for_reasoning(self) -> ReasonerContext:
         git_state = read_git_state(self.repo_root)
+        skills = discover_skills(self.repo_root, include_global=False)
         summary = (
             f"branch={git_state.get('branch', '')}\nrecent_diff={git_state.get('recent_diff', '')}\nstaged={git_state.get('staged', '')}\n"
         )
         return ReasonerContext(
             corpus_type=self.corpus_type,
             summary=summary,
-            metadata={"repo_root": str(self.repo_root), "corpus_id": self.corpus_id, "privacy_zone": self.privacy_zone},
+            metadata={
+                "repo_root": str(self.repo_root),
+                "corpus_id": self.corpus_id,
+                "privacy_zone": self.privacy_zone,
+                "skills": ",".join(skill.name for skill in skills[:20]),
+                "skill_kinds": ",".join(skill.vaner_kind for skill in skills[:20] if skill.vaner_kind),
+            },
             corpus_id=self.corpus_id,
             privacy_zone=self.privacy_zone,
         )

--- a/src/vaner/intent/features.py
+++ b/src/vaner/intent/features.py
@@ -48,6 +48,21 @@ async def extract_hybrid_features(
     macro_support = max((int(row.get("use_count", 0)) for row in matching_macros), default=0)
     macro_confidence = max((float(row.get("confidence", 0.0)) for row in matching_macros), default=0.0)
     transition_support = sum(int(row.get("transition_count", 0)) for row in habit_transitions)
+    skill_events = [event for event in signals if event.kind == "skill_loaded"]
+    skill_presence = 1.0 if skill_events else 0.0
+    prompt_kind = "change"
+    prompt_lower = (prompt or "").lower()
+    if any(token in prompt_lower for token in ("debug", "traceback", "exception", "failing", "fix")):
+        prompt_kind = "debug"
+    elif any(token in prompt_lower for token in ("explain", "why", "understand")):
+        prompt_kind = "explain"
+    elif any(token in prompt_lower for token in ("research", "investigate", "compare")):
+        prompt_kind = "research"
+    skill_kind_match = 0.0
+    for event in skill_events:
+        kind = str(event.payload.get("vaner_kind", "")).strip().lower()
+        if kind and kind == prompt_kind:
+            skill_kind_match += 1.0
 
     return {
         "signal_count_total": float(len(signals)),
@@ -66,11 +81,13 @@ async def extract_hybrid_features(
         "prompt_macro_confidence": float(macro_confidence),
         "habit_transition_support": float(transition_support),
         "workflow_phase_known": 1.0 if workflow_phase else 0.0,
+        "skill_presence": skill_presence,
+        "skill_kind_match": skill_kind_match,
     }
 
 
 def feature_vector_for_artefact(features: dict[str, float], artefact: Artefact) -> list[float]:
-    # Order must exactly match FEATURE_KEYS in vaner.intent.trainer (26 entries).
+    # Order must exactly match FEATURE_KEYS in vaner.intent.trainer.
     return [
         features.get("signal_count_recent_15m", 0.0),
         features.get("query_count_total", 0.0),
@@ -97,6 +114,8 @@ def feature_vector_for_artefact(features: dict[str, float], artefact: Artefact) 
         features.get("policy_signal_coverage_gap", 0.0),
         features.get("policy_signal_pattern", 0.0),
         features.get("policy_signal_freshness", 0.0),
+        features.get("skill_presence", 0.0),
+        features.get("skill_kind_match", 0.0),
         # Artefact-level fields (always last, matches trainer.py FEATURE_KEYS[-2:])
         float(artefact.access_count),
         float(max(0.0, time.time() - artefact.generated_at)),

--- a/src/vaner/intent/frontier.py
+++ b/src/vaner/intent/frontier.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vaner.intent.scoring_policy import ScoringPolicy
+from vaner.intent.skills_discovery import SkillRef, match_skill_paths
 
 if TYPE_CHECKING:
     from vaner.intent.arcs import ConversationArcModel
@@ -139,6 +140,7 @@ class ExplorationFrontier:
         "arc": 1.0,
         "pattern": 1.2,  # validated patterns get a slight head start
         "llm_branch": 0.9,
+        "skill": 1.1,
     }
 
     def __init__(
@@ -447,6 +449,41 @@ class ExplorationFrontier:
                 priority=priority,
                 depth=0,
                 reason=f"validated pattern (confirmed {confirmation_count}x)",
+                layer="tactical",
+            )
+            if self.push(scenario):
+                admitted += 1
+        return admitted
+
+    def seed_from_skills(self, skills: list[SkillRef], available_paths: list[str]) -> int:
+        """Seed scenarios from loaded skill hints."""
+        if not skills:
+            return 0
+        self._total_available = max(self._total_available, len(available_paths))
+        admitted = 0
+        for skill in skills:
+            matched = match_skill_paths(skill, available_paths, limit=10)
+            if not matched:
+                continue
+            pattern_strength = min(1.0, (len(skill.tags) + len(skill.triggers)) / 8.0)
+            priority = self._score(
+                source="skill",
+                graph_proximity=0.0,
+                arc_probability=0.55 if skill.vaner_kind else 0.45,
+                coverage_gap=0.5,
+                pattern_strength=pattern_strength,
+                freshness_decay=1.0,
+                depth=0,
+                layer="tactical",
+            )
+            scenario = ExplorationScenario(
+                id=file_set_fingerprint(matched),
+                file_paths=matched,
+                anchor=skill.name,
+                source="skill",
+                priority=priority,
+                depth=0,
+                reason=f"skill hint: {skill.name}",
                 layer="tactical",
             )
             if self.push(scenario):

--- a/src/vaner/intent/scoring_policy.py
+++ b/src/vaner/intent/scoring_policy.py
@@ -35,6 +35,7 @@ _DEFAULT_SOURCE_MULTIPLIERS: dict[str, float] = {
     "arc": 1.0,
     "pattern": 1.2,
     "llm_branch": 0.9,
+    "skill": 1.1,
 }
 
 # Layer multipliers — strategic scenarios are slightly prioritized.

--- a/src/vaner/intent/skills_discovery.py
+++ b/src/vaner/intent/skills_discovery.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from fnmatch import fnmatch
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+@dataclass(slots=True)
+class SkillRef:
+    name: str
+    path: Path
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
+    triggers: list[str] = field(default_factory=list)
+    vaner_kind: str | None = None
+
+    def as_signal_payload(self, repo_root: Path) -> dict[str, object]:
+        try:
+            rel_path = str(self.path.relative_to(repo_root))
+            privacy_zone = "project_local"
+        except ValueError:
+            rel_path = str(self.path)
+            privacy_zone = "external"
+        return {
+            "name": self.name,
+            "description": self.description,
+            "tags": self.tags,
+            "triggers": self.triggers,
+            "vaner_kind": self.vaner_kind,
+            "path": rel_path,
+            "privacy_zone": privacy_zone,
+            "corpus_id": "repo",
+        }
+
+
+def _split_frontmatter(text: str) -> tuple[str | None, str]:
+    stripped = text.lstrip()
+    if not stripped.startswith("---\n"):
+        return None, text
+    rest = stripped[4:]
+    marker = "\n---\n"
+    idx = rest.find(marker)
+    if idx < 0:
+        return None, text
+    return rest[:idx], rest[idx + len(marker) :]
+
+
+def _str_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def _parse_frontmatter(frontmatter: str | None) -> dict[str, object]:
+    if not frontmatter:
+        return {}
+    if yaml is not None:
+        parsed = yaml.safe_load(frontmatter)
+        if isinstance(parsed, dict):
+            return parsed
+    fallback: dict[str, object] = {}
+    for line in frontmatter.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if key:
+            fallback[key] = value.strip().strip("\"'")
+    return fallback
+
+
+def _resolve_roots(repo_root: Path, roots: list[str], *, include_global: bool) -> list[Path]:
+    resolved: list[Path] = []
+    for root in roots:
+        candidate = Path(root).expanduser()
+        if not candidate.is_absolute():
+            candidate = (repo_root / candidate).resolve()
+        if not include_global:
+            try:
+                candidate.relative_to(repo_root)
+            except ValueError:
+                continue
+        resolved.append(candidate)
+    return resolved
+
+
+def discover_skills(
+    repo_root: Path,
+    *,
+    include_global: bool = False,
+    skill_roots: list[str] | None = None,
+) -> list[SkillRef]:
+    roots = skill_roots or [".cursor/skills", ".claude/skills", "skills"]
+    found: dict[str, SkillRef] = {}
+    for root in _resolve_roots(repo_root, roots, include_global=include_global):
+        if not root.exists():
+            continue
+        for path in root.rglob("SKILL.md"):
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            frontmatter, _ = _split_frontmatter(text)
+            parsed = _parse_frontmatter(frontmatter)
+            name = str(parsed.get("name", "")).strip() or path.parent.name
+            description = str(parsed.get("description", "")).strip()
+            tags = _str_list(parsed.get("tags"))
+            triggers = _str_list(parsed.get("triggers"))
+            vaner_kind: str | None = None
+            vaner = parsed.get("vaner")
+            if isinstance(vaner, dict):
+                kind = vaner.get("kind")
+                if isinstance(kind, str) and kind.strip():
+                    vaner_kind = kind.strip()
+            ref = SkillRef(
+                name=name,
+                path=path.resolve(),
+                description=description,
+                tags=tags,
+                triggers=triggers,
+                vaner_kind=vaner_kind,
+            )
+            found[str(ref.path)] = ref
+    return sorted(found.values(), key=lambda item: str(item.path))
+
+
+def match_skill_paths(skill: SkillRef, available_paths: list[str], *, limit: int = 10) -> list[str]:
+    matched: list[str] = []
+    for trigger in skill.triggers:
+        if any(ch in trigger for ch in "*?[]"):
+            matched.extend(path for path in available_paths if fnmatch(path, trigger))
+        else:
+            token = trigger.strip().lower()
+            if token:
+                matched.extend(path for path in available_paths if token in path.lower())
+        if len(matched) >= limit:
+            break
+    if not matched:
+        for token in [skill.name, *skill.tags]:
+            norm = token.strip().lower()
+            if norm:
+                matched.extend(path for path in available_paths if norm in path.lower())
+            if len(matched) >= limit:
+                break
+    return sorted(dict.fromkeys(matched))[:limit]

--- a/src/vaner/intent/trainer.py
+++ b/src/vaner/intent/trainer.py
@@ -10,7 +10,7 @@ from vaner.intent.scorer import IntentScorer
 from vaner.learning.reward import RewardInput, compute_reward
 from vaner.store.artefacts import ArtefactStore
 
-FEATURE_SCHEMA_VERSION = "v2"
+FEATURE_SCHEMA_VERSION = "v3"
 FEATURE_KEYS: tuple[str, ...] = (
     "signal_count_recent_15m",
     "query_count_total",
@@ -36,6 +36,8 @@ FEATURE_KEYS: tuple[str, ...] = (
     "policy_signal_coverage_gap",
     "policy_signal_pattern",
     "policy_signal_freshness",
+    "skill_presence",
+    "skill_kind_match",
     "access_count",
     "artefact_age_seconds",
 )

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -62,7 +62,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from mcp.server import Server
+from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 from mcp.types import (
     CallToolResult,
@@ -152,6 +152,10 @@ def build_server(repo_root: Path) -> Server:
                                 "description": "Maximum number of scenarios to return (default: 10)",
                                 "default": 10,
                             },
+                            "skill": {
+                                "type": "string",
+                                "description": "Optional skill attribution label for telemetry.",
+                            },
                         },
                     },
                 ),
@@ -164,7 +168,11 @@ def build_server(repo_root: Path) -> Server:
                             "id": {
                                 "type": "string",
                                 "description": "Scenario id returned by list_scenarios",
-                            }
+                            },
+                            "skill": {
+                                "type": "string",
+                                "description": "Optional skill attribution label for telemetry.",
+                            },
                         },
                         "required": ["id"],
                     },
@@ -180,6 +188,10 @@ def build_server(repo_root: Path) -> Server:
                                 "type": "integer",
                                 "default": 1,
                                 "description": "Expansion depth hint (currently best-effort)",
+                            },
+                            "skill": {
+                                "type": "string",
+                                "description": "Optional skill attribution label for telemetry.",
                             },
                         },
                         "required": ["id"],
@@ -209,6 +221,7 @@ def build_server(repo_root: Path) -> Server:
                             "id": {"type": "string"},
                             "result": {"type": "string", "enum": ["useful", "irrelevant", "partial"]},
                             "note": {"type": "string"},
+                            "skill": {"type": "string"},
                         },
                         "required": ["id", "result"],
                     },
@@ -223,7 +236,13 @@ def build_server(repo_root: Path) -> Server:
         await metrics_store.initialize()
         await scenario_store.initialize()
 
-        async def _record(status: str, *, tool_name: str | None = None, scenario_id: str | None = None) -> None:
+        async def _record(
+            status: str,
+            *,
+            tool_name: str | None = None,
+            scenario_id: str | None = None,
+            skill: str | None = None,
+        ) -> None:
             latency_ms = (time.perf_counter() - started) * 1000.0
             try:
                 await metrics_store.increment_mode_usage("mcp")
@@ -233,6 +252,7 @@ def build_server(repo_root: Path) -> Server:
                     status=status,
                     latency_ms=latency_ms,
                     scenario_id=scenario_id,
+                    skill=skill,
                 )
             except Exception:
                 # Metrics are best-effort; tool execution must remain non-fatal.
@@ -244,8 +264,9 @@ def build_server(repo_root: Path) -> Server:
             tool_name: str | None = None,
             scenario_id: str | None = None,
             code: str | None = None,
+            skill: str | None = None,
         ) -> CallToolResult:
-            await _record("error", tool_name=tool_name, scenario_id=scenario_id)
+            await _record("error", tool_name=tool_name, scenario_id=scenario_id, skill=skill)
             structured: dict[str, Any] | None = None
             if code:
                 structured = {"code": code, "message": message}
@@ -254,40 +275,43 @@ def build_server(repo_root: Path) -> Server:
         if name == "list_scenarios":
             limit = int(args.get("limit", 10))
             kind = args.get("kind")
+            skill = str(args.get("skill", "")).strip() or None
             if kind is not None:
                 kind = str(kind)
             scenarios = await scenario_store.list_top(kind=kind, limit=limit)
             payload = {"count": len(scenarios), "scenarios": [_scenario_to_summary(s) for s in scenarios]}
-            await _record("ok")
+            await _record("ok", skill=skill)
             return CallToolResult(content=_make_text(json.dumps(payload, indent=2)))
 
         if name == "get_scenario":
             scenario_id = str(args.get("id", "")).strip()
+            skill = str(args.get("skill", "")).strip() or None
             if not scenario_id:
-                return await _error("ERROR: id is required")
+                return await _error("ERROR: id is required", skill=skill)
             scenario = await scenario_store.get(scenario_id)
             if scenario is None:
-                return await _error(f"ERROR: Scenario '{scenario_id}' not found", scenario_id=scenario_id)
-            await _record("ok", scenario_id=scenario_id)
+                return await _error(f"ERROR: Scenario '{scenario_id}' not found", scenario_id=scenario_id, skill=skill)
+            await _record("ok", scenario_id=scenario_id, skill=skill)
             return CallToolResult(content=_make_text(json.dumps(scenario.model_dump(mode="json"), indent=2)))
 
         if name == "expand_scenario":
             scenario_id = str(args.get("id", "")).strip()
+            skill = str(args.get("skill", "")).strip() or None
             if not scenario_id:
-                return await _error("ERROR: id is required")
+                return await _error("ERROR: id is required", skill=skill)
             try:
                 _ensure_backend(config)
             except BackendNotConfiguredError as exc:
-                return await _error(str(exc), scenario_id=scenario_id, code=exc.code)
+                return await _error(str(exc), scenario_id=scenario_id, code=exc.code, skill=skill)
             try:
                 await aprecompute(repo_root, config=config)
             except Exception as exc:
-                return await _error(f"ERROR: {exc}", scenario_id=scenario_id)
+                return await _error(f"ERROR: {exc}", scenario_id=scenario_id, skill=skill)
             await scenario_store.record_expansion(scenario_id)
             scenario = await scenario_store.get(scenario_id)
             if scenario is None:
-                return await _error(f"ERROR: Scenario '{scenario_id}' not found", scenario_id=scenario_id)
-            await _record("ok", scenario_id=scenario_id)
+                return await _error(f"ERROR: Scenario '{scenario_id}' not found", scenario_id=scenario_id, skill=skill)
+            await _record("ok", scenario_id=scenario_id, skill=skill)
             return CallToolResult(content=_make_text(json.dumps(scenario.model_dump(mode="json"), indent=2)))
 
         if name == "compare_scenarios":
@@ -326,17 +350,18 @@ def build_server(repo_root: Path) -> Server:
             scenario_id = str(args.get("id", "")).strip()
             result = str(args.get("result", "")).strip()
             note = str(args.get("note", "")).strip()
+            skill = str(args.get("skill", "")).strip() or None
             if not scenario_id:
-                return await _error("ERROR: id is required")
+                return await _error("ERROR: id is required", skill=skill)
             if result not in {"useful", "irrelevant", "partial"}:
-                return await _error("ERROR: result must be useful|irrelevant|partial", scenario_id=scenario_id)
-            await scenario_store.record_outcome(scenario_id, result)
+                return await _error("ERROR: result must be useful|irrelevant|partial", scenario_id=scenario_id, skill=skill)
+            await scenario_store.record_outcome(scenario_id, result, skill=skill, source="skill" if skill else None)
             try:
-                await metrics_store.record_scenario_outcome(scenario_id=scenario_id, result=result, note=note)
+                await metrics_store.record_scenario_outcome(scenario_id=scenario_id, result=result, note=note, skill=skill)
             except Exception:
                 # Outcome telemetry should not fail the tool response.
                 pass
-            await _record("ok", scenario_id=scenario_id)
+            await _record("ok", scenario_id=scenario_id, skill=skill)
             return CallToolResult(content=_make_text(json.dumps({"ok": True, "scenario_id": scenario_id, "result": result})))
 
         return await _error(f"ERROR: Unknown tool '{name}'")
@@ -357,7 +382,7 @@ async def run_stdio(repo_root: Path) -> None:
                 server_name="vaner",
                 server_version="0.2.0",
                 capabilities=server.get_capabilities(
-                    notification_options=None,
+                    notification_options=NotificationOptions(),
                     experimental_capabilities={},
                 ),
             ),
@@ -383,7 +408,7 @@ async def run_sse(repo_root: Path, host: str, port: int) -> None:
                     server_name="vaner",
                     server_version="0.2.0",
                     capabilities=server.get_capabilities(
-                        notification_options=None,
+                        notification_options=NotificationOptions(),
                         experimental_capabilities={},
                     ),
                 ),

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -9,11 +9,14 @@ from pydantic import BaseModel, Field
 
 
 class PrivacyConfig(BaseModel):
-    allowed_paths: list[str] = Field(default_factory=lambda: ["."])
-    excluded_patterns: list[str] = Field(default_factory=lambda: ["*.env", "*.key", "*.pem", "credentials*", "secrets*"])
-    redact_patterns: list[str] = Field(default_factory=list)
-    telemetry: str = "local"
-    exclude_private: bool = False
+    allowed_paths: list[str] = Field(default_factory=lambda: ["."], description="Repository-relative paths Vaner may index.")
+    excluded_patterns: list[str] = Field(
+        default_factory=lambda: ["*.env", "*.key", "*.pem", "credentials*", "secrets*"],
+        description="Glob patterns excluded from indexing.",
+    )
+    redact_patterns: list[str] = Field(default_factory=list, description="Patterns redacted from stored snippets.")
+    telemetry: str = Field(default="local", description="Telemetry mode. Local keeps telemetry on disk only.")
+    exclude_private: bool = Field(default=False, description="Whether to skip private files detected by policy heuristics.")
 
 
 class BackendConfig(BaseModel):
@@ -45,59 +48,73 @@ class BackendConfig(BaseModel):
         model = "Qwen/Qwen2.5-Coder-32B-Instruct"
     """
 
-    name: str = "custom"
-    base_url: str = ""
-    model: str = ""
-    api_key_env: str = "OPENAI_API_KEY"
-    prefer_local: bool = True
-    fallback_enabled: bool = False
-    fallback_base_url: str | None = None
-    fallback_model: str | None = None
-    fallback_api_key_env: str = "OPENAI_API_KEY"
-    remote_budget_per_hour: int = 60
+    name: str = Field(default="custom", description="Human-readable backend profile name.")
+    base_url: str = Field(default="", description="OpenAI-compatible base URL for user-facing completions.")
+    model: str = Field(default="", description="User-facing chat model name.")
+    api_key_env: str = Field(default="OPENAI_API_KEY", description="Environment variable that stores backend API key.")
+    prefer_local: bool = Field(default=True, description="Prefer local backend routes when both local and remote exist.")
+    fallback_enabled: bool = Field(default=False, description="Enable fallback backend when primary fails.")
+    fallback_base_url: str | None = Field(default=None, description="Fallback OpenAI-compatible base URL.")
+    fallback_model: str | None = Field(default=None, description="Fallback model name.")
+    fallback_api_key_env: str = Field(default="OPENAI_API_KEY", description="Environment variable for fallback API key.")
+    remote_budget_per_hour: int = Field(default=60, description="Soft hourly budget guard for remote inference.")
 
 
 class GenerationConfig(BaseModel):
-    use_llm: bool = False
-    generation_model: str | None = None
-    max_file_chars: int = 8000
-    summary_max_tokens: int = 400
-    max_concurrent_generations: int = 4
-    max_generations_per_cycle: int = 4000
+    use_llm: bool = Field(default=False, description="Enable LLM-generated file summaries during precompute.")
+    generation_model: str | None = Field(default=None, description="Override model for generation summaries.")
+    max_file_chars: int = Field(default=8000, description="Maximum source characters sent for one summary.")
+    summary_max_tokens: int = Field(default=400, description="Token cap for generated summary text.")
+    max_concurrent_generations: int = Field(default=4, description="Max parallel summary generations.")
+    max_generations_per_cycle: int = Field(default=4000, description="Max summary generations per precompute cycle.")
 
 
 class ProxyConfig(BaseModel):
-    proxy_token: str | None = None
-    max_requests_per_minute: int = 120
-    ssl_certfile: str | None = None
-    ssl_keyfile: str | None = None
+    proxy_token: str | None = Field(default=None, description="Optional auth token for non-loopback proxy exposure.")
+    max_requests_per_minute: int = Field(default=120, description="Rate limit for proxy ingress.")
+    ssl_certfile: str | None = Field(default=None, description="TLS certificate file path for proxy server.")
+    ssl_keyfile: str | None = Field(default=None, description="TLS key file path for proxy server.")
 
 
 class GatewayConfig(BaseModel):
-    passthrough_enabled: bool = False
-    routes: dict[str, str] = Field(default_factory=dict)
-    annotate_response_trailer: bool = False
-    annotate_system_note: Literal["off", "min", "full"] = "off"
-    shadow_rate: float = 0.0
+    passthrough_enabled: bool = Field(default=False, description="Enable gateway passthrough mode.")
+    routes: dict[str, str] = Field(default_factory=dict, description="Model-prefix to provider base URL route map.")
+    annotate_response_trailer: bool = Field(default=False, description="Append gateway annotation trailer to responses.")
+    annotate_system_note: Literal["off", "min", "full"] = Field(
+        default="off",
+        description="Inject system note annotations into forwarded requests.",
+    )
+    shadow_rate: float = Field(default=0.0, description="Sampling rate for shadow traffic comparisons.")
 
 
 class MCPConfig(BaseModel):
-    transport: Literal["stdio", "sse"] = "stdio"
-    http_host: str = "127.0.0.1"
-    http_port: int = 8472
+    transport: Literal["stdio", "sse"] = Field(default="stdio", description="MCP server transport mode.")
+    http_host: str = Field(default="127.0.0.1", description="Host for SSE MCP mode.")
+    http_port: int = Field(default=8472, description="Port for SSE MCP mode.")
+
+
+class IntentConfig(BaseModel):
+    enabled: bool = Field(default=True, description="Enable intent scoring and scenario prioritization.")
+    include_global_skills: bool = Field(default=False, description="Allow scanning skills outside repository roots.")
+    skill_roots: list[str] = Field(
+        default_factory=lambda: [".cursor/skills", ".claude/skills", "skills"],
+        description="Repository-relative skill directories to scan for SKILL.md files.",
+    )
+    skills_loop_enabled: bool = Field(default=True, description="Enable closed-loop skill attribution feedback.")
+    max_feedback_events_per_cycle: int = Field(default=200, description="Max feedback events consumed each cycle.")
 
 
 class ComputeConfig(BaseModel):
-    device: str = "auto"
-    cpu_fraction: float = 0.2
-    gpu_memory_fraction: float = 0.5
-    idle_only: bool = True
-    idle_cpu_threshold: float = 0.6
-    idle_gpu_threshold: float = 0.7
-    embedding_device: str | None = None
-    exploration_concurrency: int = 4
-    max_parallel_precompute: int = 1
-    max_cycle_seconds: int = 300
+    device: str = Field(default="auto", description="Primary compute device for precompute (`auto`, `cpu`, `cuda`, `mps`).")
+    cpu_fraction: float = Field(default=0.2, description="CPU share reserved for background computation.")
+    gpu_memory_fraction: float = Field(default=0.5, description="GPU memory share reserved for background computation.")
+    idle_only: bool = Field(default=True, description="Run precompute only when host utilization is below thresholds.")
+    idle_cpu_threshold: float = Field(default=0.6, description="CPU utilization cap for `idle_only` gating.")
+    idle_gpu_threshold: float = Field(default=0.7, description="GPU utilization cap for `idle_only` gating.")
+    embedding_device: str | None = Field(default=None, description="Device for embedding model (`cpu`, `cuda`, `mps`, `auto`).")
+    exploration_concurrency: int = Field(default=4, description="Max concurrent exploration tasks.")
+    max_parallel_precompute: int = Field(default=1, description="Max parallel precompute workers.")
+    max_cycle_seconds: int = Field(default=300, description="Hard wall-clock cap for one precompute cycle.")
     """Hard wall-clock cap for a single precompute cycle.
 
     Prevents the ponder loop from running away if a backend stalls or the
@@ -106,7 +123,7 @@ class ComputeConfig(BaseModel):
     the next cycle, so bounding here is safe.
     """
 
-    max_session_minutes: int | None = None
+    max_session_minutes: int | None = Field(default=None, description="Optional total runtime cap for one daemon session.")
     """Optional cumulative cap for a continuous ``vaner daemon`` session.
 
     ``None`` (default) means unbounded — the daemon keeps running until
@@ -128,37 +145,36 @@ class ExplorationConfig(BaseModel):
 
     LLM Exploration
     ---------------
-    Set ``exploration_endpoint`` to point at a local Ollama instance or any
+    Set ``endpoint`` to point at a local Ollama instance or any
     OpenAI-compatible server (vLLM, LM Studio, remote API).  Leave empty to
-    auto-detect on localhost.  ``exploration_model`` selects the model; if
+    auto-detect on localhost.  ``model`` selects the model; if
     empty Vaner picks the first available model reported by the endpoint.
-    ``exploration_backend`` can be ``"auto"`` (probe endpoint), ``"ollama"``,
+    ``backend`` can be ``"auto"`` (probe endpoint), ``"ollama"``,
     or ``"openai"`` (OpenAI-compatible / vLLM).
 
     Embeddings
     ----------
     ``embedding_model`` names a sentence-transformers model used to embed
-    prompts and cache entries for semantic matching.  ``embedding_device``
-    controls the torch device (``"cpu"``, ``"cuda"``).  Leave
-    ``embedding_model`` empty to disable embedding-based cache matching.
+    prompts and cache entries for semantic matching. Leave ``embedding_model``
+    empty to disable embedding-based cache matching.
     """
 
-    max_exploration_depth: int = 3
+    max_exploration_depth: int = Field(default=3, description="Maximum LLM branch depth from initial seed.")
     """Maximum LLM branch depth from the original graph seed."""
 
-    frontier_max_size: int = 500
+    frontier_max_size: int = Field(default=500, description="Maximum queued scenarios in the frontier.")
     """Maximum number of pending scenarios in the frontier at once."""
 
-    min_priority: float = 0.10
+    min_priority: float = Field(default=0.10, description="Minimum effective priority required to keep a scenario.")
     """Scenarios with effective priority below this threshold are rejected."""
 
-    dedup_threshold: float = 0.70
+    dedup_threshold: float = Field(default=0.70, description="Jaccard overlap threshold used for scenario deduplication.")
     """Jaccard overlap above which two scenarios are considered duplicates."""
 
-    saturation_coverage: float = 0.90
+    saturation_coverage: float = Field(default=0.90, description="Coverage ratio considered saturated for exploration.")
     """Fraction of known files that, once covered, signals saturation."""
 
-    llm_gate: Literal["none", "non_trivial", "all"] = "non_trivial"
+    llm_gate: Literal["none", "non_trivial", "all"] = Field(default="non_trivial", description="Policy controlling LLM calls.")
     """Which scenarios are sent to the LLM.
     - "none"        — graph-walk only, no LLM calls
     - "non_trivial" — LLM for depth > 0 or non-graph sources
@@ -169,14 +185,14 @@ class ExplorationConfig(BaseModel):
     # Exploration LLM endpoint (separate from the user-facing backend)
     # ------------------------------------------------------------------
 
-    exploration_model: str = ""
+    model: str = Field(default="", description="Model for exploration LLM. Empty picks first discovered model.")
     """Model name for the exploration LLM.
     Ollama tag (e.g. ``"qwen2.5-coder:32b"``) or OpenAI-compatible model ID
     (e.g. ``"Qwen/Qwen3.5-35B-A3B-FP8"`` for vLLM).  Empty = pick first
     available model from the detected endpoint.
     """
 
-    exploration_endpoint: str = ""
+    endpoint: str = Field(default="", description="Base URL for exploration endpoint. Empty auto-probes localhost.")
     """Base URL for the exploration LLM endpoint.
 
     Examples:
@@ -189,14 +205,14 @@ class ExplorationConfig(BaseModel):
     Empty string = auto-probe localhost (Ollama on 11434, then vLLM on 8000).
     """
 
-    exploration_backend: Literal["auto", "ollama", "openai"] = "auto"
+    backend: Literal["auto", "ollama", "openai"] = Field(default="auto", description="Client protocol for exploration endpoint.")
     """Which client protocol to use.
     - ``"auto"``   — probe endpoint, infer from API shape
     - ``"ollama"`` — force Ollama ``/api/generate`` protocol
     - ``"openai"`` — force OpenAI ``/v1/chat/completions`` protocol (for vLLM)
     """
 
-    exploration_api_key: str = ""
+    api_key: str = Field(default="", description="API key for exploration endpoint (optional for local runtimes).")
     """API key for the exploration endpoint.  Use ``"EMPTY"`` for local
     vLLM which requires a non-empty but unauthenticated token.  Leave empty
     to read from the ``VANER_EXPLORATION_API_KEY`` environment variable or
@@ -207,14 +223,14 @@ class ExplorationConfig(BaseModel):
     # Embedding model for semantic cache matching
     # ------------------------------------------------------------------
 
-    embedding_model: str = "all-MiniLM-L6-v2"
+    embedding_model: str = Field(
+        default="all-MiniLM-L6-v2",
+        description="sentence-transformers model used for semantic cache matching.",
+    )
     """sentence-transformers model for semantic prompt embeddings used in
     cache matching.  Set to empty string to disable embedding-based matching
     and fall back to token-Jaccard only.
     """
-
-    embedding_device: str = "cpu"
-    """Torch device for the embedding model (``"cpu"`` or ``"cuda"``)."""
 
     @classmethod
     def conservative(cls) -> ExplorationConfig:
@@ -252,13 +268,14 @@ class VanerConfig(BaseModel):
     repo_root: Path
     store_path: Path
     telemetry_path: Path
-    max_age_seconds: int = 3600
-    max_context_tokens: int = 4096
+    max_age_seconds: int = Field(default=3600, description="Max age (seconds) for reusable context artefacts.")
+    max_context_tokens: int = Field(default=4096, description="Maximum token budget for injected context.")
     backend: BackendConfig = Field(default_factory=BackendConfig)
     privacy: PrivacyConfig = Field(default_factory=PrivacyConfig)
     generation: GenerationConfig = Field(default_factory=GenerationConfig)
     proxy: ProxyConfig = Field(default_factory=ProxyConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)
+    intent: IntentConfig = Field(default_factory=IntentConfig)
     compute: ComputeConfig = Field(default_factory=ComputeConfig)
     exploration: ExplorationConfig = Field(default_factory=ExplorationConfig)

--- a/src/vaner/store/scenarios/sqlite.py
+++ b/src/vaner/store/scenarios/sqlite.py
@@ -59,10 +59,24 @@ class ScenarioStore:
                 )
                 """
             )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS scenario_feedback (
+                    id TEXT PRIMARY KEY,
+                    scenario_id TEXT NOT NULL,
+                    source TEXT NOT NULL DEFAULT 'graph',
+                    skill TEXT,
+                    result TEXT NOT NULL,
+                    timestamp REAL NOT NULL,
+                    processed INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
             await db.execute("CREATE INDEX IF NOT EXISTS idx_scenarios_kind ON scenarios(kind)")
             await db.execute("CREATE INDEX IF NOT EXISTS idx_scenarios_score ON scenarios(score DESC)")
             await db.execute("CREATE INDEX IF NOT EXISTS idx_scenarios_freshness ON scenarios(freshness)")
             await db.execute("CREATE INDEX IF NOT EXISTS idx_scenario_evidence_sid ON scenario_evidence(scenario_id)")
+            await db.execute("CREATE INDEX IF NOT EXISTS idx_scenario_feedback_processed ON scenario_feedback(processed, timestamp)")
             await db.commit()
 
     async def upsert(self, scenario: Scenario) -> None:
@@ -150,7 +164,7 @@ class ScenarioStore:
             )
             await db.commit()
 
-    async def record_outcome(self, scenario_id: str, outcome: str) -> None:
+    async def record_outcome(self, scenario_id: str, outcome: str, *, skill: str | None = None, source: str | None = None) -> None:
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             await db.execute("UPDATE scenarios SET last_outcome = ? WHERE id = ?", (outcome, scenario_id))
@@ -161,7 +175,38 @@ class ScenarioStore:
                 scenario = self._row_to_scenario(row, evidence_map.get(scenario_id, []))
                 score = scenario_score(scenario)
                 await db.execute("UPDATE scenarios SET score = ? WHERE id = ?", (score, scenario_id))
+                now = time.time()
+                resolved_source = source or ("skill" if skill else "graph")
+                await db.execute(
+                    """
+                    INSERT INTO scenario_feedback(id, scenario_id, source, skill, result, timestamp, processed)
+                    VALUES (?, ?, ?, ?, ?, ?, 0)
+                    """,
+                    (f"{scenario_id}:{now}", scenario_id, resolved_source, skill, outcome, now),
+                )
             await db.commit()
+
+    async def consume_feedback(self, *, limit: int = 200) -> list[tuple[str, bool]]:
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cur = await db.execute(
+                """
+                SELECT id, source, result
+                FROM scenario_feedback
+                WHERE processed = 0
+                ORDER BY timestamp ASC
+                LIMIT ?
+                """,
+                (max(1, limit),),
+            )
+            rows = await cur.fetchall()
+            if not rows:
+                return []
+            ids = [str(row["id"]) for row in rows]
+            placeholders = ", ".join("?" for _ in ids)
+            await db.execute(f"UPDATE scenario_feedback SET processed = 1 WHERE id IN ({placeholders})", ids)
+            await db.commit()
+        return [(str(row["source"] or "graph"), str(row["result"] or "") in {"useful", "partial"}) for row in rows]
 
     async def mark_stale(self) -> None:
         now = time.time()

--- a/src/vaner/telemetry/metrics.py
+++ b/src/vaner/telemetry/metrics.py
@@ -87,6 +87,14 @@ class MetricsStore:
     def __init__(self, db_path: Path) -> None:
         self.db_path = db_path
 
+    @staticmethod
+    async def _ensure_column(db: aiosqlite.Connection, table: str, column: str, column_def: str) -> None:
+        cursor = await db.execute(f"PRAGMA table_info({table})")
+        rows = await cursor.fetchall()
+        names = {str(row[1]) for row in rows}
+        if column not in names:
+            await db.execute(f"ALTER TABLE {table} ADD COLUMN {column} {column_def}")
+
     async def initialize(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         async with aiosqlite.connect(self.db_path) as db:
@@ -142,6 +150,7 @@ class MetricsStore:
                     status TEXT NOT NULL,
                     latency_ms REAL NOT NULL,
                     scenario_id TEXT,
+                    skill TEXT,
                     timestamp REAL NOT NULL
                 )
                 """
@@ -153,10 +162,13 @@ class MetricsStore:
                     scenario_id TEXT NOT NULL,
                     result TEXT NOT NULL,
                     note TEXT NOT NULL DEFAULT '',
+                    skill TEXT,
                     timestamp REAL NOT NULL
                 )
                 """
             )
+            await self._ensure_column(db, "mcp_tool_calls", "skill", "TEXT")
+            await self._ensure_column(db, "scenario_outcomes", "skill", "TEXT")
             await db.commit()
 
     async def record(self, m: RequestMetrics) -> None:
@@ -321,24 +333,32 @@ class MetricsStore:
         status: str,
         latency_ms: float,
         scenario_id: str | None = None,
+        skill: str | None = None,
     ) -> None:
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
                 """
-                INSERT INTO mcp_tool_calls (id, tool_name, status, latency_ms, scenario_id, timestamp)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO mcp_tool_calls (id, tool_name, status, latency_ms, scenario_id, skill, timestamp)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (str(uuid.uuid4()), tool_name, status, latency_ms, scenario_id, time.time()),
+                (str(uuid.uuid4()), tool_name, status, latency_ms, scenario_id, skill, time.time()),
             )
             await db.commit()
 
-    async def record_scenario_outcome(self, *, scenario_id: str, result: str, note: str = "") -> None:
+    async def record_scenario_outcome(
+        self,
+        *,
+        scenario_id: str,
+        result: str,
+        note: str = "",
+        skill: str | None = None,
+    ) -> None:
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
                 """
-                INSERT INTO scenario_outcomes (id, scenario_id, result, note, timestamp)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO scenario_outcomes (id, scenario_id, result, note, skill, timestamp)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (str(uuid.uuid4()), scenario_id, result, note, time.time()),
+                (str(uuid.uuid4()), scenario_id, result, note, skill, time.time()),
             )
             await db.commit()

--- a/tests/test_cli/test_cockpit_commands.py
+++ b/tests/test_cli/test_cockpit_commands.py
@@ -76,7 +76,7 @@ def test_doctor_fails_when_config_missing(temp_repo):
     assert any(item["name"] == "config_exists" for item in payload["checks"])
 
 
-def test_doctor_includes_mcp_and_store_checks(temp_repo):
+def test_doctor_includes_mcp_and_store_checks(temp_repo, monkeypatch):
     (temp_repo / ".vaner").mkdir(parents=True, exist_ok=True)
     (temp_repo / ".vaner" / "config.toml").write_text(
         """
@@ -86,10 +86,25 @@ model = "qwen2.5-coder:7b"
 """.strip(),
         encoding="utf-8",
     )
+
+    class _FakeProc:
+        returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+        def terminate(self):
+            return None
+
+    monkeypatch.setattr(app.shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/vaner")
+    monkeypatch.setattr(app.subprocess, "Popen", lambda *args, **kwargs: _FakeProc())
     result = runner.invoke(app.app, ["doctor", "--path", str(temp_repo), "--json"])
     payload = json.loads(result.stdout)
     names = {item["name"] for item in payload["checks"]}
     assert "mcp_config_present" in names
+    assert "mcp_command_exists" in names
+    assert "mcp_server_boots" in names
+    assert "config_drift" in names
     assert "scenario_store_reachable" in names
     assert "exploration_llm_reachable" in names
 

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -54,6 +54,15 @@ transport = "sse"
 http_host = "0.0.0.0"
 http_port = 8999
 
+[intent]
+enabled = true
+include_global_skills = true
+skill_roots = [".cursor/skills"]
+
+[intent.skills_loop]
+enabled = false
+max_feedback_events_per_cycle = 77
+
 [exploration]
 endpoint = "http://127.0.0.1:11434"
 model = "qwen2.5-coder:14b"
@@ -99,8 +108,12 @@ max_parallel_precompute = 2
     assert config.gateway.shadow_rate == 0.15
     assert config.mcp.transport == "sse"
     assert config.mcp.http_port == 8999
-    assert config.exploration.exploration_endpoint == "http://127.0.0.1:11434"
-    assert config.exploration.exploration_model == "qwen2.5-coder:14b"
+    assert config.intent.include_global_skills is True
+    assert config.intent.skill_roots == [".cursor/skills"]
+    assert config.intent.skills_loop_enabled is False
+    assert config.intent.max_feedback_events_per_cycle == 77
+    assert config.exploration.endpoint == "http://127.0.0.1:11434"
+    assert config.exploration.model == "qwen2.5-coder:14b"
     assert config.privacy.allowed_paths == ["src/**"]
     assert config.max_age_seconds == 120
     assert config.max_context_tokens == 2048

--- a/tests/test_cli/test_config_generic_setter.py
+++ b/tests/test_cli/test_config_generic_setter.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+from vaner.cli.commands.config import load_config
+from vaner.cli.commands.init import init_repo
+
+
+def test_config_set_supports_backend_and_nested_gateway_keys(temp_repo) -> None:
+    init_repo(temp_repo)
+    runner = CliRunner()
+    result_model = runner.invoke(app, ["config", "set", "backend.model", "qwen3.5:35b", "--path", str(temp_repo)])
+    result_route = runner.invoke(
+        app,
+        ["config", "set", "gateway.routes.default", "https://api.openai.com/v1", "--path", str(temp_repo)],
+    )
+    result_skills = runner.invoke(app, ["config", "set", "intent.skills_loop.enabled", "false", "--path", str(temp_repo)])
+    assert result_model.exit_code == 0
+    assert result_route.exit_code == 0
+    assert result_skills.exit_code == 0
+    config = load_config(temp_repo)
+    assert config.backend.model == "qwen3.5:35b"
+    assert config.gateway.routes["default"] == "https://api.openai.com/v1"
+    assert config.intent.skills_loop_enabled is False

--- a/tests/test_cli/test_config_keys.py
+++ b/tests/test_cli/test_config_keys.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+from vaner.cli.commands.init import init_repo
+
+
+def test_config_keys_lists_schema_and_skills_loop_alias(temp_repo) -> None:
+    init_repo(temp_repo)
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "keys", "--path", str(temp_repo)])
+    assert result.exit_code == 0
+    assert "backend.model" in result.stdout
+    assert "intent.skills_loop.enabled" in result.stdout
+    assert "gateway.routes.<prefix>" in result.stdout

--- a/tests/test_cli/test_config_set_list_value.py
+++ b/tests/test_cli/test_config_set_list_value.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+from vaner.cli.commands.config import load_config
+from vaner.cli.commands.init import init_repo
+
+
+def test_config_set_list_value_round_trips(temp_repo) -> None:
+    init_repo(temp_repo)
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "set", "intent.skill_roots", '[".cursor/skills"]', "--path", str(temp_repo)])
+    assert result.exit_code == 0
+    config = load_config(temp_repo)
+    assert config.intent.skill_roots == [".cursor/skills"]

--- a/tests/test_cli/test_config_show_handles_paths.py
+++ b/tests/test_cli/test_config_show_handles_paths.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+from vaner.cli.commands.init import init_repo
+
+
+def test_config_show_json_serializes_path_fields(temp_repo) -> None:
+    init_repo(temp_repo)
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "show", "--path", str(temp_repo), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["repo_root"] == str(temp_repo.resolve())

--- a/tests/test_cli/test_distill_skill.py
+++ b/tests/test_cli/test_distill_skill.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import time
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands import app
+
+runner = CliRunner()
+
+
+def test_distill_skill_command_writes_skill(temp_repo):
+    decisions_dir = temp_repo / ".vaner" / "runtime" / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    decision_id = "dec_123"
+    payload = {
+        "id": decision_id,
+        "prompt": "investigate flaky test",
+        "prompt_hash": "abc",
+        "assembled_at": time.time(),
+        "cache_tier": "full_hit",
+        "partial_similarity": 0.0,
+        "token_budget": 4000,
+        "token_used": 300,
+        "selections": [
+            {
+                "artefact_key": "file_summary:tests/test_api.py",
+                "source_path": "tests/test_api.py",
+                "final_score": 0.9,
+                "token_count": 120,
+                "stale": False,
+                "kept": True,
+                "drop_reason": None,
+                "rationale": "contains failing assertion",
+                "factors": [],
+            }
+        ],
+        "prediction_links": {},
+        "notes": [],
+    }
+    (decisions_dir / f"{decision_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+    result = runner.invoke(app.app, ["distill-skill", decision_id, "--path", str(temp_repo)])
+    assert result.exit_code == 0
+    output = temp_repo / ".cursor" / "skills" / "vaner-distilled" / "investigate-flaky-test" / "SKILL.md"
+    assert output.exists()
+    text = output.read_text(encoding="utf-8")
+    assert "x-vaner-managed: true" in text
+    assert "Source decision id" in text

--- a/tests/test_cli/test_doctor_release_probe.py
+++ b/tests/test_cli/test_doctor_release_probe.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands import app
+
+runner = CliRunner()
+
+
+def test_doctor_release_probe_reports_outdated_install(temp_repo, monkeypatch) -> None:
+    (temp_repo / ".vaner").mkdir(parents=True, exist_ok=True)
+    (temp_repo / ".vaner" / "config.toml").write_text(
+        """
+[backend]
+base_url = "http://127.0.0.1:11434/v1"
+model = "qwen2.5-coder:7b"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    class _Resp:
+        def __init__(self, status_code: int, payload: dict[str, object] | None = None) -> None:
+            self.status_code = status_code
+            self._payload = payload or {}
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    def _fake_get(url: str, *args, **kwargs):  # noqa: ANN001
+        if "pypi.org/pypi/vaner/json" in url:
+            return _Resp(200, {"info": {"version": "999.0.0"}})
+        if url.endswith("/health"):
+            return _Resp(200)
+        return _Resp(404)
+
+    monkeypatch.setenv("VANER_DOCTOR_CHECK_UPDATES", "1")
+    monkeypatch.setenv("VANER_SKIP_MCP_BOOT_PROBE", "1")
+    monkeypatch.setattr(app.httpx, "get", _fake_get)
+
+    result = runner.invoke(app.app, ["doctor", "--path", str(temp_repo), "--json"])
+    payload = json.loads(result.stdout)
+    release_probe = next(item for item in payload["checks"] if item["name"] == "vaner_release_probe")
+    assert release_probe["ok"] is False
+    assert "vaner upgrade" in release_probe["fix"]

--- a/tests/test_cli/test_help_grouping.py
+++ b/tests/test_cli/test_help_grouping.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+
+
+def test_help_includes_expected_panels() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for panel in (
+        "Get started",
+        "Use with an agent",
+        "Inspect and debug",
+        "Background and local",
+        "Configure",
+        "Benchmark",
+    ):
+        assert panel in result.stdout

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from vaner.cli.commands.init import init_repo
+from pathlib import Path
+
+from vaner.cli.commands.init import init_repo, write_mcp_configs
 
 
 def test_init_creates_config(temp_repo):
@@ -14,3 +16,28 @@ def test_init_creates_config(temp_repo):
     assert "[mcp]" in content
     assert "[compute]" in content
     assert "idle_only = true" in content
+    assert "[intent]" in content
+    assert "[intent.skills_loop]" in content
+
+
+def test_init_writes_managed_feedback_skill(temp_repo, monkeypatch):
+    fake_home = temp_repo / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    write_mcp_configs(temp_repo)
+    assert (temp_repo / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md").exists()
+    assert (fake_home / ".claude" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md").exists()
+
+
+def test_write_mcp_configs_prefers_absolute_vaner_binary(temp_repo, monkeypatch):
+    fake_home = temp_repo / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr("vaner.cli.commands.init.shutil.which", lambda name: "/usr/local/bin/vaner" if name == "vaner" else None)
+    written, launcher = write_mcp_configs(temp_repo)
+    assert written
+    assert launcher == "/usr/local/bin/vaner"
+    cursor_payload = (temp_repo / ".cursor" / "mcp.json").read_text(encoding="utf-8")
+    assert "/usr/local/bin/vaner" in cursor_payload

--- a/tests/test_cli/test_scenarios_commands.py
+++ b/tests/test_cli/test_scenarios_commands.py
@@ -124,7 +124,9 @@ def test_init_writes_cursor_mcp_config(temp_repo, monkeypatch):
     cursor_mcp = temp_repo / ".cursor" / "mcp.json"
     assert cursor_mcp.exists()
     payload = json.loads(cursor_mcp.read_text(encoding="utf-8"))
-    assert payload["mcpServers"]["vaner"]["command"] == "vaner"
+    server = payload["mcpServers"]["vaner"]
+    assert server["command"]
+    assert "mcp" in server["args"]
 
 
 def test_scenarios_expand_and_compare_json(temp_repo, monkeypatch):

--- a/tests/test_cli/test_version_flag.py
+++ b/tests/test_cli/test_version_flag.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from vaner import __version__
+from vaner.cli.commands.app import app
+
+
+def test_version_flag_outputs_installed_version() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert f"vaner {__version__}" in result.stdout

--- a/tests/test_intent/test_frontier_feedback_loop.py
+++ b/tests/test_intent/test_frontier_feedback_loop.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+
+from vaner.models.scenario import Scenario
+from vaner.store.scenarios import ScenarioStore
+
+
+def test_consume_feedback_marks_processed(temp_repo):
+    async def _run() -> tuple[int, int]:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.upsert(
+            Scenario(
+                id="scn_processed",
+                kind="change",
+                score=0.5,
+                confidence=0.5,
+                entities=[],
+                evidence=[],
+                prepared_context="ctx",
+                coverage_gaps=[],
+                freshness="fresh",
+                cost_to_expand="low",
+            )
+        )
+        await store.record_outcome("scn_processed", "useful", skill="vaner-feedback", source="skill")
+        first = await store.consume_feedback(limit=10)
+        second = await store.consume_feedback(limit=10)
+        return len(first), len(second)
+
+    first_count, second_count = asyncio.run(_run())
+    assert first_count == 1
+    assert second_count == 0
+
+
+def test_consume_feedback_returns_entries_for_known_scenario(temp_repo):
+    async def _run() -> list[tuple[str, bool]]:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.upsert(
+            Scenario(
+                id="scn_feedback",
+                kind="change",
+                score=0.6,
+                confidence=0.6,
+                entities=[],
+                evidence=[],
+                prepared_context="ctx",
+                coverage_gaps=[],
+                freshness="fresh",
+                cost_to_expand="low",
+            )
+        )
+        await store.record_outcome("scn_feedback", "partial", skill="vaner-feedback", source="skill")
+        return await store.consume_feedback(limit=10)
+
+    feedback = asyncio.run(_run())
+    assert feedback == [("skill", True)]

--- a/tests/test_intent/test_frontier_skill_seed.py
+++ b/tests/test_intent/test_frontier_skill_seed.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vaner.intent.frontier import ExplorationFrontier
+from vaner.intent.skills_discovery import SkillRef
+
+
+def test_seed_from_skills_admits_scenarios(temp_repo: Path) -> None:
+    frontier = ExplorationFrontier(min_priority=0.01)
+    skills = [
+        SkillRef(
+            name="review",
+            path=temp_repo / ".cursor" / "skills" / "review" / "SKILL.md",
+            tags=["review"],
+            triggers=["tests/*.py"],
+            vaner_kind="research",
+        )
+    ]
+    available = ["tests/test_api.py", "src/app.py"]
+    admitted = frontier.seed_from_skills(skills, available)
+    assert admitted == 1
+    popped = frontier.pop()
+    assert popped is not None
+    assert popped.source == "skill"
+    assert "tests/test_api.py" in popped.file_paths

--- a/tests/test_intent/test_skills_discovery.py
+++ b/tests/test_intent/test_skills_discovery.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vaner.intent.skills_discovery import discover_skills
+
+
+def test_discover_skills_reads_frontmatter(temp_repo: Path) -> None:
+    skill_file = temp_repo / ".cursor" / "skills" / "demo" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True, exist_ok=True)
+    skill_file.write_text(
+        """---
+name: demo-skill
+description: Demo skill
+tags: [python, tests]
+triggers: ["src/*.py"]
+vaner:
+  kind: debug
+---
+body
+""",
+        encoding="utf-8",
+    )
+    skills = discover_skills(temp_repo, include_global=False)
+    assert len(skills) == 1
+    assert skills[0].name == "demo-skill"
+    assert skills[0].vaner_kind == "debug"
+    assert "python" in skills[0].tags
+
+
+def test_discover_skills_excludes_global_when_disabled(temp_repo: Path) -> None:
+    external_root = temp_repo.parent / "global-skills"
+    external_skill = external_root / "g" / "SKILL.md"
+    external_skill.parent.mkdir(parents=True, exist_ok=True)
+    external_skill.write_text("---\nname: g\n---\n", encoding="utf-8")
+    skills = discover_skills(
+        temp_repo,
+        include_global=False,
+        skill_roots=[str(external_root)],
+    )
+    assert skills == []

--- a/tests/test_mcp/test_scenario_tools.py
+++ b/tests/test_mcp/test_scenario_tools.py
@@ -60,7 +60,10 @@ def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
         assert "legacy_get_metrics" not in names
 
         listed_scenarios = await call_handler(
-            CallToolRequest(method="tools/call", params={"name": "list_scenarios", "arguments": {"limit": 5}})
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "list_scenarios", "arguments": {"limit": 5, "skill": "vaner-feedback"}},
+            )
         )
         payload = json.loads(listed_scenarios.root.content[0].text)
         assert payload["count"] >= 1
@@ -79,7 +82,10 @@ def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
         assert unknown_payload["count"] == 0
 
         fetched = await call_handler(
-            CallToolRequest(method="tools/call", params={"name": "get_scenario", "arguments": {"id": "scn_mcp_1"}})
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "get_scenario", "arguments": {"id": "scn_mcp_1", "skill": "vaner-feedback"}},
+            )
         )
         scenario = json.loads(fetched.root.content[0].text)
         assert scenario["id"] == "scn_mcp_1"
@@ -139,7 +145,10 @@ def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
         outcome = await call_handler(
             CallToolRequest(
                 method="tools/call",
-                params={"name": "report_outcome", "arguments": {"id": "scn_mcp_1", "result": "useful"}},
+                params={
+                    "name": "report_outcome",
+                    "arguments": {"id": "scn_mcp_1", "result": "useful", "skill": "vaner-feedback"},
+                },
             )
         )
         assert json.loads(outcome.root.content[0].text)["ok"] is True
@@ -154,10 +163,15 @@ def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
 
         async with aiosqlite.connect(temp_repo / ".vaner" / "metrics.db") as db:
             cur = await db.execute(
-                "SELECT COUNT(*) FROM mcp_tool_calls WHERE tool_name = ? AND status = ?",
-                ("list_scenarios", "ok"),
+                "SELECT COUNT(*) FROM mcp_tool_calls WHERE tool_name = ? AND status = ? AND skill = ?",
+                ("list_scenarios", "ok", "vaner-feedback"),
             )
             assert int((await cur.fetchone())[0]) >= 1
+            outcome_cur = await db.execute(
+                "SELECT COUNT(*) FROM scenario_outcomes WHERE scenario_id = ? AND skill = ?",
+                ("scn_mcp_1", "vaner-feedback"),
+            )
+            assert int((await outcome_cur.fetchone())[0]) >= 1
 
     asyncio.run(_run())
 

--- a/tests/test_telemetry/test_scenario_metrics.py
+++ b/tests/test_telemetry/test_scenario_metrics.py
@@ -18,12 +18,18 @@ def test_record_scenario_outcome_and_mcp_tool_call(temp_repo):
             status="ok",
             latency_ms=12.3,
             scenario_id="scn_1",
+            skill="vaner-feedback",
         )
-        await store.record_scenario_outcome(scenario_id="scn_1", result="useful", note="high quality")
+        await store.record_scenario_outcome(
+            scenario_id="scn_1",
+            result="useful",
+            note="high quality",
+            skill="vaner-feedback",
+        )
         async with aiosqlite.connect(db_path) as db:
-            mcp_cur = await db.execute("SELECT COUNT(*) FROM mcp_tool_calls")
+            mcp_cur = await db.execute("SELECT COUNT(*) FROM mcp_tool_calls WHERE skill = ?", ("vaner-feedback",))
             mcp_count = int((await mcp_cur.fetchone())[0])
-            out_cur = await db.execute("SELECT COUNT(*) FROM scenario_outcomes")
+            out_cur = await db.execute("SELECT COUNT(*) FROM scenario_outcomes WHERE skill = ?", ("vaner-feedback",))
             outcome_count = int((await out_cur.fetchone())[0])
         return mcp_count, outcome_count
 


### PR DESCRIPTION
## Summary
- rename and document exploration/config schema keys, dedupe embedding device ownership, and align runtime wiring
- polish CLI UX with grouped help, version flag, richer `config` commands, stronger doctor diagnostics, and safer completion/MCP setup paths
- land the skills-loop closed-loop artifacts (`distill-skill`, managed feedback skill scaffolding, scenario feedback plumbing) plus docs/tests

## Test plan
- [x] `pytest -q tests/test_cli`
- [x] `pytest -q tests/test_engine.py tests/test_api.py tests/test_intent tests/test_mcp tests/test_telemetry`
- [x] `ruff check src tests`
- [x] `python -m compileall -q src`

Made with [Cursor](https://cursor.com)