### PR TITLE
feat(onboarding): ship supervised startup rescue and hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-20
+
+### Added
+
+- Added `vaner up` and `vaner down` to run daemon and cockpit as one supervised flow with a single startup command.
+- Added preflight safeguards for unsafe repo roots, inotify headroom checks, and proactive port selection.
+- Added runtime log tailing for daemon and cockpit via `vaner logs`.
+- Added fallback from inotify to polling watchers when Linux watch limits are exhausted.
+- Added runtime snapshot checks that power both `vaner status` and `vaner doctor` consistently.
+- Added new diagnostics for `repo_root_sensible`, `inotify_headroom`, and `cli_up_to_date`.
+
+### Changed
+
+- Hardened background daemon startup with dead-on-arrival detection and startup error surfacing.
+- Hardened cockpit startup with explicit busy-port remediation guidance and fallback port suggestions.
+- Updated onboarding docs, troubleshooting docs, README, and installer/landing callouts to make `vaner up` the primary post-install flow.
+
 ## [0.3.0] - 2026-04-20
 
 ### Added
@@ -22,6 +39,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Cockpit now serves an interactive dashboard at `/` (scenario cards, outcome actions, compute device switching), and `/ui` redirects to `/` for backwards compatibility.
 - CLI UX polish:
   - added `vaner --version`, grouped help panels, and command aliases (`ls`, `ps`, `logs`)
   - added `config get`, `config keys`, and `config edit`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
 repository-code: "https://github.com/Borgels/vaner"
 url: "https://vaner.ai"
 license: "Apache-2.0"
-version: "0.3.0"
+version: "0.4.0"
 date-released: "2026-04-20"

--- a/README.md
+++ b/README.md
@@ -67,10 +67,32 @@ vaner init --path .                 # initialize this repo + pick backend intera
 vaner mcp --path .                  # smoke-test the MCP server in stdio mode
 ```
 
-### 3. Run it
+### 3. Start Vaner
+
+```bash
+# in your project repo
+vaner up --path .
+```
+
+`vaner up` starts both the background daemon and cockpit, opens `http://127.0.0.1:8473/`,
+and keeps them supervised in one command. Press `Ctrl+C` (or run `vaner down`) to stop.
+
+If nothing seems to happen, run:
+
+```bash
+vaner doctor --path .
+```
+
+Advanced (manual mode):
 
 ```bash
 vaner daemon start --no-once --path .
+vaner daemon serve-http --path .
+```
+
+Optional local debugging:
+
+```bash
 vaner query "where is auth enforced?" --explain --path .
 vaner inspect --last --path .
 ```

