### PR TITLE
ci: make windows verify non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   verify:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     timeout-minutes: 30
     env:
       PYTHONPATH: src


### PR DESCRIPTION
## Summary
- keep the Windows verify leg in CI for compatibility signal
- mark only the Windows matrix leg as non-blocking using `continue-on-error`
- keep Linux and macOS legs fully blocking for merge confidence

## Test plan
- [x] YAML hooks (`check yaml`) pass locally
- [x] Workflow syntax validated by GitHub Actions on PR

Made with [Cursor](https://cursor.com)