### PR TITLE
fix: ship vaner 0.6.2 hardening (refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - _TBD_
 
+## [0.6.2] - 2026-04-21
+
+### Fixed
+
+- Fixed version-pinned installer fallback so `VANER_VERSION=<tag>` can fall back to the matching GitHub tag when PyPI does not have that release yet.
+- Fixed the default install/query path to degrade gracefully when `sentence-transformers` is unavailable instead of crashing at first query-time embedding use.
+- Fixed `vaner uninstall` so repo-local Cursor MCP wiring is removed correctly when `vaner init` created `.cursor/mcp.json`.
+- Fixed managed feedback skill content drift by shipping a single current `vaner.feedback`-based skill template instead of duplicated legacy tool instructions.
+- Improved MCP v1 `suggest` / `search` ranking in fresh repos so Vaner-managed config/skill files are downranked unless the query explicitly targets them.
+
+### Added
+
+- Added regression tests for pinned installer fallback, uninstall symmetry, managed skill content, graceful missing-embedding fallback, and MCP ranking around Vaner-managed files.
+
 ## [0.6.1] - 2026-04-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Common installer flags:
 - `--with-ollama`
 - `--minimal` (legacy minimal extras; pairs with `--no-mcp` when needed)
 - `--backend-preset ollama|lmstudio|vllm|openai|anthropic|openrouter|skip`
+- `--backend-url <url>`, `--backend-model <model>`, `--backend-api-key-env <env>`
 - `--compute-preset background|balanced|dedicated`
 - `--max-session-minutes <n>`
 - `--no-mcp` (skip MCP extras)
@@ -50,9 +51,9 @@ Common installer flags:
 ### Manual install (advanced)
 
 ```bash
-pipx install 'vaner[mcp]'
+pipx install 'vaner[all]'
 # or
-uv tool install 'vaner[mcp]'
+uv tool install 'vaner[all]'
 ```
 
 ### Upgrade
@@ -66,7 +67,8 @@ vaner version
 
 Vaner stores local runtime state in your repository under `.vaner/` (for example `store.db`, `scenarios.db`,
 `metrics.db`, and `telemetry.db`). Retention is controlled by `limits.max_age_seconds` in `.vaner/config.toml`.
-Old signal/replay/query and stale cache entries are purged during precompute cycles.
+Old signal/replay/query and stale cache entries are purged during engine/precompute activity. There is not yet a
+separate `prune` or `compact` command.
 
 Useful commands:
 
@@ -88,10 +90,18 @@ Key non-interactive flags:
 - `--backend-model` and `--backend-api-key-env`
 - `--compute-preset background|balanced|dedicated`
 - `--max-session-minutes <n>`
-- `--clients auto|all|none|other|<csv>`
 - `--force`
-- `--dry-run`
-- `--accept-cloud-costs`
+- `--interactive/--no-interactive`
+- `--no-mcp`
+
+What `vaner init` does by default:
+
+- writes repo-local config to `.vaner/config.toml`
+- writes repo-local Cursor MCP wiring to `.cursor/mcp.json`
+- writes managed feedback skills to `.cursor/skills/vaner/vaner-feedback/SKILL.md` and `~/.claude/skills/vaner/vaner-feedback/SKILL.md`
+
+Use `vaner init --no-mcp --path .` if you want config only and do not want Vaner to wire MCP clients or managed
+skills. If Cursor is already open, reload the window after `vaner init` so the new MCP server is picked up.
 
 Start / verify runtime:
 

--- a/docs/testing/2026-04-v0.6.1-install-findings.md
+++ b/docs/testing/2026-04-v0.6.1-install-findings.md
@@ -1,0 +1,273 @@
+# Vaner v0.6.1 install and usage findings (Linux)
+
+## Environment
+
+- Host: Linux 6.17.0-20-generic, bash.
+- Prior install at start of test: `vaner 0.6.0` via `uv tool`.
+- Previous global state quarantined to `~/.vaner.bak-v060-test`.
+- Test sandboxes:
+  - `/tmp/vaner-061-test`
+  - `/tmp/vaner-061-nomcp`
+  - `/tmp/vaner-061-keepstate`
+  - `/tmp/vaner-061-retention`
+- Installer under test: local `scripts/install.sh` from the `v0.6.1` repo checkout.
+- Release artifact used for continuation after installer failure: GitHub release wheel `vaner-0.6.1-py3-none-any.whl`.
+
+## Install path findings
+
+- Starting point was a real-upgrade environment:
+  - existing `~/.cursor/mcp.json`
+  - existing global `~/.vaner/`
+  - 50 stale `~/.cursor/mcp.json.vaner-backup-*` files from older runs
+- Pre-cleanup and quarantine worked as intended for the test itself:
+  - old `~/.vaner/` moved aside
+  - `~/.cursor/mcp.json` preserved to `~/.cursor/mcp.json.pre-061-test`
+  - stale backup pile removed before retest
+
+### Installer behavior
+
+- `VANER_YES=1 VANER_VERSION=0.6.1 bash scripts/install.sh` fails hard immediately:
+  - `No solution found when resolving dependencies`
+  - because `vaner[mcp]==0.6.1` is not published on PyPI
+  - no GitHub/release fallback occurs on the version-pinned path
+- Manual install from the GitHub release wheel succeeds:
+  - `uv tool install --force /tmp/vaner-061-install/vaner-0.6.1-py3-none-any.whl`
+  - `vaner --version` then reports `vaner 0.6.1`
+- Re-running `VANER_YES=1 bash scripts/install.sh` without pinning succeeds and keeps MCP wiring stable:
+  - `~/.cursor/mcp.json` still points at `/home/abo/.local/bin/vaner mcp --path /home/abo`
+  - backup rotation/no-op behavior is much better than before: no new `~/.cursor/mcp.json.vaner-backup-*` pileup was created in this rerun
+
+### Important install regression
+
+- After the wheel install plus installer rerun, `vaner query ...` fails with:
+  - `ModuleNotFoundError: No module named 'sentence_transformers'`
+- Net effect:
+  - MCP transport boots
+  - CLI baseline works
+  - but at least one real query/intention path is not install-complete on this machine after the tested release install flow
+
+## Init behavior findings
+
+- `vaner init --path <repo>` writes:
+  - `<repo>/.vaner/config.toml`
+  - `<repo>/.cursor/mcp.json`
+  - `<repo>/.cursor/skills/vaner/vaner-feedback/SKILL.md`
+  - `~/.claude/skills/vaner/vaner-feedback/SKILL.md`
+- `vaner init --no-mcp --path <repo>` behaves well for MCP opt-out:
+  - no project `.cursor/` directory is created
+  - global `~/.cursor/mcp.json` stays unchanged
+  - a pre-existing `AGENTS.md` stayed unchanged
+
+### Skill file behavior
+
+- Managed skill content is unexpectedly duplicated on repeated install/init runs.
+- Observed both in:
+  - `~/.cursor/skills/vaner/vaner-feedback/SKILL.md`
+  - `~/.claude/skills/vaner/vaner-feedback/SKILL.md`
+- In this test those files contained the same skill block repeated 3 times.
+- The content is also stale relative to the new MCP v1 surface:
+  - it still references `list_scenarios`, `get_scenario`, `expand_scenario`, and `report_outcome`
+  - those are legacy tool names, not the current `vaner.*` tool surface
+
+## CLI smoke findings
+
+### Passing commands
+
+- `vaner --version`
+- `vaner init --path /tmp/vaner-061-test`
+- `vaner status --path /tmp/vaner-061-test`
+- `vaner doctor --path /tmp/vaner-061-test`
+- `vaner config show --path /tmp/vaner-061-test`
+- `vaner config keys --path /tmp/vaner-061-test`
+- `vaner config set intent.lookback_turns 6 --path /tmp/vaner-061-test`
+- `vaner scenarios list --path /tmp/vaner-061-test`
+- `timeout -s INT 8s vaner up --path /tmp/vaner-061-test`
+- `vaner down --path /tmp/vaner-061-test`
+- `vaner forget --path /tmp/vaner-061-test`
+- `vaner uninstall --path /tmp/vaner-061-test`
+
+### Improvements confirmed vs v0.6.0
+
+- `vaner config show` no longer crashes.
+- `vaner config keys` no longer crashes.
+- `vaner config set intent.lookback_turns 6` now works and persists.
+- `vaner uninstall` now exists.
+
+### CLI caveats
+
+- `vaner doctor --path /tmp/vaner-061-test` exits non-zero in a fresh repo because backend/cockpit/daemon are not configured or running yet.
+  - This is reasonable behavior, but it is part of the first-run user experience.
+- `vaner up` still behaves like an attached foreground flow unless interrupted.
+
+## MCP surface and protocol findings
+
+### Direct stdio probe
+
+- Direct MCP client initialization against `vaner mcp --path /tmp/vaner-061-test` now works.
+- Server reports:
+  - name: `vaner`
+  - version: `1.0.0`
+  - tool count: `10`
+- Advertised tools:
+  - `vaner.status`
+  - `vaner.suggest`
+  - `vaner.resolve`
+  - `vaner.expand`
+  - `vaner.search`
+  - `vaner.explain`
+  - `vaner.feedback`
+  - `vaner.warm`
+  - `vaner.inspect`
+  - `vaner.debug.trace`
+
+### Direct SSE probe
+
+- `vaner mcp --transport sse --host 127.0.0.1 --port 8482 --path /tmp/vaner-061-test` started successfully.
+- `curl -I http://127.0.0.1:8482/sse` returned `200 OK`.
+- MCP SSE client initialization succeeded and `vaner.status` responded successfully.
+
+### Tool behavior quality
+
+- `vaner.status` works and returns a sane readiness payload.
+- `vaner.suggest` works without crashing, but the returned suggestions were weak/misaligned in this fresh sandbox.
+  - Example suggestions pointed to `.cursor/skills/vaner/vaner-feedback/SKILL.md` and `.cursor/mcp.json` for an install-script edit question.
+- `vaner.search` works without crashing, but also returned weak results in the fresh sandbox.
+- `vaner.resolve` fails cleanly when no backend is configured:
+  - error code: `backend_not_configured`
+  - message includes concrete remediation commands
+
+## Cursor integration findings
+
+- The standalone MCP server works, but Vaner did not become usable as an MCP server directly inside this already-running Cursor agent session.
+- Current session MCP descriptors still only expose the built-in/plugin servers under the session `mcps/` directory; there was no `vaner` server folder for this live session.
+- Net effect:
+  - `~/.cursor/mcp.json` was written correctly
+  - but this conversation/session did not dynamically gain access to Vaner through `CallMcpTool`
+  - a reload/restart boundary still appears necessary before Cursor picks up the newly wired server
+
+## System-prompt and takeover safety findings
+
+- Good:
+  - `--no-mcp` is a real opt-out for project-level MCP/client wiring
+  - pre-existing `AGENTS.md` stayed untouched in the no-MCP journey
+  - global `~/.cursor/mcp.json` was unchanged by `vaner init --no-mcp`
+- Mixed:
+  - standard `vaner init` still writes managed skills outside the repo (`~/.claude/...`)
+  - repeated installs/inits append duplicated skill content instead of keeping one clean managed block
+- Interpretation:
+  - Vaner is not directly overwriting the repo system prompt material tested here
+  - but it is still injecting global managed skill files by default, and those writes are not cleanly idempotent
+
+## Uninstall findings
+
+### Positive
+
+- `vaner uninstall` now exists.
+- `vaner uninstall --keep-state` preserves `<repo>/.vaner/` as expected.
+- Managed project skill files were removed.
+
+### Remaining uninstall bug
+
+- Project MCP config removal is not reliable.
+- In two separate uninstall checks:
+  - `/tmp/vaner-061-test/.cursor/mcp.json` still existed after uninstall
+  - it still contained the live `vaner` MCP server entry
+  - `vaner uninstall --keep-state --path /tmp/vaner-061-keepstate` reported `updated 0 client configs`
+- Net effect:
+  - uninstall looks successful in the summary output
+  - but project-local Cursor MCP wiring can remain active
+
+## Retention and DB growth findings
+
+### Short retention burn
+
+- Fresh repo before any workload:
+  - no local `.db` files existed under `/tmp/vaner-061-retention/.vaner/`
+- After:
+  - 10 failed `vaner query` attempts
+  - plus `timeout -s INT 15s vaner up --path /tmp/vaner-061-retention`
+- Resulting DB files:
+  - `store.db`: 299008 bytes
+  - `scenarios.db`: 40960 bytes
+  - `metrics.db`: 53248 bytes
+  - `telemetry.db`: 12288 bytes
+
+### Table counts after the short run
+
+- `store.db`
+  - `signal_events`: 2
+  - `artefacts`: 2
+  - `query_history`: 0
+  - `prediction_cache`: 0
+  - `hypotheses`: 0
+
+### Query failure in the retention test
+
+- `vaner query probe query N --path /tmp/vaner-061-retention` failed every time with:
+  - `ModuleNotFoundError: No module named 'sentence_transformers'`
+- This blocked a fuller retention/aging exercise through the normal query path.
+
+### Code-level retention behavior observed
+
+- Purge hooks still exist and are still invoked from `Engine.precompute()`:
+  - `purge_old_signal_events`
+  - `purge_old_replay_entries`
+  - `purge_old_query_history`
+  - `purge_expired_prediction_cache`
+  - `purge_stale_patterns`
+- Retention default is still `max_age_seconds = 3600`.
+- Engine still clamps retention with `max(3600, int(self.config.max_age_seconds))`.
+- Practical gap remains:
+  - purge is coupled to engine/precompute activity
+  - there is still no dedicated user-facing `prune`/`compact` command for explicit DB hygiene
+
+## Severity-ranked issues
+
+### Broken
+
+1. Version-pinned installer path for the new release is broken when PyPI is missing.
+   - Repro: `VANER_YES=1 VANER_VERSION=0.6.1 bash scripts/install.sh`
+   - Result: dependency resolution fails and install aborts instead of falling back.
+2. Installed v0.6.1 environment still has a missing runtime dependency for real query flow on this machine.
+   - Repro: `vaner query "probe query" --path /tmp/vaner-061-retention`
+   - Result: `ModuleNotFoundError: No module named 'sentence_transformers'`
+3. `vaner uninstall` does not fully remove project-local Cursor MCP wiring.
+   - Repro: `vaner init --path <repo>` then `vaner uninstall --path <repo>`
+   - Result: `<repo>/.cursor/mcp.json` can remain in place with the `vaner` entry still active.
+
+### Degraded
+
+1. Cursor session pickup is not live enough for immediate in-session MCP use after install/init.
+   - The server works directly over stdio and SSE, but this active Cursor agent session did not gain a usable `vaner` MCP server without a reload boundary.
+2. `vaner.suggest` and `vaner.search` returned weak, low-signal results in a fresh sandbox for an install-script-oriented prompt.
+3. Managed skill files are duplicated across repeated install/init runs.
+
+### UX-smell
+
+1. Managed skill content is outdated and still references the legacy pre-v1 tool names.
+2. Standard init/install still writes global managed Claude skill files by default, which can feel like cross-client takeover even when the user is mainly focused on Cursor.
+3. `vaner up` remains foreground/attached and easy to leave running unless the user interrupts it explicitly.
+
+### Nit
+
+1. Fresh `doctor` output is accurate but still reads fairly failure-heavy for a normal first-run local-only repo.
+2. Installer output still includes VS Code extension build steps even in a CLI/MCP-first workflow.
+
+## Fixed-from-v0.6.0
+
+1. MCP server bootstrap crash is fixed for both stdio and SSE.
+2. `config show` / `config keys` crash is fixed.
+3. `intent.lookback_turns` can now be set through CLI config.
+4. Backup-file explosion in `~/.cursor` did not reproduce in the v0.6.1 rerun.
+5. `vaner uninstall` now exists, even though its project MCP cleanup is still incomplete.
+
+## Backlog items to pin
+
+1. Make the version-pinned installer path fall back to GitHub release assets or GitHub source when PyPI is unavailable.
+2. Ensure the advertised install path yields a fully working query/intention stack, including `sentence_transformers` where required.
+3. Fix `vaner uninstall` so it actually removes project-local `.cursor/mcp.json` Vaner entries and reports accurate counts.
+4. Make managed skill writes idempotent and replace-in-place rather than append.
+5. Update managed skill content to the current MCP v1 tool surface.
+6. Decide whether global skill/config writes should be opt-in or split by client target.
+7. Improve first-run relevance quality for `vaner.suggest` / `vaner.search` in sparse repos.
+8. Add a dedicated retention hygiene command (`vaner prune` / `vaner compact`) and document exactly what gets purged when.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vaner"
-version = "0.6.1"
+version = "0.6.2"
 description = "Predictive context middleware layer for AI workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -720,10 +720,14 @@ package_base_spec() {
 github_package_spec() {
   local extras
   extras="$(package_extras)"
+  local ref=""
+  if [[ -n "$VANER_VERSION" ]]; then
+    ref="@v$VANER_VERSION"
+  fi
   if [[ -n "$extras" ]]; then
-    printf 'vaner%s @ git+https://github.com/Borgels/vaner.git' "$extras"
+    printf 'vaner%s @ git+https://github.com/Borgels/vaner.git%s' "$extras" "$ref"
   else
-    printf 'git+https://github.com/Borgels/vaner.git'
+    printf 'git+https://github.com/Borgels/vaner.git%s' "$ref"
   fi
 }
 
@@ -754,24 +758,25 @@ install_vaner_with_uv() {
       return 0
     fi
   fi
-  if [[ -z "$VANER_VERSION" ]]; then
+  if [[ -n "$VANER_VERSION" ]]; then
+    ui_warn "Pinned PyPI package 'vaner==$VANER_VERSION' not found. Falling back to matching GitHub tag."
+  else
     ui_warn "PyPI package 'vaner' not found yet. Falling back to GitHub source install."
-    run_cmd uv tool install --upgrade "$(github_package_spec)"
-    return 0
   fi
-  return 1
+  run_cmd uv tool install --upgrade "$(github_package_spec)"
+  return 0
 }
 
 install_vaner_with_pipx() {
   local spec
   spec="$(package_spec)"
   if ! run_cmd pipx install --force "$spec"; then
-    if [[ -z "$VANER_VERSION" ]]; then
-      ui_warn "PyPI package 'vaner' not found yet. Falling back to GitHub source install."
-      run_cmd pipx install --force "$(github_package_spec)"
+    if [[ -n "$VANER_VERSION" ]]; then
+      ui_warn "Pinned PyPI package 'vaner==$VANER_VERSION' not found. Falling back to matching GitHub tag."
     else
-      return 1
+      ui_warn "PyPI package 'vaner' not found yet. Falling back to GitHub source install."
     fi
+    run_cmd pipx install --force "$(github_package_spec)"
   fi
   if [[ "$VANER_NO_MODIFY_PATH" != "1" ]]; then
     run_cmd pipx ensurepath
@@ -838,7 +843,7 @@ print_install_plan() {
   local extras
   extras="$(package_extras)"
   if [[ -n "$VANER_VERSION" ]]; then
-    printf '  package: vaner%s==%s\n' "$extras" "$VANER_VERSION"
+    printf '  package: vaner%s==%s (fallback to GitHub tag if PyPI unavailable)\n' "$extras" "$VANER_VERSION"
   else
     printf '  package: vaner%s (latest; fallback to GitHub source if PyPI unavailable)\n' "$extras"
   fi

--- a/src/vaner/_version.py
+++ b/src/vaner/_version.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "0.6.1"
+VERSION = "0.6.2"

--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -119,7 +119,12 @@ def _remove_vaner_from_json_config(path: Path, *, container_key: str = "mcpServe
         return False
     for key in keys_to_remove:
         container.pop(key, None)
-    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    if not container:
+        payload.pop(container_key, None)
+    if payload:
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    else:
+        path.unlink(missing_ok=True)
     return True
 
 
@@ -139,9 +144,18 @@ def _remove_managed_skill(path: Path) -> bool:
 
 def _remove_mcp_config_entries(repo_root: Path) -> int:
     updated = 0
+    updated_paths: set[Path] = set()
+
+    repo_cursor = repo_root / ".cursor" / "mcp.json"
+    if _remove_vaner_from_json_config(repo_cursor, container_key="mcpServers"):
+        updated += 1
+        updated_paths.add(repo_cursor)
+
     for detected in mcp_clients.detect_all(repo_root):
         config_path = detected.path
         if config_path is None:
+            continue
+        if config_path in updated_paths:
             continue
         if detected.spec.kind == "json-mcpServers":
             if _remove_vaner_from_json_config(config_path, container_key="mcpServers"):

--- a/src/vaner/cli/commands/mcp_clients.py
+++ b/src/vaner/cli/commands/mcp_clients.py
@@ -100,7 +100,7 @@ def _cline_path() -> Path:
 
 
 def _detect_cursor(repo_root: Path) -> Path | None:
-    candidates = [_home() / ".cursor", repo_root / ".cursor"]
+    candidates = [repo_root / ".cursor", _home() / ".cursor"]
     return next((candidate for candidate in candidates if candidate.exists()), None)
 
 
@@ -157,6 +157,9 @@ def _detect_roo(_repo_root: Path) -> Path | None:
 
 
 def _cursor_config(_repo_root: Path) -> Path:
+    repo_cursor = _repo_root / ".cursor" / "mcp.json"
+    if repo_cursor.exists():
+        return repo_cursor
     return _home() / ".cursor" / "mcp.json"
 
 

--- a/src/vaner/clients/embeddings.py
+++ b/src/vaner/clients/embeddings.py
@@ -10,13 +10,13 @@ def sentence_transformer_embed(
     model: str = "all-MiniLM-L6-v2",
     device: str = "cpu",
 ) -> Callable[[list[str]], Awaitable[list[list[float]]]]:
+    from sentence_transformers import SentenceTransformer
+
     encoder = None
 
     async def _call(texts: list[str]) -> list[list[float]]:
         nonlocal encoder
         if encoder is None:
-            from sentence_transformers import SentenceTransformer
-
             encoder = SentenceTransformer(model, device=device)
         vectors = encoder.encode(texts, convert_to_numpy=True, normalize_embeddings=True)
         return [vector.tolist() for vector in vectors]

--- a/src/vaner/defaults/skills/vaner-feedback/SKILL.md
+++ b/src/vaner/defaults/skills/vaner-feedback/SKILL.md
@@ -10,36 +10,6 @@ x-vaner-managed: true
 
 Use this skill when finishing a task that used Vaner MCP scenarios.
 
-1. Keep scenario ids returned by `list_scenarios`, `get_scenario`, or `expand_scenario`.
-2. Call `report_outcome` with `id`, `result` (`useful` | `partial` | `irrelevant`), and optional `note`.
-3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and adjust future frontier weights.
----
-name: vaner-feedback
-description: Report scenario outcomes back to Vaner after completing a task.
-tags: [vaner, feedback]
-vaner:
-  kind: research
-  feedback: auto
-x-vaner-managed: true
----
-
-Use this skill when finishing a task that used Vaner MCP scenarios.
-
-1. Keep scenario ids returned by `list_scenarios`, `get_scenario`, or `expand_scenario`.
-2. Call `report_outcome` with `id`, `result` (`useful` | `partial` | `irrelevant`), and optional `note`.
-3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and adjust future frontier weights.
----
-name: vaner-feedback
-description: Report scenario outcomes back to Vaner after completing a task.
-tags: [vaner, feedback]
-vaner:
-  kind: research
-  feedback: auto
-x-vaner-managed: true
----
-
-Use this skill when finishing a task that used Vaner MCP scenarios.
-
-1. Keep scenario ids returned by `list_scenarios`, `get_scenario`, or `expand_scenario`.
-2. Call `report_outcome` with `id`, `result` (`useful` | `partial` | `irrelevant`), and optional `note`.
-3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and adjust future frontier weights.
+1. Keep the `resolution_id` returned by `vaner.resolve`, and note any item ids you want to praise or reject from `vaner.expand` / `vaner.search`.
+2. Call `vaner.feedback` with `rating` (`useful` | `partial` | `wrong` | `irrelevant`) and include `resolution_id` plus any optional `correction`, `preferred_items`, or `rejected_items`.
+3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and improve future scenario ranking.

--- a/src/vaner/intent/cache.py
+++ b/src/vaner/intent/cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import math
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -12,6 +13,8 @@ from pydantic import ValidationError
 from vaner.intent.scoring_policy import ScoringPolicy
 from vaner.models.context import ContextPackage
 from vaner.store.artefacts import ArtefactStore
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -63,7 +66,12 @@ class TieredPredictionCache:
     async def _embed_prompt(self, prompt: str) -> list[float] | None:
         if self.embed is None:
             return None
-        vectors = await self.embed([prompt])
+        try:
+            vectors = await self.embed([prompt])
+        except Exception as exc:
+            logger.warning("Vaner cache embeddings unavailable (%s); falling back to lexical matching.", exc)
+            self.embed = None
+            return None
         if not vectors:
             return None
         vector = vectors[0]

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -74,6 +74,12 @@ BACKEND_NOT_CONFIGURED_MESSAGE = (
 )
 
 _SUGGESTION_CACHE_CAPACITY = 128
+_MANAGED_PATH_MARKERS = (
+    ".cursor/mcp.json",
+    ".cursor/skills/vaner/vaner-feedback/skill.md",
+    ".claude/skills/vaner/vaner-feedback/skill.md",
+)
+_MANAGED_QUERY_HINTS = {"mcp", "cursor", "claude", "skill", "skills", "feedback", "config", "prompt"}
 
 
 def _make_text(content: str) -> list[TextContent]:
@@ -132,6 +138,33 @@ def _scenario_to_summary(scenario: Scenario) -> dict[str, Any]:
 def _build_decision_id(prompt: str) -> str:
     digest = hashlib.sha256(f"{prompt}-{time.time_ns()}".encode()).hexdigest()[:16]
     return f"dec_{digest}"
+
+
+def _normalize_path(value: str) -> str:
+    return value.replace("\\", "/").strip().lower()
+
+
+def _scenario_paths(scenario: Scenario) -> set[str]:
+    paths = {_normalize_path(entity) for entity in scenario.entities if entity}
+    paths.update(_normalize_path(ref.source_path) for ref in scenario.evidence if ref.source_path)
+    return {path for path in paths if path}
+
+
+def _query_targets_managed_files(query_tokens: set[str]) -> bool:
+    return bool(query_tokens & _MANAGED_QUERY_HINTS)
+
+
+def _is_managed_path(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return any(normalized.endswith(marker) for marker in _MANAGED_PATH_MARKERS)
+
+
+def _scenario_penalty(scenario: Scenario, query_tokens: set[str]) -> float:
+    if _query_targets_managed_files(query_tokens):
+        return 0.0
+    if any(_is_managed_path(path) for path in _scenario_paths(scenario)):
+        return 0.35
+    return 0.0
 
 
 def build_server(repo_root: Path) -> Server:
@@ -350,7 +383,10 @@ def build_server(repo_root: Path) -> Server:
             ranked: list[dict[str, Any]] = []
             for scenario in scenarios:
                 overlap = len(query_tokens & set(tok.lower() for tok in scenario.entities))
-                confidence = min(0.98, 0.25 + (overlap * 0.15) + (scenario.score * 0.45))
+                confidence = min(
+                    0.98,
+                    max(0.0, 0.25 + (overlap * 0.15) + (scenario.score * 0.45) - _scenario_penalty(scenario, query_tokens)),
+                )
                 label = f"{scenario.kind} / {' '.join(scenario.entities[:4]) or scenario.id}"
                 suggestion_id = f"sug_{hashlib.sha1((query + scenario.id).encode('utf-8')).hexdigest()[:8]}"
                 item = {
@@ -388,11 +424,14 @@ def build_server(repo_root: Path) -> Server:
             scenarios = await scenario_store.list_top(limit=25)
             candidate: Scenario | None = None
             best_overlap = -1
+            best_rank = float("-inf")
             for scenario in scenarios:
                 overlap = len(query_tokens & set(tok.lower() for tok in scenario.entities))
-                if overlap > best_overlap or (overlap == best_overlap and candidate and scenario.score > candidate.score):
+                rank = scenario.score - _scenario_penalty(scenario, query_tokens)
+                if overlap > best_overlap or (overlap == best_overlap and rank > best_rank):
                     candidate = scenario
                     best_overlap = overlap
+                    best_rank = rank
             if candidate is None:
                 await aprecompute(repo_root, config=config)
                 scenarios = await scenario_store.list_top(limit=25)
@@ -715,13 +754,17 @@ def build_server(repo_root: Path) -> Server:
                 score = len(query_tokens & set(tok.lower() for tok in scenario.entities))
                 if score <= 0 and mode == "lexical":
                     continue
+                final_score = round(
+                    max(0.0, min(1.0, 0.2 + score * 0.2 + scenario.score * 0.5 - _scenario_penalty(scenario, query_tokens))),
+                    4,
+                )
                 results.append(
                     {
                         "id": f"res_{idx}",
                         "source": scenario.id,
                         "kind": "file",
                         "snippet": scenario.prepared_context[:160],
-                        "score": round(min(1.0, 0.2 + score * 0.2 + scenario.score * 0.5), 4),
+                        "score": final_score,
                     }
                 )
             results.sort(key=lambda item: float(item["score"]), reverse=True)

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
 from vaner.cli.commands.init import init_repo, write_mcp_configs
 
 
@@ -41,3 +45,36 @@ def test_write_mcp_configs_prefers_absolute_vaner_binary(temp_repo, monkeypatch)
     assert launcher == "/usr/local/bin/vaner"
     cursor_payload = (temp_repo / ".cursor" / "mcp.json").read_text(encoding="utf-8")
     assert "/usr/local/bin/vaner" in cursor_payload
+
+
+def test_write_mcp_configs_writes_single_current_feedback_skill(temp_repo, monkeypatch):
+    fake_home = temp_repo / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    write_mcp_configs(temp_repo)
+    repo_skill = (temp_repo / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert repo_skill.count("---") == 2
+    assert "vaner.feedback" in repo_skill
+    assert "report_outcome" not in repo_skill
+    assert "list_scenarios" not in repo_skill
+
+
+def test_uninstall_removes_repo_cursor_wiring_and_skills(temp_repo, monkeypatch):
+    fake_home = temp_repo / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    write_mcp_configs(temp_repo)
+    runner = CliRunner()
+    result = runner.invoke(app, ["uninstall", "--path", str(temp_repo)])
+
+    assert result.exit_code == 0
+
+    repo_mcp = temp_repo / ".cursor" / "mcp.json"
+    assert not repo_mcp.exists() or "vaner" not in json.loads(repo_mcp.read_text(encoding="utf-8")).get("mcpServers", {})
+    assert not (temp_repo / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md").exists()
+    assert not (fake_home / ".claude" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md").exists()

--- a/tests/test_cli/test_install_script_fallback.py
+++ b/tests/test_cli/test_install_script_fallback.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shlex
 import subprocess
 from pathlib import Path
 
@@ -8,7 +7,10 @@ from pathlib import Path
 def _run_install_shell(body: str) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).resolve().parents[2]
     script_path = repo_root / "scripts" / "install.sh"
-    command = f"source <(sed '$d' {shlex.quote(str(script_path))}); {body}"
+    script_text = script_path.read_text(encoding="utf-8")
+    prefix, marker, _ = script_text.rpartition('\nmain "$@"\n')
+    assert marker, "expected install.sh to end with main invocation"
+    command = f"{prefix}\n{body}\n"
     return subprocess.run(
         ["bash", "-lc", command],
         cwd=repo_root,

--- a/tests/test_cli/test_install_script_fallback.py
+++ b/tests/test_cli/test_install_script_fallback.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+
+def _run_install_shell(body: str) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "install.sh"
+    command = f"source <(sed '$d' {shlex.quote(str(script_path))}); {body}"
+    return subprocess.run(
+        ["bash", "-lc", command],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_version_pinned_uv_install_falls_back_to_matching_git_tag() -> None:
+    result = _run_install_shell(
+        """
+VANER_VERSION=0.6.2
+VANER_NO_MCP=0
+VANER_MINIMAL=0
+calls=()
+run_cmd() {
+  local joined="$*"
+  calls+=("$joined")
+  if [[ "$joined" == *"vaner[all]==0.6.2"* ]]; then
+    return 1
+  fi
+  if [[ "$joined" == *"git+https://github.com/Borgels/vaner.git@v0.6.2"* ]]; then
+    return 0
+  fi
+  return 1
+}
+ui_warn() { :; }
+install_vaner_with_uv
+printf '%s\n' "${calls[@]}"
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "uv tool install --upgrade vaner[all]==0.6.2" in result.stdout
+    assert "git+https://github.com/Borgels/vaner.git@v0.6.2" in result.stdout

--- a/tests/test_cli/test_query.py
+++ b/tests/test_cli/test_query.py
@@ -37,3 +37,32 @@ def test_run_query_returns_injected_context_and_writes_inspect(temp_repo):
     inspect_path = temp_repo / ".vaner" / "runtime" / "last_context.md"
     assert "sample.py" in result
     assert inspect_path.exists()
+
+
+def test_run_query_gracefully_disables_missing_embeddings(temp_repo, monkeypatch):
+    init_repo(temp_repo)
+    store = ArtefactStore(temp_repo / ".vaner" / "store.db")
+
+    async def _seed() -> None:
+        await store.initialize()
+        await store.upsert(
+            Artefact(
+                key="file_summary:sample.py",
+                kind=ArtefactKind.FILE_SUMMARY,
+                source_path="sample.py",
+                source_mtime=time.time(),
+                generated_at=time.time(),
+                model="test",
+                content="authentication flow and token validation",
+            )
+        )
+
+    asyncio.run(_seed())
+    monkeypatch.setattr(
+        "vaner.clients.embeddings.sentence_transformer_embed",
+        lambda **_: (_ for _ in ()).throw(ModuleNotFoundError("No module named 'sentence_transformers'")),
+    )
+
+    result = run_query(temp_repo, "explain authentication flow")
+
+    assert "sample.py" in result

--- a/tests/test_docs/test_mcp_tool_matrix.py
+++ b/tests/test_docs/test_mcp_tool_matrix.py
@@ -84,3 +84,13 @@ def test_source_and_docs_do_not_reference_removed_tools() -> None:
             if pattern.search(text):
                 violations.append(f"{path}: {pattern.pattern}")
     assert violations == []
+
+
+def test_readme_init_flags_match_current_cli_surface() -> None:
+    root = Path(__file__).resolve().parents[2]
+    readme = (root / "README.md").read_text(encoding="utf-8")
+
+    assert "--clients" not in readme
+    assert "--accept-cloud-costs" not in readme
+    assert "--no-mcp" in readme
+    assert "--interactive/--no-interactive" in readme

--- a/tests/test_mcp_v2/test_search.py
+++ b/tests/test_mcp_v2/test_search.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+
+from vaner.models.scenario import EvidenceRef, Scenario
+from vaner.store.scenarios import ScenarioStore
+
 from .conftest import call_tool, parse_content, seed_scenario
 
 
@@ -8,3 +13,56 @@ def test_search_returns_results(temp_repo, mcp_server) -> None:
     result = call_tool(mcp_server, "vaner.search", {"query": "auth policy", "mode": "hybrid"})
     payload = parse_content(result)
     assert "results" in payload
+
+
+def test_search_downranks_vaner_managed_files(temp_repo, mcp_server) -> None:
+    async def _seed() -> None:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.upsert(
+            Scenario(
+                id="scn_managed",
+                kind="research",
+                score=0.95,
+                confidence=0.9,
+                entities=[".cursor/mcp.json"],
+                evidence=[
+                    EvidenceRef(
+                        key="file_summary:.cursor/mcp.json",
+                        source_path=".cursor/mcp.json",
+                        excerpt="Generated Cursor MCP wiring",
+                        weight=1.0,
+                    )
+                ],
+                prepared_context="Generated Cursor MCP config.",
+            )
+        )
+        await store.upsert(
+            Scenario(
+                id="scn_install",
+                kind="change",
+                score=0.8,
+                confidence=0.8,
+                entities=["scripts/install.sh", "install", "installer"],
+                evidence=[
+                    EvidenceRef(
+                        key="file_summary:scripts/install.sh",
+                        source_path="scripts/install.sh",
+                        excerpt="Installer entrypoint",
+                        weight=1.0,
+                    )
+                ],
+                prepared_context="Installer logic lives in scripts/install.sh.",
+            )
+        )
+
+    asyncio.run(_seed())
+
+    result = call_tool(
+        mcp_server,
+        "vaner.search",
+        {"query": "Where should I edit the repository to change how Vaner installs itself?", "mode": "hybrid", "limit": 1},
+    )
+    payload = parse_content(result)
+
+    assert payload["results"][0]["source"] == "scn_install"

--- a/tests/test_mcp_v2/test_suggest.py
+++ b/tests/test_mcp_v2/test_suggest.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+
+from vaner.models.scenario import EvidenceRef, Scenario
+from vaner.store.scenarios import ScenarioStore
+
 from .conftest import call_tool, parse_content, seed_scenario
 
 
@@ -8,3 +13,56 @@ def test_suggest_returns_candidates(temp_repo, mcp_server) -> None:
     result = call_tool(mcp_server, "vaner.suggest", {"query": "where auth is enforced"})
     payload = parse_content(result)
     assert "suggestions" in payload
+
+
+def test_suggest_downranks_vaner_managed_files(temp_repo, mcp_server) -> None:
+    async def _seed() -> None:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.upsert(
+            Scenario(
+                id="scn_managed",
+                kind="research",
+                score=0.95,
+                confidence=0.9,
+                entities=[".cursor/skills/vaner/vaner-feedback/SKILL.md"],
+                evidence=[
+                    EvidenceRef(
+                        key="file_summary:.cursor/skills/vaner/vaner-feedback/SKILL.md",
+                        source_path=".cursor/skills/vaner/vaner-feedback/SKILL.md",
+                        excerpt="managed feedback skill",
+                        weight=1.0,
+                    )
+                ],
+                prepared_context="Managed Vaner feedback skill.",
+            )
+        )
+        await store.upsert(
+            Scenario(
+                id="scn_install",
+                kind="change",
+                score=0.8,
+                confidence=0.8,
+                entities=["scripts/install.sh", "install", "installer"],
+                evidence=[
+                    EvidenceRef(
+                        key="file_summary:scripts/install.sh",
+                        source_path="scripts/install.sh",
+                        excerpt="installer entrypoint",
+                        weight=1.0,
+                    )
+                ],
+                prepared_context="Installer logic lives in scripts/install.sh.",
+            )
+        )
+
+    asyncio.run(_seed())
+
+    result = call_tool(
+        mcp_server,
+        "vaner.suggest",
+        {"query": "Where should I edit the repository to change how Vaner installs itself?", "limit": 1},
+    )
+    payload = parse_content(result)
+
+    assert payload["suggestions"][0]["scenario_id"] == "scn_install"


### PR DESCRIPTION
## Summary
- replay the 0.6.2 hardening changes on top of current `main` to replace the conflicted `feat/v0.6.2-hardening` integration path
- include installer fallback hardening, embedding-dependency graceful degradation, uninstall/mcp cleanup, managed skill alignment, and MCP suggest/search ranking downrank for managed files
- bump package metadata to `0.6.2`, update docs/changelog, and include focused regression tests for these fixes

## Validation
- [x] `ruff check src tests`
- [x] `pytest tests/test_cli/test_init.py tests/test_cli/test_query.py tests/test_cli/test_install_script_fallback.py tests/test_docs/test_mcp_tool_matrix.py tests/test_mcp_v2/test_suggest.py tests/test_mcp_v2/test_search.py`

## Notes
- This PR is the clean replacement for #125, which is left open only as historical context from the earlier conflicted branch path.

Made with [Cursor](https://cursor.com)