--- a/ide/vscode/package-lock.json
+++ b/ide/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaner-cockpit",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaner-cockpit",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "devDependencies": {
         "@types/node": "^20.14.12",
         "@types/vscode": "^1.92.0",

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vaner-cockpit",
   "displayName": "Vaner Cockpit",
   "description": "Local Vaner cockpit for VS Code and Cursor.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "borgels",
   "engines": {
     "vscode": "^1.92.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vaner"
-version = "0.3.0"
+version = "0.4.0"
 description = "Predictive context middleware layer for AI workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -894,11 +894,13 @@ print_footer() {
     ui_success "Vaner installed successfully"
   fi
   printf '\nNext steps:\n'
-  printf '  vaner init --path .            # initialize this repo\n'
-  printf '  vaner daemon start --no-once --path .\n'
-  printf '  vaner query "where is auth enforced?" --path .\n'
+  printf '  cd /path/to/your/repo\n'
+  printf '  vaner up --path .              # starts daemon + cockpit together\n'
+  printf '  vaner doctor --path .          # if anything looks off\n'
   printf '\nConnect your AI client over MCP:\n'
   printf '  https://docs.vaner.ai/mcp      # Claude Code, Cursor, VS Code, Codex, ...\n'
+  printf '\nTroubleshooting:\n'
+  printf '  https://docs.vaner.ai/troubleshooting\n'
   if [[ "$VANER_NO_MCP" == "1" ]]; then
     printf '\n  Note: installed without the [mcp] extra. Re-run without --no-mcp to enable\n'
     printf "        'vaner mcp' for client integration.\n"

--- a/src/vaner/_version.py
+++ b/src/vaner/_version.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "0.3.0"
+VERSION = "0.4.0"

--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -7,11 +7,13 @@ import ipaddress
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import tomllib
 import traceback
 from datetime import UTC, datetime
+from errno import EADDRINUSE
 from pathlib import Path
 from time import perf_counter
 from typing import Any, get_origin
@@ -22,12 +24,24 @@ import typer
 from pydantic import TypeAdapter
 from pydantic_core import to_jsonable_python
 from rich.console import Console
+from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from vaner import __version__, api
 from vaner.cli.commands.config import load_config, set_compute_value, set_config_value
-from vaner.cli.commands.daemon import daemon_status, run_daemon_forever, start_daemon, stop_daemon
+from vaner.cli.commands.daemon import (
+    COCKPIT_PROCESS,
+    DAEMON_PROCESS,
+    clear_pid,
+    daemon_status,
+    log_path,
+    process_status,
+    run_daemon_forever,
+    start_daemon,
+    stop_daemon,
+    write_pid,
+)
 from vaner.cli.commands.distill import distill_skill_file
 from vaner.cli.commands.explain import render_human, render_json
 from vaner.cli.commands.init import (
@@ -44,7 +58,10 @@ from vaner.cli.commands.inspect import inspect_decision as inspect_decision_outp
 from vaner.cli.commands.inspect import inspect_last as inspect_last_output
 from vaner.cli.commands.inspect import list_decisions as list_decisions_output
 from vaner.cli.commands.profile import export_pins, import_pins, pin_fact, profile_show, unpin_fact
+from vaner.cli.commands.runtime_snapshot import runtime_snapshot
+from vaner.cli.commands.supervisor import run_down, run_up
 from vaner.daemon.http import create_daemon_http_app
+from vaner.daemon.preflight import check_repo_root
 from vaner.daemon.runner import VanerDaemon
 from vaner.eval import evaluate_repo, run_eval
 from vaner.models.config import VanerConfig
@@ -139,6 +156,19 @@ def _friendly_error_message(exc: Exception) -> str:
     if isinstance(exc, aiosqlite.Error):
         return f"Database error: {exc}. Remove `.vaner/store.db` if it is corrupted, then rerun."
     return f"Vaner failed: {exc}"
+
+
+def _is_port_free(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.2)
+        return sock.connect_ex((host, port)) != 0
+
+
+def _next_free_port(host: str, start_port: int, max_offset: int = 10) -> int | None:
+    for candidate in range(start_port, start_port + max_offset + 1):
+        if _is_port_free(host, candidate):
+            return candidate
+    return None
 
 
 def _detect_local_runtime() -> dict[str, object]:
@@ -467,6 +497,17 @@ def init(
         typer.echo("Recommended: curl -fsSL https://vaner.ai/install.sh | bash -s -- --with-ollama")
     typer.echo(f"Hardware profile: device={hardware['device']} gpu_count={hardware['gpu_count']} vram_gb={hardware['vram_gb']}")
     typer.echo("Next: connect your AI client → https://docs.vaner.ai/mcp")
+    checklist_lines = [
+        "1. Start the background worker: `vaner daemon start` (or `vaner daemon run-forever`).",
+        "2. Ensure local runtime is ready: `ollama serve`, then `ollama pull <model>`.",
+        "3. Open the cockpit: `vaner show` (http://127.0.0.1:8473/).",
+        "4. Enable the `vaner` MCP tool in your client and reload the window.",
+        "5. Ask the agent to use Vaner MCP tools for non-trivial tasks.",
+        "",
+        "Vaner is local-first. No background process runs unless you start the daemon",
+        "or your MCP client invokes it. `vaner doctor` will tell you what's missing.",
+    ]
+    _console.print(Panel("\n".join(checklist_lines), title="What happens next", border_style="cyan"))
     has_vscode = (repo_root / ".vscode").exists() or os.environ.get("TERM_PROGRAM") == "vscode"
     has_cursor = os.environ.get("CURSOR_TRACE_ID") is not None or os.environ.get("CURSOR_AGENT") is not None
     if has_vscode or has_cursor:
@@ -493,8 +534,13 @@ def daemon_start(
     path: str | None = typer.Option(None, help="Repository root"),
     once: bool = typer.Option(True, help="Run one cycle only"),
     interval_seconds: int = typer.Option(15, "--interval-seconds", help="Loop interval for background mode"),
+    force: bool = typer.Option(False, "--force", help="Allow broad/non-repo root paths."),
 ) -> None:
-    written = start_daemon(_repo_root(path), once=once, interval_seconds=interval_seconds)
+    repo_root = _repo_root(path)
+    root_check = check_repo_root(repo_root, force=force)
+    if not root_check.get("ok"):
+        _fail(str(root_check.get("detail")), hint=str(root_check.get("fix")))
+    written = start_daemon(repo_root, once=once, interval_seconds=interval_seconds)
     typer.echo(f"Daemon started. Artefacts written: {written}")
 
 
@@ -528,7 +574,30 @@ def daemon_serve_http(
     repo_root = _repo_root(path)
     config = load_config(repo_root)
     app_instance = create_daemon_http_app(config)
-    uvicorn.run(app_instance, host=host, port=port)
+    write_pid(repo_root, COCKPIT_PROCESS, os.getpid())
+    try:
+        uvicorn.run(app_instance, host=host, port=port)
+    except OSError as exc:
+        if exc.errno not in {EADDRINUSE, 98}:
+            raise
+        current = process_status(repo_root, COCKPIT_PROCESS)
+        next_port = _next_free_port(host, port)
+        if current.get("running") and current.get("pid") != os.getpid():
+            _fail(
+                f"Cockpit port {host}:{port} is already in use by an existing Vaner cockpit process.",
+                hint="Run `vaner down --path .` or use a different port with `vaner daemon serve-http --port <port>`.",
+            )
+        if next_port is not None:
+            _fail(
+                f"Cockpit port {host}:{port} is busy.",
+                hint=f"Try `vaner daemon serve-http --path . --host {host} --port {next_port}`.",
+            )
+        _fail(
+            f"Cockpit port {host}:{port} is busy and no fallback port was found.",
+            hint="Free the port or stop conflicting process, then rerun `vaner daemon serve-http`.",
+        )
+    finally:
+        clear_pid(repo_root, COCKPIT_PROCESS)
 
 
 @app.command("inspect", help="Inspect context decision records.", rich_help_panel="Inspect and debug")
@@ -1248,7 +1317,7 @@ def show(
     """Open the local web cockpit in the default browser."""
     import webbrowser
 
-    target_url = f"{cockpit_url.rstrip('/')}/ui"
+    target_url = f"{cockpit_url.rstrip('/')}/"
     opened = webbrowser.open(target_url)
     if opened:
         typer.echo(f"Opened {target_url}")
@@ -1256,14 +1325,134 @@ def show(
         typer.echo(f"Open this URL manually: {target_url}")
 
 
+@app.command("up", help="Start daemon and cockpit together.", rich_help_panel="Get started")
+def up(
+    path: str | None = typer.Option(None, help="Repository root"),
+    host: str = typer.Option("127.0.0.1", "--host", help="Cockpit host"),
+    port: int = typer.Option(8473, "--port", help="Cockpit port"),
+    interval_seconds: int = typer.Option(15, "--interval-seconds", help="Daemon loop interval"),
+    open_browser: bool | None = typer.Option(
+        None,
+        "--open/--no-open",
+        help="Open cockpit in browser. Defaults to true on TTY sessions.",
+    ),
+    detach: bool = typer.Option(False, "--detach", help="Start processes and return immediately."),
+    force: bool = typer.Option(False, "--force", help="Allow broad/non-repo root paths."),
+) -> None:
+    """Start a supervised local Vaner session."""
+    should_open = _console.is_terminal if open_browser is None else open_browser
+    payload = run_up(
+        _repo_root(path),
+        host=host,
+        port=port,
+        mcp_sse_port=8472,
+        interval_seconds=interval_seconds,
+        open_browser=should_open,
+        force=force,
+    )
+    if payload.get("reattached"):
+        typer.echo(f"Vaner already running (daemon pid={payload['daemon_pid']}, cockpit pid={payload['cockpit_pid']}).")
+        return
+    cockpit_url = str(payload.get("cockpit_url", f"http://{host}:{port}"))
+    ready = bool(payload.get("ready"))
+    checklist_lines = [
+        f"Daemon PID: {payload.get('daemon_pid')}",
+        f"Cockpit PID: {payload.get('cockpit_pid')}",
+        f"Cockpit URL: {cockpit_url}",
+        "Health: ready" if ready else "Health: still starting (check `vaner logs`).",
+        "Next: run `vaner status` to verify full readiness.",
+    ]
+    ports = payload.get("ports", {})
+    if isinstance(ports, dict) and ports.get("cockpit_changed"):
+        checklist_lines.append(f"Cockpit port auto-shifted to {cockpit_url} because {host}:{port} was busy.")
+    inotify = payload.get("inotify", {})
+    if isinstance(inotify, dict) and not inotify.get("ok", True):
+        checklist_lines.append(
+            f"Inotify warning: {inotify.get('detail')}. Consider `{inotify.get('fix', 'sudo sysctl fs.inotify.max_user_watches=524288')}`."
+        )
+    _console.print(Panel("\n".join(checklist_lines), title="Vaner up", border_style="green" if ready else "yellow"))
+    if detach:
+        return
+    typer.echo("Press Ctrl+C to stop daemon and cockpit.")
+    try:
+        while True:
+            import time as _time
+
+            _time.sleep(1)
+    except KeyboardInterrupt:
+        down_payload = run_down(_repo_root(path))
+        daemon_state = down_payload["daemon"]
+        cockpit_state = down_payload["cockpit"]
+        typer.echo(
+            "Stopped: "
+            f"daemon(pid={daemon_state['pid']}, ok={daemon_state['stopped']}), "
+            f"cockpit(pid={cockpit_state['pid']}, ok={cockpit_state['stopped']})"
+        )
+
+
+@app.command("down", help="Stop daemon and cockpit from `vaner up`.", rich_help_panel="Get started")
+def down(path: str | None = typer.Option(None, help="Repository root")) -> None:
+    payload = run_down(_repo_root(path))
+    daemon_state = payload["daemon"]
+    cockpit_state = payload["cockpit"]
+    typer.echo(
+        "Stopped: "
+        f"daemon(pid={daemon_state['pid']}, ok={daemon_state['stopped']}), "
+        f"cockpit(pid={cockpit_state['pid']}, ok={cockpit_state['stopped']})"
+    )
+
+
 @app.command("logs", help="Alias for `vaner watch`.", rich_help_panel="Use with an agent")
 def logs_alias(
-    cockpit_url: str = typer.Option("http://127.0.0.1:8473", "--cockpit-url", help="Vaner cockpit URL"),
-    as_json: bool = typer.Option(False, "--json", help="Emit raw decision events as JSON"),
-    contains: str | None = typer.Option(None, "--filter", help="Substring filter against serialized decision payload"),
-    limit: int | None = typer.Option(None, "--limit", min=1, help="Stop after N matching events"),
+    path: str | None = typer.Option(None, help="Repository root"),
+    follow: bool = typer.Option(True, "--follow/--no-follow", help="Tail runtime logs continuously."),
+    events: bool = typer.Option(False, "--events", help="Show decision stream events instead of runtime logs."),
+    cockpit_url: str = typer.Option("http://127.0.0.1:8473", "--cockpit-url", help="Vaner cockpit URL for --events mode."),
+    as_json: bool = typer.Option(False, "--json", help="Emit raw decision events as JSON (--events mode)."),
+    contains: str | None = typer.Option(None, "--filter", help="Substring filter for --events mode."),
+    limit: int | None = typer.Option(None, "--limit", min=1, help="Stop after N matching lines/events."),
 ) -> None:
-    watch(cockpit_url=cockpit_url, as_json=as_json, contains=contains, limit=limit)
+    if events:
+        watch(cockpit_url=cockpit_url, as_json=as_json, contains=contains, limit=limit)
+        return
+    repo_root = _repo_root(path)
+    daemon_log = log_path(repo_root, DAEMON_PROCESS)
+    cockpit_log = log_path(repo_root, COCKPIT_PROCESS)
+    paths = [("daemon", daemon_log), ("cockpit", cockpit_log)]
+    for label, file_path in paths:
+        if not file_path.exists():
+            typer.echo(f"[{label}] no log file yet at {file_path}")
+            continue
+        lines = file_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        tail = lines[-20:]
+        for line in tail:
+            typer.echo(f"[{label}] {line}")
+    if not follow:
+        return
+    typer.echo("Following runtime logs... (Ctrl+C to stop)")
+    offsets = {label: (path.stat().st_size if path.exists() else 0) for label, path in paths}
+    emitted = 0
+    try:
+        while True:
+            import time as _time
+
+            for label, file_path in paths:
+                if not file_path.exists():
+                    continue
+                with file_path.open("r", encoding="utf-8", errors="replace") as handle:
+                    handle.seek(offsets[label])
+                    chunk = handle.read()
+                    offsets[label] = handle.tell()
+                if not chunk:
+                    continue
+                for line in chunk.splitlines():
+                    typer.echo(f"[{label}] {line}")
+                    emitted += 1
+                    if limit is not None and emitted >= limit:
+                        return
+            _time.sleep(0.5)
+    except KeyboardInterrupt:
+        return
 
 
 @app.command("ps", help="Alias for `vaner status`.", rich_help_panel="Get started")
@@ -1283,36 +1472,18 @@ def status(
 ) -> None:
     """Show one-screen Vaner health and compute status."""
     repo_root = _repo_root(path)
-    config = load_config(repo_root)
-    daemon = daemon_status(repo_root)
+    snapshot = runtime_snapshot(repo_root, cockpit_url)
+    config = snapshot["config"]
     latest = api.inspect_last_decision(repo_root)
-
-    cockpit_health = {"reachable": False, "detail": ""}
-    try:
-        response = httpx.get(f"{cockpit_url.rstrip('/')}/health", timeout=2.0)
-        cockpit_health["reachable"] = response.status_code == 200
-        cockpit_health["detail"] = response.text
-    except Exception as exc:
-        cockpit_health["detail"] = str(exc)
-
-    scenario_counts: dict[str, int] = {"fresh": 0, "recent": 0, "stale": 0, "total": 0}
-    try:
-        store = ScenarioStore(repo_root / ".vaner" / "scenarios.db")
-        import asyncio
-
-        async def _counts() -> dict[str, int]:
-            await store.initialize()
-            return await store.freshness_counts()
-
-        scenario_counts = asyncio.run(_counts())
-    except Exception:
-        scenario_counts = {"fresh": 0, "recent": 0, "stale": 0, "total": 0}
+    scenario_counts = dict(snapshot["scenario_counts"])
+    daemon_text = str(snapshot["daemon"]["status"])
+    cockpit_ok = bool(snapshot["cockpit_reachable"])
 
     payload = {
         "repo_root": str(repo_root),
-        "daemon": daemon,
+        "daemon": daemon_text,
         "cockpit_url": cockpit_url,
-        "cockpit": cockpit_health,
+        "cockpit": {"reachable": cockpit_ok, "detail": snapshot["cockpit_detail"]},
         "mcp": config.mcp.model_dump(mode="json"),
         "compute": config.compute.model_dump(mode="json"),
         "backend": {
@@ -1323,6 +1494,14 @@ def status(
         "scenarios_ready": scenario_counts["total"],
         "scenario_counts": scenario_counts,
         "last_decision": latest.id if latest else None,
+        "runtime_snapshot": {
+            "daemon_pid_alive": snapshot["daemon_pid_alive"],
+            "cockpit_pid_alive": snapshot["cockpit_pid_alive"],
+            "backend_reachable": snapshot["backend_reachable"],
+            "repo_root_sensible": snapshot["repo_root_sensible"],
+            "inotify_headroom_pct": snapshot["inotify_headroom_pct"],
+            "cli_up_to_date": snapshot["cli_up_to_date"],
+        },
         "timestamp": datetime.now(UTC).isoformat(),
     }
     if as_json:
@@ -1333,7 +1512,7 @@ def status(
     typer.echo("=" * 40)
     typer.echo(f"repo:     {payload['repo_root']}")
     typer.echo(f"daemon:   {payload['daemon']}")
-    typer.echo(f"cockpit:  {'ok' if cockpit_health['reachable'] else 'down'} ({cockpit_url})")
+    typer.echo(f"cockpit:  {'ok' if cockpit_ok else 'down'} ({cockpit_url})")
     typer.echo(f"mcp:      transport={config.mcp.transport} sse={config.mcp.http_host}:{config.mcp.http_port}")
     typer.echo(f"backend:  {config.backend.base_url or '(unset)'} [{config.backend.model or '(unset)'}]")
     typer.echo(
@@ -1345,6 +1524,30 @@ def status(
     typer.echo(f"decision: {payload['last_decision'] or 'none'}")
     typer.echo(f"scenarios:{payload['scenarios_ready']}")
     typer.echo(f"freshness: fresh={scenario_counts['fresh']} recent={scenario_counts['recent']} stale={scenario_counts['stale']}")
+    if not bool(snapshot["repo_root_sensible"]):
+        _console.print(
+            Panel(
+                str(snapshot["repo_root_fix"] or "Use a project repository path instead of your home directory."),
+                title="Next best step",
+                border_style="yellow",
+            )
+        )
+    elif not bool(snapshot["daemon_pid_alive"]):
+        _console.print(
+            Panel(
+                "Start everything with `vaner up --path .` (or run `vaner daemon start --path . --no-once`).",
+                title="Next best step",
+                border_style="yellow",
+            )
+        )
+    elif not cockpit_ok:
+        _console.print(
+            Panel(
+                "Cockpit is down. Run `vaner up --path .` or restart HTTP with `vaner daemon serve-http --path .`.",
+                title="Next best step",
+                border_style="yellow",
+            )
+        )
 
 
 @app.command("doctor", rich_help_panel="Get started")
@@ -1355,6 +1558,7 @@ def doctor(
 ) -> None:
     """Run local diagnostics and print actionable fixes."""
     repo_root = _repo_root(path)
+    snapshot = runtime_snapshot(repo_root, cockpit_url)
     checks: list[dict[str, object]] = []
     config_path = repo_root / ".vaner" / "config.toml"
     checks.append(
@@ -1366,7 +1570,8 @@ def doctor(
         }
     )
 
-    config = load_config(repo_root) if config_path.exists() else None
+    config = snapshot["config"] if config_path.exists() else None
+    runtime: dict[str, object] = {"detected": False}
     if config is not None:
         has_backend = bool(config.backend.base_url.strip() and config.backend.model.strip())
         has_routes = bool(config.gateway.routes)
@@ -1376,6 +1581,34 @@ def doctor(
                 "ok": has_backend or has_routes,
                 "detail": "backend/base_url+model or gateway/routes must be set",
                 "fix": "Set [backend] base_url/model or add [gateway.routes] entries in .vaner/config.toml.",
+            }
+        )
+        checks.append(
+            {
+                "name": "repo_root_sensible",
+                "ok": bool(snapshot["repo_root_sensible"]),
+                "level": "warn" if not snapshot["repo_root_sensible"] else "pass",
+                "detail": snapshot["repo_root_detail"],
+                "fix": snapshot["repo_root_fix"],
+            }
+        )
+        inotify_payload = snapshot["inotify"]
+        checks.append(
+            {
+                "name": "inotify_headroom",
+                "ok": bool(inotify_payload.get("ok", True)),
+                "level": "warn" if not inotify_payload.get("ok", True) else "pass",
+                "detail": inotify_payload.get("detail", ""),
+                "fix": inotify_payload.get("fix", ""),
+            }
+        )
+        checks.append(
+            {
+                "name": "cli_up_to_date",
+                "ok": bool(snapshot["cli_up_to_date"]),
+                "level": "warn" if not snapshot["cli_up_to_date"] else "pass",
+                "detail": snapshot["cli_update_detail"],
+                "fix": "Run `pipx upgrade vaner` (or `vaner upgrade`).",
             }
         )
         checks.append(
@@ -1403,6 +1636,35 @@ def doctor(
                 "fix": "Start Ollama/LM Studio/vLLM so Vaner can precompute scenarios with local hardware.",
             }
         )
+        if runtime.get("name") == "ollama" and config.backend.model.strip():
+            backend_model = config.backend.model.strip()
+            ollama_ok = False
+            ollama_detail = "model not found"
+            try:
+                tags_response = httpx.get("http://127.0.0.1:11434/api/tags", timeout=1.5)
+                tags_response.raise_for_status()
+                payload = tags_response.json()
+                models_payload = payload.get("models", []) if isinstance(payload, dict) else []
+                model_names = {
+                    str(item.get("name", "")).strip()
+                    for item in models_payload
+                    if isinstance(item, dict) and str(item.get("name", "")).strip()
+                }
+                ollama_ok = backend_model in model_names
+                if model_names:
+                    ollama_detail = f"backend_model={backend_model} installed={', '.join(sorted(model_names)[:5])}"
+                else:
+                    ollama_detail = "no models returned by /api/tags"
+            except Exception as exc:
+                ollama_detail = str(exc)
+            checks.append(
+                {
+                    "name": "ollama_model_pulled",
+                    "ok": ollama_ok,
+                    "detail": ollama_detail,
+                    "fix": f"Run `ollama pull {backend_model}` to install the configured model.",
+                }
+            )
         is_cloud_backend = config.backend.base_url.startswith("https://")
         if is_cloud_backend and not runtime.get("detected"):
             checks.append(
@@ -1414,25 +1676,22 @@ def doctor(
                 }
             )
 
-    try:
-        health = httpx.get(f"{cockpit_url.rstrip('/')}/health", timeout=2.0)
-        checks.append(
-            {
-                "name": "cockpit_reachable",
-                "ok": health.status_code == 200,
-                "detail": f"status={health.status_code}",
-                "fix": "Start the cockpit server with `vaner daemon serve-http`.",
-            }
-        )
-    except Exception as exc:
-        checks.append(
-            {
-                "name": "cockpit_reachable",
-                "ok": False,
-                "detail": str(exc),
-                "fix": "Start the cockpit server with `vaner daemon serve-http`.",
-            }
-        )
+    checks.append(
+        {
+            "name": "cockpit_reachable",
+            "ok": bool(snapshot["cockpit_reachable"]),
+            "detail": str(snapshot["cockpit_detail"]),
+            "fix": "Start everything with `vaner up --path .` (or run `vaner daemon serve-http --path .`).",
+        }
+    )
+    checks.append(
+        {
+            "name": "daemon_running",
+            "ok": bool(snapshot["daemon_pid_alive"]),
+            "detail": str(snapshot["daemon"]["status"]),
+            "fix": "Run `vaner up --path .` (or `vaner daemon start --path . --no-once`).",
+        }
+    )
 
     cursor_mcp_path = repo_root / ".cursor" / "mcp.json"
     claude_mcp_path = Path.home() / ".claude" / "claude_desktop_config.json"
@@ -1444,6 +1703,16 @@ def doctor(
             "fix": "Run `vaner init` to scaffold MCP client configuration files.",
         }
     )
+    if cursor_mcp_path.exists():
+        checks.append(
+            {
+                "name": "mcp_client_instructions",
+                "ok": False,
+                "level": "warn",
+                "detail": "Cursor MCP config found.",
+                "fix": "Reload Cursor after `vaner init` so the MCP server is picked up.",
+            }
+        )
     mcp_commands: list[str] = []
     for path_candidate in (cursor_mcp_path, claude_mcp_path):
         if not path_candidate.exists():
@@ -1523,27 +1792,6 @@ def doctor(
                         "fix": "Run `vaner mcp --path .` manually to inspect startup errors.",
                     }
                 )
-    if os.environ.get("VANER_DOCTOR_CHECK_UPDATES", "").strip() == "1":
-        try:
-            response = httpx.get("https://pypi.org/pypi/vaner/json", timeout=1.5)
-            latest = str(response.json().get("info", {}).get("version", "")).strip()
-            checks.append(
-                {
-                    "name": "vaner_release_probe",
-                    "ok": (not latest) or latest == __version__,
-                    "detail": f"installed={__version__} latest={latest or 'unknown'}",
-                    "fix": "Run `vaner upgrade` to install the latest release.",
-                }
-            )
-        except Exception as exc:
-            checks.append(
-                {
-                    "name": "vaner_release_probe",
-                    "ok": False,
-                    "detail": str(exc),
-                    "fix": "Run `vaner upgrade` to install the latest release.",
-                }
-            )
     try:
         import asyncio
 
@@ -1572,7 +1820,7 @@ def doctor(
             }
         )
 
-    overall_ok = all(bool(item["ok"]) for item in checks)
+    overall_ok = all(bool(item["ok"]) or item.get("level") == "warn" for item in checks)
     payload = {"ok": overall_ok, "checks": checks}
     if as_json:
         typer.echo(json.dumps(payload, indent=2))
@@ -1581,9 +1829,12 @@ def doctor(
     _console.print("[bold]Vaner doctor[/bold]")
     _console.print("=" * 40)
     for check in checks:
-        mark = "[green]PASS[/green]" if check["ok"] else "[red]FAIL[/red]"
+        if check.get("level") == "warn":
+            mark = "[yellow]WARN[/yellow]"
+        else:
+            mark = "[green]PASS[/green]" if check["ok"] else "[red]FAIL[/red]"
         _console.print(f"{mark} {check['name']}: {check['detail']}")
-        if not check["ok"] and check["fix"]:
+        if (not check["ok"] or check.get("level") == "warn") and check["fix"]:
             _console.print(f"       fix: {_format_fix_hint(str(check['fix']))}")
     raise typer.Exit(code=0 if overall_ok else 1)
 

--- a/src/vaner/cli/commands/daemon.py
+++ b/src/vaner/cli/commands/daemon.py
@@ -7,19 +7,31 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from vaner import api
 from vaner.cli.commands.config import load_config
 from vaner.daemon.runner import VanerDaemon
 
+DAEMON_PROCESS = "daemon"
+COCKPIT_PROCESS = "cockpit"
 
-def pid_path(repo_root: Path) -> Path:
-    return repo_root / ".vaner" / "runtime" / "daemon.pid"
+
+def runtime_dir(repo_root: Path) -> Path:
+    return repo_root / ".vaner" / "runtime"
 
 
-def _read_pid(repo_root: Path) -> int | None:
-    path = pid_path(repo_root)
+def pid_path(repo_root: Path, process_name: str = DAEMON_PROCESS) -> Path:
+    return runtime_dir(repo_root) / f"{process_name}.pid"
+
+
+def log_path(repo_root: Path, process_name: str) -> Path:
+    return runtime_dir(repo_root) / "logs" / f"{process_name}.log"
+
+
+def _read_pid(repo_root: Path, process_name: str = DAEMON_PROCESS) -> int | None:
+    path = pid_path(repo_root, process_name)
     if not path.exists():
         return None
     raw = path.read_text(encoding="utf-8").strip()
@@ -37,33 +49,76 @@ def _is_pid_running(pid: int) -> bool:
         return False
 
 
+def _tail_log(log_file: Path, max_lines: int = 12) -> str:
+    if not log_file.exists():
+        return ""
+    lines = log_file.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(lines[-max_lines:]).strip()
+
+
+def write_pid(repo_root: Path, process_name: str, pid: int) -> None:
+    path = pid_path(repo_root, process_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{pid}\n", encoding="utf-8")
+
+
+def clear_pid(repo_root: Path, process_name: str) -> None:
+    pid_path(repo_root, process_name).unlink(missing_ok=True)
+
+
+def process_status(repo_root: Path, process_name: str) -> dict[str, object]:
+    pid = _read_pid(repo_root, process_name)
+    running = bool(pid and _is_pid_running(pid))
+    return {
+        "name": process_name,
+        "pid": pid,
+        "running": running,
+        "status": f"running (pid={pid})" if running else "stopped",
+    }
+
+
 def start_daemon(repo_root: Path, once: bool = True, interval_seconds: int = 15) -> int:
-    pid_file = pid_path(repo_root)
-    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    runtime_dir(repo_root).mkdir(parents=True, exist_ok=True)
     if once:
         return api.prepare(repo_root)
 
-    existing_pid = _read_pid(repo_root)
+    existing_pid = _read_pid(repo_root, DAEMON_PROCESS)
     if existing_pid is not None and _is_pid_running(existing_pid):
         return 0
 
-    process = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "vaner.cli.main",
-            "daemon",
-            "run-forever",
-            "--path",
-            str(repo_root),
-            "--interval-seconds",
-            str(interval_seconds),
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-    pid_file.write_text(f"{process.pid}\n", encoding="utf-8")
+    daemon_log_path = log_path(repo_root, DAEMON_PROCESS)
+    daemon_log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_handle = daemon_log_path.open("a", encoding="utf-8")
+    try:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "vaner.cli.main",
+                "daemon",
+                "run-forever",
+                "--path",
+                str(repo_root),
+                "--interval-seconds",
+                str(interval_seconds),
+            ],
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    finally:
+        log_handle.close()
+    exit_code: int | None = None
+    for _ in range(5):
+        time.sleep(0.1)
+        exit_code = process.poll()
+        if exit_code is not None:
+            break
+    if exit_code is not None:
+        details = _tail_log(daemon_log_path)
+        suffix = f"\n{details}" if details else ""
+        raise RuntimeError(f"Background daemon failed to start (exit={exit_code}).{suffix}")
+    write_pid(repo_root, DAEMON_PROCESS, process.pid)
     return 0
 
 
@@ -74,19 +129,16 @@ def run_daemon_forever(repo_root: Path, interval_seconds: int = 15) -> None:
 
 
 def stop_daemon(repo_root: Path) -> bool:
-    pid = _read_pid(repo_root)
+    pid = _read_pid(repo_root, DAEMON_PROCESS)
     if pid is None:
         return False
     try:
         os.kill(pid, signal.SIGTERM)
     except OSError:
         pass
-    pid_path(repo_root).unlink(missing_ok=True)
+    clear_pid(repo_root, DAEMON_PROCESS)
     return True
 
 
 def daemon_status(repo_root: Path) -> str:
-    pid = _read_pid(repo_root)
-    if pid is None:
-        return "stopped"
-    return f"running (pid={pid})" if _is_pid_running(pid) else "stopped"
+    return str(process_status(repo_root, DAEMON_PROCESS)["status"])

--- a/src/vaner/cli/commands/runtime_snapshot.py
+++ b/src/vaner/cli/commands/runtime_snapshot.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import httpx
+
+from vaner import __version__
+from vaner.cli.commands.config import load_config
+from vaner.cli.commands.daemon import COCKPIT_PROCESS, DAEMON_PROCESS, process_status
+from vaner.daemon.preflight import check_inotify_budget, check_repo_root
+from vaner.store.scenarios import ScenarioStore
+
+
+def _probe(url: str, timeout: float = 1.5) -> tuple[bool, str]:
+    try:
+        response = httpx.get(url, timeout=timeout)
+        return response.status_code == 200, f"status={response.status_code}"
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _backend_reachable(base_url: str) -> tuple[bool, str]:
+    stripped = base_url.rstrip("/")
+    if not stripped:
+        return False, "backend URL is unset"
+    tags_url = f"{stripped.replace('/v1', '')}/api/tags" if "/v1" in stripped else f"{stripped}/api/tags"
+    ok, detail = _probe(tags_url, timeout=1.2)
+    return ok, detail
+
+
+def _scenario_counts(repo_root: Path) -> dict[str, int]:
+    async def _counts() -> dict[str, int]:
+        store = ScenarioStore(repo_root / ".vaner" / "scenarios.db")
+        await store.initialize()
+        return await store.freshness_counts()
+
+    try:
+        return asyncio.run(_counts())
+    except Exception:
+        return {"fresh": 0, "recent": 0, "stale": 0, "total": 0}
+
+
+def _release_probe(enabled: bool) -> dict[str, object]:
+    if not enabled:
+        return {"ok": True, "detail": "disabled"}
+    try:
+        response = httpx.get("https://pypi.org/pypi/vaner/json", timeout=0.3)
+        latest = str(response.json().get("info", {}).get("version", "")).strip()
+        up_to_date = (not latest) or latest == __version__
+        return {
+            "ok": up_to_date,
+            "detail": f"installed={__version__} latest={latest or 'unknown'}",
+            "latest": latest,
+        }
+    except Exception as exc:
+        return {"ok": False, "detail": str(exc), "latest": ""}
+
+
+def runtime_snapshot(repo_root: Path, cockpit_url: str) -> dict[str, object]:
+    config = load_config(repo_root)
+    daemon_state = process_status(repo_root, DAEMON_PROCESS)
+    cockpit_state = process_status(repo_root, COCKPIT_PROCESS)
+    cockpit_ok, cockpit_detail = _probe(f"{cockpit_url.rstrip('/')}/health", timeout=1.8)
+    backend_ok, backend_detail = _backend_reachable(config.backend.base_url)
+    root_check = check_repo_root(repo_root, force=False)
+    inotify_check = check_inotify_budget(repo_root)
+    update_check = _release_probe(enabled=os.environ.get("VANER_DOCTOR_CHECK_UPDATES", "1").strip() != "0")
+
+    return {
+        "repo_root": str(repo_root),
+        "config": config,
+        "daemon": daemon_state,
+        "cockpit_process": cockpit_state,
+        "daemon_pid_alive": bool(daemon_state["running"]),
+        "cockpit_pid_alive": bool(cockpit_state["running"]),
+        "cockpit_reachable": cockpit_ok,
+        "cockpit_detail": cockpit_detail,
+        "backend_reachable": backend_ok,
+        "backend_detail": backend_detail,
+        "inotify_headroom_pct": inotify_check.get("headroom_pct", 100.0),
+        "inotify": inotify_check,
+        "repo_root_sensible": bool(root_check.get("ok")),
+        "repo_root_detail": str(root_check.get("detail", "")),
+        "repo_root_fix": str(root_check.get("fix", "")),
+        "cli_up_to_date": bool(update_check.get("ok")),
+        "cli_update_detail": str(update_check.get("detail", "")),
+        "scenario_counts": _scenario_counts(repo_root),
+    }

--- a/src/vaner/cli/commands/supervisor.py
+++ b/src/vaner/cli/commands/supervisor.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+
+import httpx
+
+from vaner.cli.commands.daemon import (
+    COCKPIT_PROCESS,
+    DAEMON_PROCESS,
+    clear_pid,
+    log_path,
+    process_status,
+    runtime_dir,
+    write_pid,
+)
+from vaner.cli.commands.init import init_repo, write_mcp_configs
+from vaner.daemon.preflight import check_inotify_budget, check_ports, check_repo_root
+
+
+def _is_pid_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _stop_pid(pid: int, timeout_seconds: float = 5.0) -> bool:
+    if not _is_pid_running(pid):
+        return True
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        return False
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not _is_pid_running(pid):
+            return True
+        time.sleep(0.1)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+    return not _is_pid_running(pid)
+
+
+def _wait_for_health(cockpit_url: str, timeout_seconds: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    health_url = f"{cockpit_url.rstrip('/')}/health"
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(health_url, timeout=1.0)
+            if response.status_code == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(0.2)
+    return False
+
+
+def _ensure_initialized(repo_root: Path) -> None:
+    config_path = repo_root / ".vaner" / "config.toml"
+    if config_path.exists():
+        return
+    init_repo(repo_root)
+    try:
+        write_mcp_configs(repo_root)
+    except Exception:
+        pass
+
+
+def _spawn_process(command: list[str], logfile: Path) -> subprocess.Popen[bytes]:
+    logfile.parent.mkdir(parents=True, exist_ok=True)
+    log_handle = logfile.open("a", encoding="utf-8")
+    process = subprocess.Popen(
+        command,
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    log_handle.close()
+    return process
+
+
+def run_up(
+    repo_root: Path,
+    *,
+    host: str,
+    port: int,
+    mcp_sse_port: int,
+    interval_seconds: int,
+    open_browser: bool,
+    force: bool = False,
+) -> dict[str, object]:
+    root_check = check_repo_root(repo_root, force=force)
+    if not root_check.get("ok"):
+        raise RuntimeError(str(root_check.get("fix") or root_check.get("detail")))
+    inotify_check = check_inotify_budget(repo_root)
+    _ensure_initialized(repo_root)
+    ports_check = check_ports(host, port, mcp_sse_port)
+    chosen_port = int(ports_check.get("cockpit_port", port))
+    runtime_dir(repo_root).mkdir(parents=True, exist_ok=True)
+    daemon_state = process_status(repo_root, DAEMON_PROCESS)
+    cockpit_state = process_status(repo_root, COCKPIT_PROCESS)
+    if daemon_state["running"] and cockpit_state["running"]:
+        return {
+            "started": False,
+            "reattached": True,
+            "daemon_pid": daemon_state["pid"],
+            "cockpit_pid": cockpit_state["pid"],
+        }
+    if daemon_state["running"] and not cockpit_state["running"]:
+        clear_pid(repo_root, COCKPIT_PROCESS)
+    if cockpit_state["running"] and not daemon_state["running"]:
+        clear_pid(repo_root, DAEMON_PROCESS)
+
+    launcher = [sys.executable, "-m", "vaner.cli.main", "daemon"]
+    daemon_process = _spawn_process(
+        launcher
+        + [
+            "run-forever",
+            "--path",
+            str(repo_root),
+            "--interval-seconds",
+            str(interval_seconds),
+        ],
+        log_path(repo_root, DAEMON_PROCESS),
+    )
+    write_pid(repo_root, DAEMON_PROCESS, daemon_process.pid)
+    cockpit_process = _spawn_process(
+        launcher
+        + [
+            "serve-http",
+            "--path",
+            str(repo_root),
+            "--host",
+            host,
+            "--port",
+            str(chosen_port),
+        ],
+        log_path(repo_root, COCKPIT_PROCESS),
+    )
+    write_pid(repo_root, COCKPIT_PROCESS, cockpit_process.pid)
+
+    cockpit_url = f"http://{host}:{chosen_port}"
+    ready = _wait_for_health(cockpit_url)
+    if open_browser:
+        webbrowser.open(f"{cockpit_url}/")
+
+    return {
+        "started": True,
+        "reattached": False,
+        "ready": ready,
+        "cockpit_url": cockpit_url,
+        "inotify": inotify_check,
+        "ports": ports_check,
+        "daemon_pid": daemon_process.pid,
+        "cockpit_pid": cockpit_process.pid,
+    }
+
+
+def run_down(repo_root: Path) -> dict[str, object]:
+    daemon_state = process_status(repo_root, DAEMON_PROCESS)
+    cockpit_state = process_status(repo_root, COCKPIT_PROCESS)
+
+    stopped_daemon = False
+    stopped_cockpit = False
+    if daemon_state["pid"]:
+        stopped_daemon = _stop_pid(int(daemon_state["pid"]))
+    if cockpit_state["pid"]:
+        stopped_cockpit = _stop_pid(int(cockpit_state["pid"]))
+    clear_pid(repo_root, DAEMON_PROCESS)
+    clear_pid(repo_root, COCKPIT_PROCESS)
+
+    return {
+        "daemon": {"pid": daemon_state["pid"], "stopped": stopped_daemon or not daemon_state["running"]},
+        "cockpit": {"pid": cockpit_state["pid"], "stopped": stopped_cockpit or not cockpit_state["running"]},
+    }

--- a/src/vaner/daemon/cockpit_html.py
+++ b/src/vaner/daemon/cockpit_html.py
@@ -1,0 +1,611 @@
+from __future__ import annotations
+
+from typing import Literal
+
+
+def build_cockpit_html(mode: Literal["daemon", "proxy"]) -> str:
+    if mode not in {"daemon", "proxy"}:
+        raise ValueError(f"Unsupported cockpit mode: {mode}")
+
+    return _COCKPIT_HTML.replace("__VANER_MODE__", mode)
+
+
+_COCKPIT_HTML = """<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Vaner Cockpit</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f6f7f9;
+        --surface: #ffffff;
+        --muted: #6a7280;
+        --border: #d7dde4;
+        --text: #111827;
+        --accent: #2563eb;
+        --fresh: #0f766e;
+        --recent: #0369a1;
+        --stale: #b45309;
+        --warn: #92400e;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #111827;
+          --surface: #1f2937;
+          --muted: #94a3b8;
+          --border: #334155;
+          --text: #f9fafb;
+          --accent: #60a5fa;
+          --fresh: #14b8a6;
+          --recent: #38bdf8;
+          --stale: #fbbf24;
+          --warn: #f59e0b;
+        }
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        line-height: 1.45;
+        background: var(--bg);
+        color: var(--text);
+      }
+      .wrap {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .panel {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 14px;
+        margin-bottom: 14px;
+      }
+      h1, h2 { margin: 0; }
+      h1 { font-size: 1.45rem; }
+      h2 { font-size: 1.05rem; margin-bottom: 10px; }
+      .header {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+      }
+      .subtle { color: var(--muted); font-size: 0.9rem; }
+      .pills, .chips {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .pill, .chip {
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        padding: 4px 10px;
+        font-size: 0.85rem;
+      }
+      .chip.fresh { border-color: color-mix(in srgb, var(--fresh) 60%, var(--border)); }
+      .chip.recent { border-color: color-mix(in srgb, var(--recent) 60%, var(--border)); }
+      .chip.stale { border-color: color-mix(in srgb, var(--stale) 60%, var(--border)); }
+      .status-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #9ca3af;
+      }
+      .status-dot.live { background: #22c55e; }
+      .status-dot.error { background: #ef4444; }
+      .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+      }
+      @media (max-width: 900px) {
+        .grid { grid-template-columns: 1fr; }
+      }
+      .scenario-list {
+        display: grid;
+        gap: 10px;
+      }
+      .scenario-card {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 12px;
+      }
+      .scenario-card.flash {
+        outline: 2px solid color-mix(in srgb, var(--accent) 65%, transparent);
+      }
+      .row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+      }
+      .mono {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.85rem;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      .tag {
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 2px 6px;
+        font-size: 0.8rem;
+      }
+      .warning {
+        margin-top: 8px;
+        border-left: 3px solid var(--warn);
+        padding-left: 8px;
+        color: var(--warn);
+        font-size: 0.86rem;
+      }
+      .actions {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      button {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface);
+        color: var(--text);
+        padding: 6px 10px;
+        cursor: pointer;
+      }
+      button.primary {
+        border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+      }
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      select, input {
+        min-width: 220px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface);
+        color: var(--text);
+        padding: 6px;
+      }
+      details { margin-top: 8px; }
+      pre {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 8px;
+        overflow-x: auto;
+        white-space: pre-wrap;
+      }
+      .toast {
+        position: fixed;
+        right: 14px;
+        bottom: 14px;
+        max-width: 380px;
+        padding: 10px 12px;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        background: var(--surface);
+        display: none;
+      }
+      .toast.show { display: block; }
+      .hidden { display: none; }
+    </style>
+  </head>
+  <body data-mode="__VANER_MODE__">
+    <div class="wrap">
+      <section class="panel header">
+        <div>
+          <h1>Vaner Cockpit</h1>
+          <div class="subtle" id="subtitle">Live status and controls</div>
+        </div>
+        <div class="row">
+          <div id="streamDot" class="status-dot"></div>
+          <span id="streamState" class="subtle">connecting...</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Status</h2>
+        <div id="statusPills" class="pills"></div>
+      </section>
+
+      <section class="panel" id="summaryPanel">
+        <h2 id="summaryTitle">Summary</h2>
+        <div id="summaryChips" class="chips"></div>
+      </section>
+
+      <div class="grid">
+        <section class="panel" id="leftPanel">
+          <h2 id="leftTitle">Top Scenarios</h2>
+          <div id="scenarioList" class="scenario-list"></div>
+          <pre id="proxyDecision" class="hidden"></pre>
+        </section>
+        <section class="panel" id="rightPanel">
+          <h2 id="rightTitle">Compute</h2>
+          <div class="subtle" id="computeState">loading...</div>
+          <div id="daemonComputeControls" class="actions">
+            <select id="deviceSelect"></select>
+            <button id="applyDevice" class="primary">Apply Device</button>
+          </div>
+          <div id="proxyComputeControls" class="actions hidden">
+            <input id="cpuFraction" type="number" min="0.01" max="1" step="0.01" />
+            <button id="applyCpuFraction" class="primary">Apply CPU Fraction</button>
+          </div>
+          <div id="proxyGatewayControls" class="actions hidden">
+            <button id="gatewayDisable">Disable enrichment</button>
+            <button id="gatewayEnable">Enable enrichment</button>
+          </div>
+          <div id="computeWarning" class="warning hidden"></div>
+        </section>
+      </div>
+    </div>
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+    <script>
+      window.__VANER_MODE = "__VANER_MODE__";
+      const mode = window.__VANER_MODE;
+      const isDaemon = mode === "daemon";
+      const isProxy = mode === "proxy";
+
+      const subtitle = document.getElementById("subtitle");
+      const summaryTitle = document.getElementById("summaryTitle");
+      const summaryChips = document.getElementById("summaryChips");
+      const leftTitle = document.getElementById("leftTitle");
+      const rightTitle = document.getElementById("rightTitle");
+      const scenarioList = document.getElementById("scenarioList");
+      const proxyDecision = document.getElementById("proxyDecision");
+      const statusPills = document.getElementById("statusPills");
+      const computeState = document.getElementById("computeState");
+      const computeWarning = document.getElementById("computeWarning");
+      const daemonComputeControls = document.getElementById("daemonComputeControls");
+      const proxyComputeControls = document.getElementById("proxyComputeControls");
+      const proxyGatewayControls = document.getElementById("proxyGatewayControls");
+      const deviceSelect = document.getElementById("deviceSelect");
+      const applyDevice = document.getElementById("applyDevice");
+      const cpuFraction = document.getElementById("cpuFraction");
+      const applyCpuFraction = document.getElementById("applyCpuFraction");
+      const gatewayDisable = document.getElementById("gatewayDisable");
+      const gatewayEnable = document.getElementById("gatewayEnable");
+      const streamDot = document.getElementById("streamDot");
+      const streamState = document.getElementById("streamState");
+      const toast = document.getElementById("toast");
+
+      let scenarioMap = new Map();
+
+      function escapeHtml(value) {
+        return String(value ?? "")
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;")
+          .replaceAll("'", "&#39;");
+      }
+
+      function showToast(message) {
+        toast.textContent = String(message);
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2200);
+      }
+
+      function setStreamState(state) {
+        streamDot.classList.remove("live", "error");
+        if (state === "live") {
+          streamDot.classList.add("live");
+          streamState.textContent = "live";
+          return;
+        }
+        if (state === "error") {
+          streamDot.classList.add("error");
+          streamState.textContent = "reconnecting...";
+          return;
+        }
+        streamState.textContent = "connecting...";
+      }
+
+      function renderStatus(status) {
+        const backend = status.backend || {};
+        const compute = status.compute || {};
+        const mcp = status.mcp || {};
+        const pills = [
+          `<span class="pill"><strong>Health:</strong>${escapeHtml(status.health || "unknown")}</span>`,
+          `<span class="pill"><strong>Backend:</strong>${
+            escapeHtml(backend.base_url || "(unset)")
+          } [${escapeHtml(backend.model || "(unset)")} ]</span>`,
+          `<span class="pill"><strong>Device:</strong>${escapeHtml(compute.device || "auto")}</span>`,
+        ];
+        if (isDaemon) {
+          pills.push(
+            `<span class="pill"><strong>MCP:</strong>${
+              escapeHtml(mcp.transport || "unknown")
+            } ${escapeHtml(mcp.http_host || "")}:${escapeHtml(mcp.http_port || "")}</span>`
+          );
+        }
+        if (isProxy) {
+          pills.push(`<span class="pill"><strong>Gateway:</strong>${status.gateway_enabled ? "enabled" : "disabled"}</span>`);
+        }
+        statusPills.innerHTML = pills.join("");
+        computeState.textContent =
+          `Selected device: ${compute.device || "auto"} | ` +
+          `cpu_fraction=${compute.cpu_fraction} | ` +
+          `gpu_fraction=${compute.gpu_memory_fraction}`;
+        if (isProxy) {
+          cpuFraction.value = String(compute.cpu_fraction ?? 0.2);
+        }
+      }
+
+      function renderSummary(stats) {
+        if (isDaemon) {
+          summaryTitle.textContent = "Scenario Freshness";
+          const summary = stats || { fresh: 0, recent: 0, stale: 0, total: 0 };
+          summaryChips.innerHTML = `
+            <span class="chip fresh">fresh: ${summary.fresh ?? 0}</span>
+            <span class="chip recent">recent: ${summary.recent ?? 0}</span>
+            <span class="chip stale">stale: ${summary.stale ?? 0}</span>
+            <span class="chip">total: ${summary.total ?? 0}</span>
+          `;
+          return;
+        }
+        summaryTitle.textContent = "Impact Summary";
+        const impact = stats || {};
+        summaryChips.innerHTML = `
+          <span class="chip">count: ${impact.count ?? 0}</span>
+          <span class="chip">latency_gain_ms: ${Number(impact.mean_latency_gain_ms || 0).toFixed(2)}</span>
+          <span class="chip">char_delta: ${Number(impact.mean_char_delta || 0).toFixed(2)}</span>
+          <span class="chip">idle_seconds_used: ${Number(impact.idle_seconds_used || 0).toFixed(2)}</span>
+        `;
+      }
+
+      async function postJson(url, payload) {
+        const response = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          throw new Error((await response.text()) || `Request failed: ${response.status}`);
+        }
+        return await response.json();
+      }
+
+      function daemonCardHtml(row) {
+        const entities = (row.entities || []).map((entity) => `<span class="tag mono">${escapeHtml(entity)}</span>`).join("");
+        const gaps = (row.coverage_gaps || []).map((gap) => `<div class="warning">${escapeHtml(gap)}</div>`).join("");
+        const evidence = (row.evidence || [])
+          .slice(0, 4)
+          .map((ev) => `<li><span class="mono">${escapeHtml(ev.source_path || ev.key || "")}</span>: ${escapeHtml(ev.excerpt || "")}</li>`)
+          .join("");
+        return `
+          <div class="row">
+            <div class="pills">
+              <span class="pill">${escapeHtml(row.kind)}</span>
+              <span class="pill">score ${Number(row.score || 0).toFixed(3)}</span>
+              <span class="pill">${escapeHtml(row.freshness || "unknown")}</span>
+            </div>
+            <span class="mono">${escapeHtml(row.id || "")}</span>
+          </div>
+          <div class="tags">${entities || '<span class="subtle">No entities</span>'}</div>
+          ${gaps}
+          <div class="actions">
+            <button data-action="expand" data-id="${escapeHtml(row.id)}">Expand</button>
+            <button data-action="outcome" data-id="${escapeHtml(row.id)}" data-result="useful">Useful</button>
+            <button data-action="outcome" data-id="${escapeHtml(row.id)}" data-result="partial">Partial</button>
+            <button data-action="outcome" data-id="${escapeHtml(row.id)}" data-result="irrelevant">Irrelevant</button>
+          </div>
+          <details>
+            <summary>Details</summary>
+            <div class="subtle">Evidence</div>
+            <ul>${evidence || "<li>No evidence</li>"}</ul>
+            <div class="subtle">Prepared context</div>
+            <pre>${escapeHtml(row.prepared_context || "")}</pre>
+          </details>
+        `;
+      }
+
+      function renderDaemonScenarios(rows, highlightIds = new Set()) {
+        if (!rows.length) {
+          scenarioList.innerHTML = '<div class="subtle">No scenarios yet.</div>';
+          return;
+        }
+        scenarioList.innerHTML = rows.map((row) => {
+          const flash = highlightIds.has(row.id) ? "flash" : "";
+          return `<article class="scenario-card ${flash}" data-scenario-id="${escapeHtml(row.id)}">${daemonCardHtml(row)}</article>`;
+        }).join("");
+      }
+
+      function applyModeLayout() {
+        if (isDaemon) {
+          subtitle.textContent = "Live scenario frontier and compute controls";
+          leftTitle.textContent = "Top Scenarios";
+          rightTitle.textContent = "Compute";
+          proxyDecision.classList.add("hidden");
+          proxyComputeControls.classList.add("hidden");
+          proxyGatewayControls.classList.add("hidden");
+          daemonComputeControls.classList.remove("hidden");
+          return;
+        }
+        subtitle.textContent = "Live proxy decisions, impact, and controls";
+        leftTitle.textContent = "Recent Proxy Decisions";
+        rightTitle.textContent = "Proxy Controls";
+        scenarioList.classList.add("hidden");
+        proxyDecision.classList.remove("hidden");
+        daemonComputeControls.classList.add("hidden");
+        proxyComputeControls.classList.remove("hidden");
+        proxyGatewayControls.classList.remove("hidden");
+      }
+
+      async function refreshStatus() {
+        const response = await fetch("/status");
+        renderStatus(await response.json());
+      }
+
+      async function refreshDaemonScenarios() {
+        const response = await fetch("/scenarios?limit=10");
+        const payload = await response.json();
+        const rows = payload.scenarios || [];
+        scenarioMap = new Map(rows.map((row) => [row.id, row]));
+        renderDaemonScenarios(rows);
+      }
+
+      async function refreshDevices() {
+        const response = await fetch("/compute/devices");
+        const payload = await response.json();
+        const devices = payload.devices || [];
+        deviceSelect.innerHTML = devices.map((device) => (
+          `<option value="${escapeHtml(device.id)}">${escapeHtml(device.label)} (${escapeHtml(device.kind)})</option>`
+        )).join("");
+        if (payload.selected) {
+          deviceSelect.value = payload.selected;
+        }
+        if (payload.warning) {
+          computeWarning.classList.remove("hidden");
+          computeWarning.textContent = payload.warning;
+        } else {
+          computeWarning.classList.add("hidden");
+          computeWarning.textContent = "";
+        }
+      }
+
+      async function refreshProxySummary() {
+        const response = await fetch("/impact/summary");
+        renderSummary(await response.json());
+      }
+
+      async function refreshProxyDecisions() {
+        const response = await fetch("/decisions?limit=1");
+        const payload = await response.json();
+        const item = (payload.items || [])[0];
+        proxyDecision.textContent = item ? JSON.stringify(item, null, 2) : "No decisions yet.";
+      }
+
+      scenarioList.addEventListener("click", async (event) => {
+        if (!isDaemon) return;
+        const target = event.target;
+        if (!(target instanceof HTMLButtonElement)) return;
+        const id = target.dataset.id;
+        if (!id) return;
+        target.disabled = true;
+        try {
+          if (target.dataset.action === "expand") {
+            await postJson(`/scenarios/${id}/expand`, {});
+            showToast(`Expanded ${id}`);
+          } else if (target.dataset.action === "outcome") {
+            await postJson(`/scenarios/${id}/outcome`, { result: target.dataset.result });
+            showToast(`Recorded ${target.dataset.result} for ${id}`);
+          }
+          await refreshDaemonScenarios();
+          await refreshStatus();
+        } catch (error) {
+          showToast(`Action failed: ${error}`);
+        } finally {
+          target.disabled = false;
+        }
+      });
+
+      applyDevice.addEventListener("click", async () => {
+        if (!isDaemon) return;
+        applyDevice.disabled = true;
+        try {
+          await postJson("/compute", { device: deviceSelect.value });
+          showToast(`Set compute device to ${deviceSelect.value}`);
+          await refreshStatus();
+          await refreshDevices();
+        } catch (error) {
+          showToast(`Failed to update device: ${error}`);
+        } finally {
+          applyDevice.disabled = false;
+        }
+      });
+
+      applyCpuFraction.addEventListener("click", async () => {
+        if (!isProxy) return;
+        applyCpuFraction.disabled = true;
+        try {
+          const value = Number(cpuFraction.value || "0.2");
+          await postJson("/compute", { cpu_fraction: value });
+          showToast(`Set CPU fraction to ${value}`);
+          await refreshStatus();
+        } catch (error) {
+          showToast(`Failed to update CPU fraction: ${error}`);
+        } finally {
+          applyCpuFraction.disabled = false;
+        }
+      });
+
+      gatewayDisable.addEventListener("click", async () => {
+        if (!isProxy) return;
+        await postJson("/gateway/toggle", { enabled: false });
+        showToast("Gateway enrichment disabled");
+        await refreshStatus();
+      });
+
+      gatewayEnable.addEventListener("click", async () => {
+        if (!isProxy) return;
+        await postJson("/gateway/toggle", { enabled: true });
+        showToast("Gateway enrichment enabled");
+        await refreshStatus();
+      });
+
+      function wireDaemonStream() {
+        const stream = new EventSource("/scenarios/stream");
+        stream.onopen = () => setStreamState("live");
+        stream.onerror = () => setStreamState("error");
+        stream.onmessage = (event) => {
+          setStreamState("live");
+          const data = JSON.parse(event.data);
+          renderSummary(data.summary);
+          const rows = [];
+          const highlightIds = new Set();
+          const top = data.top_scenarios || [];
+          for (const entry of top) {
+            const previous = scenarioMap.get(entry.id);
+            const merged = { ...(previous || {}), ...entry };
+            scenarioMap.set(entry.id, merged);
+            rows.push(merged);
+            highlightIds.add(entry.id);
+          }
+          if (rows.length) {
+            renderDaemonScenarios(rows, highlightIds);
+          }
+        };
+      }
+
+      function wireProxyStream() {
+        const stream = new EventSource("/decisions/stream");
+        stream.onopen = () => setStreamState("live");
+        stream.onerror = () => setStreamState("error");
+        stream.onmessage = (event) => {
+          setStreamState("live");
+          proxyDecision.textContent = JSON.stringify(JSON.parse(event.data), null, 2);
+        };
+      }
+
+      applyModeLayout();
+      if (isDaemon) {
+        Promise.all([refreshStatus(), refreshDaemonScenarios(), refreshDevices()]).then(() => {
+          fetch("/status").then((r) => r.json()).then((payload) => renderSummary(payload.scenario_counts));
+        }).catch((error) => showToast(`Initial load failed: ${error}`));
+        wireDaemonStream();
+      } else {
+        Promise.all([refreshStatus(), refreshProxySummary(), refreshProxyDecisions()]).catch(
+          (error) => showToast(`Initial load failed: ${error}`)
+        );
+        wireProxyStream();
+      }
+
+      setInterval(() => {
+        refreshStatus().catch(() => {});
+        if (isProxy) {
+          refreshProxySummary().catch(() => {});
+        }
+      }, 15000);
+    </script>
+  </body>
+</html>
+"""

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, StreamingResponse
 
+from vaner import __version__ as _vaner_version
 from vaner.cli.commands.config import load_config, set_compute_value
+from vaner.daemon.cockpit_html import build_cockpit_html
 from vaner.models.config import VanerConfig
 from vaner.store.scenarios import ScenarioStore
 from vaner.telemetry.metrics import MetricsStore
@@ -30,7 +32,7 @@ def create_daemon_http_app(config: VanerConfig) -> FastAPI:
         await metrics_store.initialize()
         yield
 
-    app = FastAPI(title="Vaner Cockpit", version="0.3.0", lifespan=lifespan)
+    app = FastAPI(title="Vaner Cockpit", version=_vaner_version, lifespan=lifespan)
 
     @app.get("/health")
     async def health() -> dict[str, str]:
@@ -45,6 +47,7 @@ def create_daemon_http_app(config: VanerConfig) -> FastAPI:
                 "health": "ok",
                 "gateway_enabled": config.gateway.passthrough_enabled,
                 "compute": config.compute.model_dump(mode="json"),
+                "backend": config.backend.model_dump(mode="json"),
                 "mcp": config.mcp.model_dump(mode="json"),
                 "scenario_counts": freshness,
                 "top_scenario": top[0].id if top else None,
@@ -104,39 +107,6 @@ def create_daemon_http_app(config: VanerConfig) -> FastAPI:
         rows = await scenario_store.list_top(kind=kind, limit=max(1, min(limit, 100)))
         return JSONResponse({"count": len(rows), "scenarios": [row.model_dump(mode="json") for row in rows]})
 
-    @app.get("/scenarios/{scenario_id}")
-    async def get_scenario(scenario_id: str) -> JSONResponse:
-        row = await scenario_store.get(scenario_id)
-        if row is None:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        return JSONResponse(row.model_dump(mode="json"))
-
-    @app.post("/scenarios/{scenario_id}/expand")
-    async def expand_scenario(scenario_id: str) -> JSONResponse:
-        row = await scenario_store.get(scenario_id)
-        if row is None:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        await scenario_store.record_expansion(scenario_id)
-        refreshed = await scenario_store.get(scenario_id)
-        if refreshed is None:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        return JSONResponse({"ok": True, "scenario": refreshed.model_dump(mode="json")})
-
-    @app.post("/scenarios/{scenario_id}/outcome")
-    async def report_outcome(scenario_id: str, payload: dict[str, Any]) -> JSONResponse:
-        row = await scenario_store.get(scenario_id)
-        if row is None:
-            raise HTTPException(status_code=404, detail="Scenario not found")
-        result = str(payload.get("result", "")).strip()
-        note = str(payload.get("note", "")).strip()
-        skill = str(payload.get("skill", "")).strip() or None
-        if result not in {"useful", "partial", "irrelevant"}:
-            raise HTTPException(status_code=400, detail="result must be one of useful|partial|irrelevant")
-        await scenario_store.record_outcome(scenario_id, result, skill=skill, source="skill" if skill else None)
-        await metrics_store.record_scenario_outcome(scenario_id=scenario_id, result=result, note=note, skill=skill)
-        refreshed = await scenario_store.get(scenario_id)
-        return JSONResponse({"ok": True, "scenario": refreshed.model_dump(mode="json") if refreshed else None})
-
     @app.get("/scenarios/stream")
     async def scenario_stream(limit: int | None = None) -> StreamingResponse:
         async def event_gen():
@@ -195,41 +165,45 @@ def create_daemon_http_app(config: VanerConfig) -> FastAPI:
 
         return StreamingResponse(event_gen(), media_type="text/event-stream")
 
-    @app.get("/ui", response_class=HTMLResponse)
-    async def ui() -> str:
-        return """<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Vaner Cockpit</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <style>
-      body { font-family: system-ui, sans-serif; margin: 16px; line-height: 1.4; }
-      pre { padding: 10px; border: 1px solid #ddd; border-radius: 6px; overflow-x: auto; }
-      .row { margin: 12px 0; }
-    </style>
-  </head>
-  <body>
-    <h2>Vaner Cockpit</h2>
-    <div class="row"><strong>Top Scenario</strong></div>
-    <pre id="scenario">loading...</pre>
-    <div class="row"><strong>Compute devices</strong></div>
-    <pre id="devices">loading...</pre>
-    <script>
-      const scenarioEl = document.getElementById("scenario");
-      const devicesEl = document.getElementById("devices");
-      const stream = new EventSource("/scenarios/stream");
-      stream.onmessage = (event) => {
-        scenarioEl.textContent = JSON.stringify(JSON.parse(event.data), null, 2);
-      };
-      fetch("/compute/devices").then((r) => r.json()).then((d) => {
-        devicesEl.textContent = JSON.stringify(d, null, 2);
-      }).catch(() => {
-        devicesEl.textContent = "Failed to load compute devices";
-      });
-    </script>
-  </body>
-</html>
-"""
+    @app.get("/scenarios/{scenario_id}")
+    async def get_scenario(scenario_id: str) -> JSONResponse:
+        row = await scenario_store.get(scenario_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Scenario not found")
+        return JSONResponse(row.model_dump(mode="json"))
+
+    @app.post("/scenarios/{scenario_id}/expand")
+    async def expand_scenario(scenario_id: str) -> JSONResponse:
+        row = await scenario_store.get(scenario_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Scenario not found")
+        await scenario_store.record_expansion(scenario_id)
+        refreshed = await scenario_store.get(scenario_id)
+        if refreshed is None:
+            raise HTTPException(status_code=404, detail="Scenario not found")
+        return JSONResponse({"ok": True, "scenario": refreshed.model_dump(mode="json")})
+
+    @app.post("/scenarios/{scenario_id}/outcome")
+    async def report_outcome(scenario_id: str, payload: dict[str, Any]) -> JSONResponse:
+        row = await scenario_store.get(scenario_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Scenario not found")
+        result = str(payload.get("result", "")).strip()
+        note = str(payload.get("note", "")).strip()
+        skill = str(payload.get("skill", "")).strip() or None
+        if result not in {"useful", "partial", "irrelevant"}:
+            raise HTTPException(status_code=400, detail="result must be one of useful|partial|irrelevant")
+        await scenario_store.record_outcome(scenario_id, result, skill=skill, source="skill" if skill else None)
+        await metrics_store.record_scenario_outcome(scenario_id=scenario_id, result=result, note=note, skill=skill)
+        refreshed = await scenario_store.get(scenario_id)
+        return JSONResponse({"ok": True, "scenario": refreshed.model_dump(mode="json") if refreshed else None})
+
+    @app.get("/", response_class=HTMLResponse)
+    async def cockpit() -> str:
+        return build_cockpit_html("daemon")
+
+    @app.get("/ui")
+    async def ui() -> RedirectResponse:
+        return RedirectResponse(url="/", status_code=307)
 
     return app

--- a/src/vaner/daemon/preflight.py
+++ b/src/vaner/daemon/preflight.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import socket
+from pathlib import Path
+
+_DISALLOWED_ROOTS = {
+    Path("/").resolve(),
+    Path("/home").resolve(),
+    Path("/root").resolve(),
+    Path.home().resolve(),
+}
+
+
+def _is_git_repo(path: Path) -> bool:
+    return (path / ".git").exists()
+
+
+def _count_files_limited(root: Path, limit: int = 100_000) -> int:
+    total = 0
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(os.scandir(current))
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_dir(follow_symlinks=False):
+                if entry.name in {".git", ".venv", "node_modules", ".next", ".cache", ".vaner"}:
+                    continue
+                stack.append(Path(entry.path))
+                continue
+            total += 1
+            if total >= limit:
+                return total
+    return total
+
+
+def check_repo_root(repo_root: Path, *, force: bool = False) -> dict[str, object]:
+    resolved = repo_root.resolve()
+    if resolved in _DISALLOWED_ROOTS and not force:
+        return {
+            "ok": False,
+            "reason": "unsafe_root",
+            "detail": f"Refusing broad root path: {resolved}",
+            "fix": "Pick your project root, e.g. `vaner up --path ~/repos/my-project`.",
+        }
+    is_git = _is_git_repo(resolved)
+    if is_git:
+        return {"ok": True, "reason": "git_repo", "detail": str(resolved)}
+    approx_files = _count_files_limited(resolved)
+    if approx_files >= 100_000 and not force:
+        return {
+            "ok": False,
+            "reason": "non_git_large_root",
+            "detail": f"Path is not a git repo and is very large (files >= {approx_files}).",
+            "fix": "Pick your project root, e.g. `vaner up --path ~/repos/my-project`.",
+        }
+    return {"ok": True, "reason": "small_non_git", "detail": f"non-git path files={approx_files}"}
+
+
+def _read_int_file(path: Path) -> int | None:
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except Exception:
+        return None
+
+
+def _estimate_dir_count(root: Path, limit: int = 200_000) -> int:
+    total = 0
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        total += 1
+        if total >= limit:
+            return total
+        try:
+            for entry in os.scandir(current):
+                if not entry.is_dir(follow_symlinks=False):
+                    continue
+                if entry.name in {".git", ".venv", "node_modules", ".next", ".cache", ".vaner"}:
+                    continue
+                stack.append(Path(entry.path))
+        except OSError:
+            continue
+    return total
+
+
+def check_inotify_budget(repo_root: Path) -> dict[str, object]:
+    budget = _read_int_file(Path("/proc/sys/fs/inotify/max_user_watches"))
+    if not budget:
+        return {"ok": True, "level": "warn", "detail": "Could not read inotify watch budget."}
+    approx_dirs = _estimate_dir_count(repo_root)
+    usage_ratio = min(1.0, float(approx_dirs) / float(max(1, budget)))
+    headroom_pct = max(0.0, (1.0 - usage_ratio) * 100.0)
+    ok = usage_ratio < 0.5
+    payload = {
+        "ok": ok,
+        "level": "pass" if ok else "warn",
+        "detail": (f"dirs~{approx_dirs} budget={budget} headroom={headroom_pct:.1f}% (watch estimates are approximate)"),
+        "headroom_pct": round(headroom_pct, 2),
+        "fix": "sudo sysctl fs.inotify.max_user_watches=524288",
+    }
+    return payload
+
+
+def _is_port_free(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.2)
+        return sock.connect_ex((host, port)) != 0
+
+
+def _pick_port(host: str, preferred: int, window: int = 10) -> int:
+    for candidate in range(preferred, preferred + window + 1):
+        if _is_port_free(host, candidate):
+            return candidate
+    return preferred
+
+
+def check_ports(host: str, cockpit_port: int, mcp_sse_port: int) -> dict[str, object]:
+    resolved_cockpit = _pick_port(host, cockpit_port)
+    resolved_mcp = _pick_port(host, mcp_sse_port)
+    return {
+        "ok": True,
+        "cockpit_port": resolved_cockpit,
+        "mcp_sse_port": resolved_mcp,
+        "cockpit_changed": resolved_cockpit != cockpit_port,
+        "mcp_changed": resolved_mcp != mcp_sse_port,
+    }

--- a/src/vaner/daemon/signals/fs_watcher.py
+++ b/src/vaner/daemon/signals/fs_watcher.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import errno
+import logging
 import threading
 from pathlib import Path
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
+logger = logging.getLogger(__name__)
 
 _SKIPPED_PARTS = {
     ".git",
@@ -106,7 +111,19 @@ class RepoChangeWatcher:
         if self._started:
             return
         self._observer.schedule(self._handler, str(self.repo_root), recursive=True)
-        self._observer.start()
+        try:
+            self._observer.start()
+        except OSError as exc:
+            if exc.errno != errno.ENOSPC:
+                raise
+            logger.warning(
+                "inotify watch limit reached for %s. Falling back to polling observer. "
+                "To raise limit: sudo sysctl fs.inotify.max_user_watches=524288",
+                self.repo_root,
+            )
+            self._observer = PollingObserver()
+            self._observer.schedule(self._handler, str(self.repo_root), recursive=True)
+            self._observer.start()
         self._started = True
 
     def stop(self) -> None:

--- a/src/vaner/intent/scorer.py
+++ b/src/vaner/intent/scorer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -10,6 +11,8 @@ import numpy as np
 from vaner.broker.selector import score_artefact
 from vaner.intent.features import feature_vector_for_artefact
 from vaner.models.artefact import Artefact
+
+logger = logging.getLogger(__name__)
 
 try:
     import lightgbm as lgb  # type: ignore
@@ -65,28 +68,40 @@ class IntentScorer:
         if backend == "lightgbm":
             if lgb is None:
                 return False
-            self._booster = lgb.Booster(model_file=str(model_path))
-            self.model_path = model_path
-            self._backend = "lightgbm"
-            return True
+            try:
+                self._booster = lgb.Booster(model_file=str(model_path))
+                self.model_path = model_path
+                self._backend = "lightgbm"
+                return True
+            except Exception as exc:
+                logger.warning("Failed to load LightGBM model '%s': %s", model_path, exc)
+                return False
         if backend == "xgboost":
             if xgb is None:
                 return False
-            booster = xgb.Booster()
-            booster.load_model(str(model_path))
-            self._booster = booster
-            self.model_path = model_path
-            self._backend = "xgboost"
-            return True
+            try:
+                booster = xgb.Booster()
+                booster.load_model(str(model_path))
+                self._booster = booster
+                self.model_path = model_path
+                self._backend = "xgboost"
+                return True
+            except Exception as exc:
+                logger.warning("Failed to load XGBoost model '%s': %s", model_path, exc)
+                return False
         if backend == "catboost":
             if CatBoostRegressor is None:
                 return False
-            model = CatBoostRegressor()
-            model.load_model(str(model_path))
-            self._booster = model
-            self.model_path = model_path
-            self._backend = "catboost"
-            return True
+            try:
+                model = CatBoostRegressor()
+                model.load_model(str(model_path))
+                self._booster = model
+                self.model_path = model_path
+                self._backend = "catboost"
+                return True
+            except Exception as exc:
+                logger.warning("Failed to load CatBoost model '%s': %s", model_path, exc)
+                return False
         return False
 
     def score(self, prompt: str, artefact: Artefact, *, features: dict[str, float] | None = None) -> float:

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -380,7 +380,7 @@ async def run_stdio(repo_root: Path) -> None:
             write_stream,
             InitializationOptions(
                 server_name="vaner",
-                server_version="0.3.0",
+                server_version="0.4.0",
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},
@@ -406,7 +406,7 @@ async def run_sse(repo_root: Path, host: str, port: int) -> None:
                 streams[1],
                 InitializationOptions(
                     server_name="vaner",
-                    server_version="0.3.0",
+                    server_version="0.4.0",
                     capabilities=server.get_capabilities(
                         notification_options=NotificationOptions(),
                         experimental_capabilities={},

--- a/src/vaner/models/signal.py
+++ b/src/vaner/models/signal.py
@@ -10,4 +10,4 @@ class SignalEvent(BaseModel):
     source: str
     kind: str
     timestamp: float
-    payload: dict[str, str] = Field(default_factory=dict)
+    payload: dict[str, object] = Field(default_factory=dict)

--- a/src/vaner/router/proxy.py
+++ b/src/vaner/router/proxy.py
@@ -13,10 +13,12 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
-from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, RedirectResponse, StreamingResponse
 
+from vaner import __version__ as _vaner_version
 from vaner.api import aquery
 from vaner.cli.commands.config import load_config, set_compute_value
+from vaner.daemon.cockpit_html import build_cockpit_html
 from vaner.models.config import VanerConfig
 from vaner.models.decision import DecisionRecord
 from vaner.router.backends import (
@@ -152,7 +154,7 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
         except (NotImplementedError, RuntimeError):
             pass
 
-    app = FastAPI(title="Vaner Proxy", version="0.3.0", lifespan=lifespan)
+    app = FastAPI(title="Vaner Proxy", version=_vaner_version, lifespan=lifespan)
     limiter = _RateLimiter(config.proxy.max_requests_per_minute)
     required_token = (config.proxy.proxy_token or "").strip()
     shadow_rate = max(0.0, min(config.gateway.shadow_rate, 1.0))
@@ -224,10 +226,7 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
                 "health": "ok",
                 "gateway_enabled": gateway_enabled,
                 "compute": config.compute.model_dump(mode="json"),
-                "backend": {
-                    "base_url": config.backend.base_url,
-                    "model": config.backend.model,
-                },
+                "backend": config.backend.model_dump(mode="json"),
             }
         )
 
@@ -258,78 +257,13 @@ def create_app(config: VanerConfig, store: ArtefactStore) -> FastAPI:
         gateway_enabled = bool(payload.get("enabled", True))
         return JSONResponse({"ok": True, "gateway_enabled": gateway_enabled})
 
-    @app.get("/ui", response_class=HTMLResponse)
-    async def cockpit_ui() -> str:
-        return """<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>Vaner Cockpit</title>
-    <style>
-      body { font-family: sans-serif; margin: 20px; background: #0f1117; color: #e8e8e8; }
-      .card { background: #171a22; border: 1px solid #2a2f3b; border-radius: 8px; padding: 12px; margin: 12px 0; }
-      button { background: #3a7afe; color: white; border: 0; border-radius: 6px; padding: 6px 10px; cursor: pointer; }
-      pre { background: #10131a; border-radius: 6px; padding: 10px; overflow-x: auto; }
-      input { padding: 6px 8px; border-radius: 6px; border: 1px solid #2a2f3b; background: #10131a; color: #e8e8e8; }
-    </style>
-  </head>
-  <body>
-    <h2>Vaner Cockpit</h2>
-    <div class="card"><strong>Status</strong><pre id="status">loading…</pre></div>
-    <div class="card"><strong>Impact</strong><pre id="impact">loading…</pre></div>
-    <div class="card"><strong>Last decision</strong><pre id="decision">waiting…</pre></div>
-    <div class="card">
-      <strong>Compute controls</strong><br/>
-      <label>CPU fraction <input id="cpu" value="0.2"/></label>
-      <button id="applyCompute">Apply</button>
-      <pre id="computeResult"></pre>
-    </div>
-    <div class="card">
-      <strong>Gateway toggle</strong><br/>
-      <button id="disable">Disable enrichment</button>
-      <button id="enable">Enable enrichment</button>
-    </div>
-    <script>
-      async function refresh() {
-        const status = await fetch('/status').then(r => r.json());
-        const impact = await fetch('/impact/summary').then(r => r.json());
-        document.getElementById('status').textContent = JSON.stringify(status, null, 2);
-        document.getElementById('impact').textContent = JSON.stringify(impact, null, 2);
-      }
-      const stream = new EventSource('/decisions/stream');
-      stream.onmessage = (event) => {
-        document.getElementById('decision').textContent = JSON.stringify(JSON.parse(event.data), null, 2);
-      };
-      document.getElementById('applyCompute').onclick = async () => {
-        const cpu = parseFloat(document.getElementById('cpu').value);
-        const result = await fetch('/compute', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({cpu_fraction: cpu}),
-        }).then(r => r.json());
-        document.getElementById('computeResult').textContent = JSON.stringify(result, null, 2);
-        refresh();
-      };
-      document.getElementById('disable').onclick = async () => {
-        await fetch('/gateway/toggle', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({enabled: false}),
-        });
-        refresh();
-      };
-      document.getElementById('enable').onclick = async () => {
-        await fetch('/gateway/toggle', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({enabled: true}),
-        });
-        refresh();
-      };
-      refresh();
-    </script>
-  </body>
-</html>"""
+    @app.get("/", response_class=HTMLResponse)
+    async def cockpit() -> str:
+        return build_cockpit_html("proxy")
+
+    @app.get("/ui")
+    async def cockpit_ui() -> RedirectResponse:
+        return RedirectResponse(url="/", status_code=307)
 
     async def _publish_decision_event(event: dict[str, Any]) -> None:
         if not decision_stream_subscribers:

--- a/tests/test_cli/test_daemon_port.py
+++ b/tests/test_cli/test_daemon_port.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands import app
+
+runner = CliRunner()
+
+
+def test_serve_http_busy_port_prints_remediation(monkeypatch, temp_repo) -> None:
+    (temp_repo / ".vaner").mkdir(parents=True, exist_ok=True)
+    (temp_repo / ".vaner" / "config.toml").write_text(
+        """
+[backend]
+base_url = "http://127.0.0.1:11434/v1"
+model = "qwen3.5:35b"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    class _Uvicorn:
+        @staticmethod
+        def run(*_args, **_kwargs):
+            raise OSError(98, "address already in use")
+
+    monkeypatch.setitem(__import__("sys").modules, "uvicorn", _Uvicorn)
+    monkeypatch.setattr(app, "_next_free_port", lambda *_args, **_kwargs: 8474)
+
+    result = runner.invoke(app.app, ["daemon", "serve-http", "--path", str(temp_repo), "--port", "8473"])
+    assert result.exit_code == 1
+    assert "port 127.0.0.1:8473 is busy" in result.output
+    assert "--port 8474" in result.output

--- a/tests/test_cli/test_doctor.py
+++ b/tests/test_cli/test_doctor.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands import app
+
+runner = CliRunner()
+
+
+def _write_basic_config(temp_repo) -> None:  # noqa: ANN001
+    (temp_repo / ".vaner").mkdir(parents=True, exist_ok=True)
+    (temp_repo / ".vaner" / "config.toml").write_text(
+        """
+[backend]
+base_url = "http://127.0.0.1:11434/v1"
+model = "qwen3.5:35b"
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def test_doctor_daemon_running_fails_when_cockpit_unreachable(temp_repo, monkeypatch) -> None:
+    _write_basic_config(temp_repo)
+    config = app.load_config(temp_repo)
+
+    monkeypatch.setattr(
+        app,
+        "runtime_snapshot",
+        lambda *_args, **_kwargs: {
+            "repo_root": str(temp_repo),
+            "config": config,
+            "daemon": {"status": "stopped"},
+            "cockpit_process": {"status": "stopped"},
+            "daemon_pid_alive": False,
+            "cockpit_pid_alive": False,
+            "cockpit_reachable": False,
+            "cockpit_detail": "connection refused",
+            "backend_reachable": True,
+            "backend_detail": "ok",
+            "inotify_headroom_pct": 80.0,
+            "inotify": {"ok": True, "detail": "headroom ok", "fix": ""},
+            "repo_root_sensible": True,
+            "repo_root_detail": str(temp_repo),
+            "repo_root_fix": "",
+            "cli_up_to_date": True,
+            "cli_update_detail": "installed=current",
+            "scenario_counts": {"fresh": 0, "recent": 0, "stale": 0, "total": 0},
+        },
+    )
+    monkeypatch.setenv("VANER_SKIP_MCP_BOOT_PROBE", "1")
+    monkeypatch.setattr(app, "_detect_local_runtime", lambda: {"detected": False})
+
+    result = runner.invoke(app.app, ["doctor", "--path", str(temp_repo), "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    daemon_running = next(item for item in payload["checks"] if item["name"] == "daemon_running")
+    assert daemon_running["ok"] is False
+    assert "vaner daemon start" in daemon_running["fix"]
+
+
+def test_doctor_ollama_model_pulled_fails_for_missing_model(temp_repo, monkeypatch) -> None:
+    _write_basic_config(temp_repo)
+    config = app.load_config(temp_repo)
+    (temp_repo / ".cursor").mkdir(parents=True, exist_ok=True)
+    (temp_repo / ".cursor" / "mcp.json").write_text(
+        '{"mcpServers":{"vaner":{"command":"vaner","args":["mcp","--path","."]}}}',
+        encoding="utf-8",
+    )
+
+    class _Resp:
+        def __init__(self, status_code: int, payload: dict[str, object] | None = None) -> None:
+            self.status_code = status_code
+            self._payload = payload or {}
+            self.text = json.dumps(self._payload)
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise app.httpx.HTTPStatusError("error", request=None, response=None)
+
+    def _fake_get(url: str, *args, **kwargs):  # noqa: ANN001
+        if url.endswith("/health") or url.endswith("/status"):
+            return _Resp(200, {"status": "ok"})
+        if url.endswith("/api/tags"):
+            return _Resp(200, {"models": [{"name": "qwen2.5-coder:32b"}]})
+        return _Resp(200)
+
+    monkeypatch.setenv("VANER_SKIP_MCP_BOOT_PROBE", "1")
+    monkeypatch.setattr(
+        app, "_detect_local_runtime", lambda: {"detected": True, "name": "ollama", "url": "http://127.0.0.1:11434/api/tags"}
+    )
+    monkeypatch.setattr(
+        app,
+        "runtime_snapshot",
+        lambda *_args, **_kwargs: {
+            "repo_root": str(temp_repo),
+            "config": config,
+            "daemon": {"status": "running (pid=1)"},
+            "cockpit_process": {"status": "running (pid=2)"},
+            "daemon_pid_alive": True,
+            "cockpit_pid_alive": True,
+            "cockpit_reachable": True,
+            "cockpit_detail": "status=200",
+            "backend_reachable": True,
+            "backend_detail": "status=200",
+            "inotify_headroom_pct": 80.0,
+            "inotify": {"ok": True, "detail": "headroom ok", "fix": ""},
+            "repo_root_sensible": True,
+            "repo_root_detail": str(temp_repo),
+            "repo_root_fix": "",
+            "cli_up_to_date": True,
+            "cli_update_detail": "installed=current",
+            "scenario_counts": {"fresh": 0, "recent": 0, "stale": 0, "total": 0},
+        },
+    )
+    monkeypatch.setattr(app.httpx, "get", _fake_get)
+    monkeypatch.setattr(app.shutil, "which", lambda *_args, **_kwargs: "/usr/local/bin/vaner")
+
+    result = runner.invoke(app.app, ["doctor", "--path", str(temp_repo), "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    daemon_running = next(item for item in payload["checks"] if item["name"] == "daemon_running")
+    assert daemon_running["ok"] is True
+    model_check = next(item for item in payload["checks"] if item["name"] == "ollama_model_pulled")
+    assert model_check["ok"] is False
+    assert "ollama pull qwen3.5:35b" in model_check["fix"]

--- a/tests/test_cli/test_doctor_release_probe.py
+++ b/tests/test_cli/test_doctor_release_probe.py
@@ -20,27 +20,37 @@ model = "qwen2.5-coder:7b"
         encoding="utf-8",
     )
 
-    class _Resp:
-        def __init__(self, status_code: int, payload: dict[str, object] | None = None) -> None:
-            self.status_code = status_code
-            self._payload = payload or {}
-
-        def json(self) -> dict[str, object]:
-            return self._payload
-
-    def _fake_get(url: str, *args, **kwargs):  # noqa: ANN001
-        if "pypi.org/pypi/vaner/json" in url:
-            return _Resp(200, {"info": {"version": "999.0.0"}})
-        if url.endswith("/health"):
-            return _Resp(200)
-        return _Resp(404)
-
     monkeypatch.setenv("VANER_DOCTOR_CHECK_UPDATES", "1")
     monkeypatch.setenv("VANER_SKIP_MCP_BOOT_PROBE", "1")
-    monkeypatch.setattr(app.httpx, "get", _fake_get)
+    config = app.load_config(temp_repo)
+    monkeypatch.setattr(
+        app,
+        "runtime_snapshot",
+        lambda *_args, **_kwargs: {
+            "repo_root": str(temp_repo),
+            "config": config,
+            "daemon": {"status": "running (pid=1)"},
+            "cockpit_process": {"status": "running (pid=2)"},
+            "daemon_pid_alive": True,
+            "cockpit_pid_alive": True,
+            "cockpit_reachable": True,
+            "cockpit_detail": "status=200",
+            "backend_reachable": True,
+            "backend_detail": "status=200",
+            "inotify_headroom_pct": 90.0,
+            "inotify": {"ok": True, "detail": "headroom ok", "fix": ""},
+            "repo_root_sensible": True,
+            "repo_root_detail": str(temp_repo),
+            "repo_root_fix": "",
+            "cli_up_to_date": False,
+            "cli_update_detail": "installed=0.4.0 latest=999.0.0",
+            "scenario_counts": {"fresh": 0, "recent": 0, "stale": 0, "total": 0},
+        },
+    )
+    monkeypatch.setattr(app, "_detect_local_runtime", lambda: {"detected": False})
 
     result = runner.invoke(app.app, ["doctor", "--path", str(temp_repo), "--json"])
     payload = json.loads(result.stdout)
-    release_probe = next(item for item in payload["checks"] if item["name"] == "vaner_release_probe")
+    release_probe = next(item for item in payload["checks"] if item["name"] == "cli_up_to_date")
     assert release_probe["ok"] is False
-    assert "vaner upgrade" in release_probe["fix"]
+    assert "pipx upgrade vaner" in release_probe["fix"]

--- a/tests/test_cli/test_status_doctor_consistency.py
+++ b/tests/test_cli/test_status_doctor_consistency.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands import app
+
+runner = CliRunner()
+
+
+def test_status_and_doctor_share_runtime_snapshot_when_daemon_down(temp_repo, monkeypatch) -> None:
+    (temp_repo / ".vaner").mkdir(parents=True, exist_ok=True)
+    (temp_repo / ".vaner" / "config.toml").write_text(
+        """
+[backend]
+base_url = "http://127.0.0.1:11434/v1"
+model = "qwen3.5:35b"
+""".strip(),
+        encoding="utf-8",
+    )
+    config = app.load_config(temp_repo)
+    snapshot = {
+        "repo_root": str(temp_repo),
+        "config": config,
+        "daemon": {"status": "stopped"},
+        "cockpit_process": {"status": "stopped"},
+        "daemon_pid_alive": False,
+        "cockpit_pid_alive": False,
+        "cockpit_reachable": False,
+        "cockpit_detail": "connection refused",
+        "backend_reachable": True,
+        "backend_detail": "status=200",
+        "inotify_headroom_pct": 42.0,
+        "inotify": {"ok": False, "detail": "headroom low", "fix": "sysctl ..."},
+        "repo_root_sensible": True,
+        "repo_root_detail": str(temp_repo),
+        "repo_root_fix": "",
+        "cli_up_to_date": True,
+        "cli_update_detail": "installed=current latest=current",
+        "scenario_counts": {"fresh": 0, "recent": 0, "stale": 0, "total": 0},
+    }
+    monkeypatch.setenv("VANER_SKIP_MCP_BOOT_PROBE", "1")
+    monkeypatch.setattr(app, "_detect_local_runtime", lambda: {"detected": False})
+    monkeypatch.setattr(app, "runtime_snapshot", lambda *_args, **_kwargs: snapshot)
+
+    status_result = runner.invoke(app.app, ["status", "--path", str(temp_repo), "--json"])
+    assert status_result.exit_code == 0
+    status_payload = json.loads(status_result.stdout)
+    assert status_payload["daemon"] == "stopped"
+
+    doctor_result = runner.invoke(app.app, ["doctor", "--path", str(temp_repo), "--json"])
+    assert doctor_result.exit_code == 1
+    doctor_payload = json.loads(doctor_result.stdout)
+    daemon_check = next(item for item in doctor_payload["checks"] if item["name"] == "daemon_running")
+    assert daemon_check["ok"] is False

--- a/tests/test_cli/test_up.py
+++ b/tests/test_cli/test_up.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+from vaner.cli.commands.daemon import COCKPIT_PROCESS, DAEMON_PROCESS, write_pid
+from vaner.cli.commands.supervisor import run_down, run_up
+
+
+def test_run_up_writes_pid_files_and_run_down_cleans(monkeypatch, temp_repo) -> None:
+    (temp_repo / ".vaner").mkdir(parents=True, exist_ok=True)
+    (temp_repo / ".vaner" / "config.toml").write_text(
+        """
+[backend]
+base_url = "http://127.0.0.1:11434/v1"
+model = "qwen3.5:35b"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    pid_seed = {"value": 1000}
+
+    class _Proc:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+    def _fake_spawn(_cmd, _logfile):
+        pid_seed["value"] += 1
+        return _Proc(pid_seed["value"])
+
+    monkeypatch.setattr("vaner.cli.commands.supervisor._spawn_process", _fake_spawn)
+    monkeypatch.setattr("vaner.cli.commands.supervisor._wait_for_health", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("vaner.cli.commands.supervisor.check_repo_root", lambda *_args, **_kwargs: {"ok": True})
+    monkeypatch.setattr(
+        "vaner.cli.commands.supervisor.check_ports",
+        lambda *_args, **_kwargs: {"cockpit_port": 8473, "mcp_sse_port": 8472, "cockpit_changed": False},
+    )
+    monkeypatch.setattr(
+        "vaner.cli.commands.supervisor.check_inotify_budget",
+        lambda *_args, **_kwargs: {"ok": True, "detail": "headroom ok"},
+    )
+    monkeypatch.setattr("vaner.cli.commands.supervisor._stop_pid", lambda *_args, **_kwargs: True)
+
+    payload = run_up(temp_repo, host="127.0.0.1", port=8473, mcp_sse_port=8472, interval_seconds=15, open_browser=False)
+    assert payload["started"] is True
+    assert (temp_repo / ".vaner" / "runtime" / "daemon.pid").exists()
+    assert (temp_repo / ".vaner" / "runtime" / "cockpit.pid").exists()
+
+    down_payload = run_down(temp_repo)
+    assert down_payload["daemon"]["stopped"] is True
+    assert down_payload["cockpit"]["stopped"] is True
+    assert not (temp_repo / ".vaner" / "runtime" / "daemon.pid").exists()
+    assert not (temp_repo / ".vaner" / "runtime" / "cockpit.pid").exists()
+
+
+def test_run_up_is_idempotent_when_processes_already_running(monkeypatch, temp_repo) -> None:
+    write_pid(temp_repo, DAEMON_PROCESS, os.getpid())
+    write_pid(temp_repo, COCKPIT_PROCESS, os.getpid())
+    monkeypatch.setattr("vaner.cli.commands.supervisor.check_repo_root", lambda *_args, **_kwargs: {"ok": True})
+    monkeypatch.setattr(
+        "vaner.cli.commands.supervisor.check_inotify_budget",
+        lambda *_args, **_kwargs: {"ok": True, "detail": "headroom ok"},
+    )
+    payload = run_up(temp_repo, host="127.0.0.1", port=8473, mcp_sse_port=8472, interval_seconds=15, open_browser=False)
+    assert payload["reattached"] is True
+    assert payload["started"] is False

--- a/tests/test_daemon/test_fs_watcher.py
+++ b/tests/test_daemon/test_fs_watcher.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import errno
+
+from vaner.daemon.signals import fs_watcher
+
+
+def test_repo_change_watcher_falls_back_to_polling_on_enospc(monkeypatch, temp_repo) -> None:
+    events: dict[str, int] = {"polling_started": 0}
+
+    class _FakeObserver:
+        def schedule(self, *_args, **_kwargs) -> None:
+            return None
+
+        def start(self) -> None:
+            raise OSError(errno.ENOSPC, "watch limit reached")
+
+        def stop(self) -> None:
+            return None
+
+        def join(self, timeout: float = 0.0) -> None:
+            return None
+
+    class _FakePollingObserver:
+        def schedule(self, *_args, **_kwargs) -> None:
+            return None
+
+        def start(self) -> None:
+            events["polling_started"] += 1
+
+        def stop(self) -> None:
+            return None
+
+        def join(self, timeout: float = 0.0) -> None:
+            return None
+
+    monkeypatch.setattr(fs_watcher, "Observer", _FakeObserver)
+    monkeypatch.setattr(fs_watcher, "PollingObserver", _FakePollingObserver)
+
+    watcher = fs_watcher.RepoChangeWatcher(temp_repo)
+    watcher.start()
+    try:
+        assert events["polling_started"] == 1
+    finally:
+        watcher.stop()

--- a/tests/test_daemon/test_http.py
+++ b/tests/test_daemon/test_http.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+from fastapi.testclient import TestClient
+
+from vaner.daemon.http import create_daemon_http_app
+from vaner.models.config import VanerConfig
+from vaner.models.scenario import Scenario
+from vaner.store.scenarios import ScenarioStore
+
+
+def test_cockpit_root_serves_html_and_expected_endpoints(temp_repo) -> None:
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+    )
+    app = create_daemon_http_app(config)
+    with TestClient(app) as client:
+        response = client.get("/")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "Vaner Cockpit" in response.text
+    assert 'data-mode="daemon"' in response.text
+    assert 'window.__VANER_MODE = "daemon"' in response.text
+    assert "/scenarios/stream" in response.text
+    assert "/compute/devices" in response.text
+    assert "/scenarios/" in response.text
+
+
+def test_status_payload_includes_backend(temp_repo) -> None:
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+    )
+    app = create_daemon_http_app(config)
+    with TestClient(app) as client:
+        response = client.get("/status")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "backend" in payload
+    assert payload["backend"]["base_url"] == config.backend.base_url
+    assert payload["backend"]["model"] == config.backend.model
+
+
+def test_ui_route_redirects_to_root(temp_repo) -> None:
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+    )
+    app = create_daemon_http_app(config)
+    with TestClient(app) as client:
+        response = client.get("/ui", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/"
+
+
+def test_scenario_stream_route_not_shadowed_by_id_route(temp_repo) -> None:
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+    )
+
+    async def _seed() -> None:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.upsert(
+            Scenario(
+                id="scn_stream_1",
+                kind="debug",
+                score=0.9,
+                confidence=0.8,
+                entities=["src/main.py"],
+                evidence=[],
+                prepared_context="ctx",
+                coverage_gaps=[],
+                freshness="fresh",
+                cost_to_expand="medium",
+                created_at=time.time(),
+            )
+        )
+
+    asyncio.run(_seed())
+
+    app = create_daemon_http_app(config)
+    with TestClient(app) as client:
+        with client.stream("GET", "/scenarios/stream?limit=1") as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+            lines = [line for line in response.iter_lines() if line]
+        data_lines = [line for line in lines if line.startswith("data: ")]
+        assert data_lines
+        payload = json.loads(data_lines[0].removeprefix("data: "))
+        assert payload["id"] == "scn_stream_1"

--- a/tests/test_daemon/test_preflight.py
+++ b/tests/test_daemon/test_preflight.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from vaner.daemon import preflight
+
+
+def test_check_repo_root_refuses_home_without_force() -> None:
+    result = preflight.check_repo_root(Path.home(), force=False)
+    assert result["ok"] is False
+    assert result["reason"] == "unsafe_root"
+
+
+def test_check_repo_root_allows_home_with_force() -> None:
+    result = preflight.check_repo_root(Path.home(), force=True)
+    assert result["ok"] is True
+
+
+def test_check_repo_root_rejects_large_non_git(monkeypatch, temp_repo) -> None:
+    monkeypatch.setattr(preflight, "_is_git_repo", lambda _path: False)
+    monkeypatch.setattr(preflight, "_count_files_limited", lambda _path, limit=100_000: 100_000)
+    result = preflight.check_repo_root(temp_repo, force=False)
+    assert result["ok"] is False
+    assert result["reason"] == "non_git_large_root"
+
+
+def test_check_inotify_budget_warns_when_headroom_low(monkeypatch, temp_repo) -> None:
+    monkeypatch.setattr(preflight, "_read_int_file", lambda _path: 1000)
+    monkeypatch.setattr(preflight, "_estimate_dir_count", lambda _path, limit=200_000: 800)
+    result = preflight.check_inotify_budget(temp_repo)
+    assert result["ok"] is False
+    assert result["level"] == "warn"
+    assert "headroom" in str(result["detail"])

--- a/tests/test_daemon/test_runner.py
+++ b/tests/test_daemon/test_runner.py
@@ -39,3 +39,29 @@ async def test_daemon_respects_max_generations_per_cycle(temp_repo):
 
     # Includes capped file summaries plus a repo index artefact.
     assert written <= config.generation.max_generations_per_cycle + 2
+
+
+@pytest.mark.asyncio
+async def test_daemon_skill_scan_accepts_list_metadata_payloads(temp_repo):
+    skill_path = temp_repo / ".cursor" / "skills" / "vaner" / "sample-skill" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_text(
+        """---
+name: sample-skill
+description: Test skill for daemon payload typing.
+tags: [vaner, feedback]
+triggers: ["src/**", "tests/**"]
+---
+""",
+        encoding="utf-8",
+    )
+
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+    )
+    daemon = VanerDaemon(config)
+    await daemon.initialize()
+    written = await daemon.run_once()
+    assert written >= 1

--- a/tests/test_intent/test_scorer_resilience.py
+++ b/tests/test_intent/test_scorer_resilience.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from vaner.intent import scorer as scorer_module
+from vaner.intent.scorer import IntentScorer
+
+
+def test_load_model_gracefully_handles_backend_decode_errors(tmp_path, monkeypatch) -> None:
+    model_path = tmp_path / "intent-model.json"
+    model_path.write_text("{}", encoding="utf-8")
+
+    class _BrokenBooster:
+        def load_model(self, _path: str) -> None:
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+    class _FakeXgb:
+        @staticmethod
+        def Booster():
+            return _BrokenBooster()
+
+    monkeypatch.setattr(scorer_module, "xgb", _FakeXgb())
+    scorer = IntentScorer()
+    loaded = scorer.load_model(model_path, backend="xgboost")
+    assert loaded is False

--- a/tests/test_router/test_proxy_app.py
+++ b/tests/test_router/test_proxy_app.py
@@ -151,9 +151,13 @@ model = "test-model"
     assert status.status_code == 200
     assert status.json()["health"] == "ok"
 
-    html = client.get("/ui")
+    html = client.get("/")
     assert html.status_code == 200
     assert "Vaner Cockpit" in html.text
+    assert 'data-mode="proxy"' in html.text
+    redirect = client.get("/ui", follow_redirects=False)
+    assert redirect.status_code == 307
+    assert redirect.headers["location"] == "/"
 
     updated = client.post("/compute", json={"cpu_fraction": 0.3})
     assert updated.status_code == 200

--- a/tests/test_router/test_proxy_cockpit.py
+++ b/tests/test_router/test_proxy_cockpit.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from vaner.models.config import BackendConfig, VanerConfig
+from vaner.router.proxy import create_app
+from vaner.store.artefacts import ArtefactStore
+
+
+def test_proxy_cockpit_root_and_ui_redirect(temp_repo) -> None:
+    config = VanerConfig(
+        repo_root=temp_repo,
+        store_path=temp_repo / ".vaner" / "store.db",
+        telemetry_path=temp_repo / ".vaner" / "telemetry.db",
+        backend=BackendConfig(base_url="http://127.0.0.1:11434/v1", model="test-model"),
+    )
+    app = create_app(config, ArtefactStore(config.store_path))
+    with TestClient(app) as client:
+        root = client.get("/")
+        ui_redirect = client.get("/ui", follow_redirects=False)
+    assert root.status_code == 200
+    assert root.headers["content-type"].startswith("text/html")
+    assert 'data-mode="proxy"' in root.text
+    assert ui_redirect.status_code == 307
+    assert ui_redirect.headers["location"] == "/"


### PR DESCRIPTION
## Summary
- add a single-command supervised startup path via `vaner up` / `vaner down` with pid/log management and health waits
- harden startup and diagnostics with preflight guardrails (repo-root safety, inotify budget checks, port conflict remediation) and inotify->polling fallback
- unify `status` + `doctor` around a shared runtime snapshot, expand onboarding docs/install messaging, and bump release metadata to `0.4.0`

## Test plan
- [x] `ruff check src tests`
- [x] `pytest` (full Vaner suite)
- [x] targeted onboarding tests (up/down, preflight, fs watcher fallback, doctor/status consistency, daemon port handling)

Made with [Cursor](https://cursor.com)