### PR TITLE
feat(cockpit): live pipeline view with scenario cluster + system vitals

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,92 @@ vaner init --path .
 vaner up --path .
 ```
 
+The installer:
+
+- Detects `uv` or `pipx` and installs `vaner[mcp]` (MCP client support included by default; pass `--no-mcp` to skip).
+- Falls back to `git+https://github.com/Borgels/vaner.git` if the PyPI package isn't available yet.
+- Asks you to pick a model backend (Ollama, LM Studio, vLLM, OpenAI, Anthropic, OpenRouter, or skip).
+- Offers a compute budget (`background` / `balanced` / `dedicated`) and an optional wall-clock cap on ponder time (`--max-session-minutes`).
+
+Non-interactive example (CI, Dockerfile):
+
+```bash
+VANER_YES=1 \
+VANER_BACKEND_PRESET=openai \
+VANER_BACKEND_API_KEY_ENV=OPENAI_API_KEY \
+VANER_BACKEND_MODEL=gpt-4o \
+VANER_COMPUTE_PRESET=background \
+VANER_MAX_SESSION_MINUTES=30 \
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+```
+
+From source (no installer):
+
+```bash
+git clone https://github.com/Borgels/vaner.git
+cd vaner
+pip install '.[mcp]'
+```
+
+Installer source for review: [`scripts/install.sh`](scripts/install.sh).
+
+### 2. Connect your AI client
+
+Vaner exposes context to your agent over [MCP](https://modelcontextprotocol.io/). Pick your client and paste the one-liner:
+
+| Client | One command |
+| --- | --- |
+| Claude Code | `claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .` |
+| Codex CLI   | `codex mcp add vaner -- vaner mcp --path .` |
+| Cursor / VS Code / Zed / Windsurf / Continue / Claude Desktop / Cline / Roo | see [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp) |
+
+Or let Vaner write the config file for you:
+
+```bash
+vaner init --path .                 # initialize this repo + pick backend interactively
+vaner mcp --path .                  # smoke-test the MCP server in stdio mode
+```
+
+### 3. Run it
+
+```bash
+vaner daemon start --no-once --path .
+vaner query "where is auth enforced?" --explain --path .
+vaner inspect --last --path .
+```
+
+Asciinema demo: coming soon.
+
+## Cockpit live pipeline view
+
+Vaner ships a cockpit UI that doubles as a real-time control surface for the
+daemon. Open it at `http://127.0.0.1:8473/` (after `vaner daemon start`) or
+co-mounted at `/cockpit/` when serving MCP over SSE.
+
+The cockpit view is organised around the actual daemon control flow:
+
+```
+Signals → Targets → Model → Artefacts → Scenarios → Decisions
+```
+
+- **Pipeline ribbon** at the top shows per-stage activity with animated
+  particles flowing left-to-right as the daemon processes each cycle. Model
+  lane surfaces a spinner while LLM requests are in flight, plus the last
+  latency.
+- **Scenario cluster** is the main canvas. Scenarios are laid out by
+  kind-bucketed force-directed layout and connected by **shared-path Jaccard
+  edges** — so even scenarios without an explicit parent/child form a visible
+  constellation when they touch the same files. Drag nodes, scroll to zoom.
+- **System vitals** (left rail) tracks mode, current cycle duration, model
+  busy state, recent LLM latency EMA, total cycles, artefacts written, and
+  error count. All values are derived from the event bus — no polling.
+- **Event stream** (right rail) is colour-coded by stage with per-stage
+  filter chips, heartbeat collapsing, and an in-flight LLM counter.
+
+Everything is driven by the unified event bus in `src/vaner/events/bus.py`,
+which the daemon runner, LLM helpers, proxy, and scenario store publish to.
+The SSE endpoint `/events/stream` accepts a `?stages=model,artefacts` filter
+for scripted consumers.
 ## Documentation
 
 Most documentation lives at [docs.vaner.ai](https://docs.vaner.ai):

--- a/docs/cockpit-dogfood-report.md
+++ b/docs/cockpit-dogfood-report.md
@@ -1,0 +1,204 @@
+# Cockpit dogfood report
+
+Branch: `cockpit-hardening-wiring`
+Tested on: Linux 6.17 / RTX 5090 (32 GB) / Python 3.12 / Ollama `qwen2.5-coder:7b`
+Scratch workspace: `/tmp/vaner-cockpit-demo`
+Ports used: daemon `:8473`, MCP SSE `:8482`, MCP stdio sidecar `:8484`
+
+## TL;DR
+
+| Surface | State before fixes | State after fixes |
+| --- | --- | --- |
+| Daemon cockpit (`:8473`) | Loaded, API wired, most interactions work | Unchanged |
+| MCP SSE cockpit (`:8482/cockpit/`) | Blank white page; all API calls 404 | Renders at `:8482/`, API wired |
+| MCP stdio sidecar (`:8484`) | Process crashed on startup | Serves cockpit, stays up |
+| MCP JSON-RPC tools (`list_scenarios` etc.) | 100 % crashed on every call | Work end-to-end |
+| Cockpit → `.vaner/config.toml` writeback | Works (backend/compute/context/MCP) | Unchanged |
+| Skill nudge, scenario pin, feedback | Work server-side | Unchanged |
+
+Two patches were applied during this session to unblock dogfooding and are already in the working tree (see "Applied during session" below). The remaining items are queued as a fix-and-polish plan.
+
+## Environment / starting conditions
+
+- `vaner` was resolving to a stale `uv tool install` that predated the cockpit factory: its `/cockpit/bootstrap.json` 404'd.
+- Three parallel `vaner` installs coexisted: pipx (openclaw proxy, untouched), uv-tool (global `vaner`), editable `pip install -e .` in this repo.
+- `~/.cursor/mcp.json` had `"mcpServers": {}`.
+- Ollama `:11434` ready with `qwen2.5-coder:7b`.
+
+Upgrade path used: `uv tool install --reinstall --python 3.12 '.[mcp]'` from [/home/abo/repos/Vaner](.) after rebuilding the SPA with `npm run build` in [ui/cockpit](ui/cockpit).
+
+## Findings
+
+### Defects
+
+#### D1. MCP server crashes on every client call (both transports) — CRITICAL, patched
+`server.get_capabilities(notification_options=None, ...)` raises `AttributeError: 'NoneType' object has no attribute 'tools_changed'` in the installed `mcp` SDK. Stdio mode died before the first message; SSE mode died on the first `initialize` request, leaving clients hanging. Every MCP client (Claude Desktop, Cursor, our `ClientSession`) was effectively unable to talk to Vaner.
+- Repro: `vaner mcp --path /tmp/x` (stdio) or any MCP initialize over `:8482/sse`.
+- Cause: `notification_options=None` passed where SDK unconditionally dereferences `.tools_changed`.
+- Fix applied in [src/vaner/mcp/server.py](src/vaner/mcp/server.py) — import `NotificationOptions` and pass `NotificationOptions()` in both `run_stdio` and `run_sse`.
+- Follow-up: add a regression test — spin up `run_sse` in a fixture and run `ClientSession.initialize()` against it. Current `tests/test_mcp/test_mcp_cockpit.py` only checks the cockpit HTTP app, not the protocol handshake.
+
+#### D2. MCP SSE cockpit UI is a blank page — CRITICAL, patched
+SPA's built `index.html` references `/assets/index-…js` with an absolute path. `run_sse` mounted the cockpit under `/cockpit/`, so `/assets/…` 404'd. `/cockpit/bootstrap.json` also 404'd (actual path was `/cockpit/cockpit/bootstrap.json`). Every API call in the client (`/status`, `/scenarios`, `/skills`) 404'd.
+- Repro: `vaner mcp --transport sse --port 8482 --path .` → open `http://127.0.0.1:8482/cockpit/`.
+- Fix applied in [src/vaner/mcp/server.py](src/vaner/mcp/server.py) — mount `build_cockpit(repo_root)` at `/` (not `/cockpit/`) when `cockpit_enabled`. The SSE transport endpoints (`/sse`, `/messages/`) do not collide because the cockpit factory only owns other paths.
+- Follow-up: extend [tests/test_mcp/test_mcp_cockpit.py](tests/test_mcp/test_mcp_cockpit.py) with a Starlette test that asserts `GET /` returns the SPA and `GET /assets/*` returns 200 under the SSE wrapper. Also delete or repurpose `redirect_to_cockpit` in docs.
+
+#### D3. `vaner query` crashes on the default install — HIGH
+`ModuleNotFoundError: sentence_transformers` inside [src/vaner/clients/embeddings.py](src/vaner/clients/embeddings.py). The README's "Run it" section (`vaner query "..."`) fails immediately for anyone who installed with the one-liner.
+- Same hit from `expand_scenario` MCP tool → `"ERROR: No module named 'sentence_transformers'"`.
+- `[project.optional-dependencies]` in [pyproject.toml](pyproject.toml) splits embeddings into a separate `[embeddings]` extra that neither `install.sh` nor `vaner[mcp]` pulls in.
+- Options:
+  1. Roll embeddings into the default dep set (adds torch weight ≈1 GB — probably a no-go for OpenSSF/install size).
+  2. Wrap the embed path with `try/except ImportError` and fall back to lexical matching with a helpful log line.
+  3. Teach `scripts/install.sh` to offer `VANER_EMBEDDINGS=1` → append `[mcp,embeddings]` and document it in `README.md`.
+- Recommendation: option 2 as the core fix + option 3 as a post-install hint. The current UX ("traceback then exit 1" on the very first documented command) is worst-case.
+
+#### D4. GPU probe can't see CUDA devices — HIGH
+`/compute/devices` returns just `[{id:"cpu"}]` with `warning: "No module named 'torch'"` even though the box has an RTX 5090 with 32 GB VRAM. The device dropdown in the Settings drawer is therefore useless for GPU selection (the user's original complaint from the prior session).
+- Root cause: the probe is implemented with `torch.cuda.device_count()` which requires the optional `embeddings` extra.
+- Fix options (can be combined):
+  1. Use `nvidia-smi --query-gpu=index,name,memory.total --format=csv,noheader` as a fallback when torch is missing. Works on this box.
+  2. On Linux, fall back to scanning `/proc/driver/nvidia/gpus/*/information`.
+  3. Add `amd` (ROCm) probe via `rocm-smi` for AMD boxes.
+- Surface the degraded state in the UI too: currently the Settings drawer just shows a red "No module named 'torch'" string with no actionable link. Replace it with a one-liner like "Install `vaner[embeddings]` (or verify NVIDIA drivers) to enable GPU selection" plus a "docs" link.
+
+#### D5. Backend preset switch doesn't fully resync UI form state — MEDIUM
+After `POST /backend` succeeds, the server correctly rewrites `[backend]` (e.g., `lmstudio` clears `model` and `api_key_env`), but the cockpit's Settings drawer continues to display the stale local input values (`Model: "qwen2.5-coder:7b"`, `API key env: "OPENAI_API_KEY"`) until a manual page reload. Same for the Preset combobox showing lag (`value: lmstudio` right after selecting `ollama`).
+- Cause: `SettingsDrawer` form state is seeded once from the initial `/status` fetch and only the field(s) touched by `onSaveBackend` are re-hydrated. In [ui/cockpit/src/components/chrome.tsx](ui/cockpit/src/components/chrome.tsx) the `backend` local state should be replaced wholesale with the server's response (`response.backend`) after every `POST /backend`.
+- Also: when picking a preset, the UI should apply the preset's defaults to the form *before* POSTing so the user can preview/override.
+
+#### D6. Pinning a scenario is a no-op for the "Pinned Context" rail — MEDIUM
+Clicking Pin in the Inspector toggles button label to "Unpin" and sets `scenarios.pinned=1`, but the left-rail "Pinned Context" list is driven by `/pinned-facts` (a separate SQLite table for free-text notes). So pinning a scenario never surfaces it in the rail. Users will assume the feature is broken.
+- Repro: click Pin on any scenario in the inspector → Pinned Context stays "No pinned facts".
+- Fix options:
+  1. Have `/pinned-facts` include a synthesized fact row for each `pinned=1` scenario (e.g., `{kind: "scenario", id, title, note: scenario.prepared_context}`).
+  2. Add a second section in the left rail: "Pinned scenarios" driven by `/scenarios?pinned=true`.
+  3. Rename the button "Pin to context" → "Mark as always-include" and document the difference from the explicit fact notes.
+- Recommendation: option 1 (lowest UI churn, matches the user's mental model).
+
+#### D7. Cockpit UI does not auto-refresh on MCP tool calls — MEDIUM
+`report_outcome` via the MCP tool correctly persists `last_outcome=partial`, but the Inspector continues to show the previous state until the user hits refresh. The `/events/stream` SSE feed only publishes ponder-loop events, not scenario mutations.
+- Fix: publish to the existing `asyncio.Queue` in `ScenarioStore` whenever `record_outcome`, `set_pinned`, or `expand_scenario` mutates a row. The UI already subscribes to `/events/stream` and `/scenarios/stream`.
+- Secondary: surface MCP tool invocations themselves as events ("MCP: report_outcome scn_…"), so the Event Stream panel becomes the single pane of glass for "who did what".
+
+#### D8. `vaner init` reports `device=cpu gpu_count=0 vram_gb=0` on a CUDA-capable host — MEDIUM
+Same root cause as D4. The installer/init path also only uses torch for detection, so the user sees a misleading "Hardware profile: device=cpu" at first run even though they have an RTX 5090.
+
+#### D9. MCP tool parameter name drift — LOW
+Tool schemas expose `{id}` but the CLI + cockpit use `scenario_id`. Tools fail with `Input validation error: 'id' is a required property` when called with `scenario_id`. Pick one name, update [src/vaner/mcp/server.py](src/vaner/mcp/server.py) schema + all call sites, and document.
+
+#### D10. `vaner --version` does not exist — TRIVIAL
+`vaner --version` returns `No such option: --version Did you mean --verbose?`. Typer has a first-class version callback; adding it is ~3 lines.
+
+### UX gaps
+
+#### U1. FrontierGraph layout is a stacked column for the demo dataset
+All 5 scenarios render in a single vertical column with identical X-coordinates, plus the heading glyph renders as "FRONTIER PS0E3AARIO GRAPH" (overlapping labels). The `kind=change` cluster has no horizontal spread. Either:
+- Use a force-directed layout seeded by (kind, depth, score).
+- Scale node X by score, Y by freshness bucket, so the graph has shape even with few scenarios.
+- Fix the header label collision (see `FrontierGraph` title + subtitle overlap).
+
+#### U2. Evidence panel shows raw `diff --git` snippets
+The daemon emits evidence notes like `"Snippet: diff --git a/auth.py …"` — the cockpit renders them verbatim, horizontal-scroll, monospace. It's unreadable and defeats the purpose of the Evidence panel. Either:
+- Strip the diff machinery in `_evidence_payload` and render a cleaner code excerpt.
+- Switch to a three-mode toggle: "Diff / File snippet / Raw".
+
+#### U3. Score breakdown is always empty
+Every scenario shows "No score components reported yet. The daemon only publishes a breakdown after it runs the next scoring pass." on first render. Given this is shown for every scenario immediately after a fresh `daemon start --once`, the copy needs rework (or the scoring pass needs to write components on first run).
+
+#### U4. `vaner init` writes a `.cursor/mcp.json` inside the project and an entry for Claude Desktop automatically
+This is friendly but can surprise users who opened init from a repo that already has its own `.cursor/mcp.json` or who don't use Claude Desktop. Consider an opt-in flag (`--mcp-clients cursor,claude,codex`) and `--dry-run`.
+
+#### U5. "Pinned Context" empty-state string mentions "Pin scenarios" but pinning does nothing (see D6)
+Tie this to D6's fix; once pinning a scenario surfaces in the rail, the copy is fine.
+
+#### U6. Viewport-minimum rendering
+At ~340 px wide (the first screenshot before resize), several labels overlap and the FrontierGraph canvas becomes unreadable. Add a min-width guard or a condensed mobile layout — the IDE browser's default viewport is narrower than you might assume.
+
+### Optimizations
+
+#### O1. The installer installs `[mcp]` but leaves the user with a half-working CLI (D3)
+Either roll the embed path into `[mcp]` behind an import-time fallback, or bundle a sensible default of `sentence-transformers` at a size users accept. Right now `vaner query` in the Quickstart is a broken-first-impression.
+
+#### O2. Event stream is under-utilized
+`/events/stream` only sees the ponder loop. Extending to scenario mutations (D7) makes the cockpit a real-time control surface.
+
+#### O3. SPA is 200 KB gzipped, 60 KB brotli-ish — acceptable, but low-hanging wins exist
+- `ui/cockpit/src/App.tsx` imports every component up-front. Code-splitting the Settings drawer alone would shave ~8 KB off initial JS.
+- `@fontsource/*` is bundled for 3 font families × 3 weights × 2 scripts = ~600 KB of woff/woff2. A `.env`-driven subset or drop to system fonts by default would cut cockpit size by >75 %.
+
+#### O4. Scenario graph recomputes layout from scratch every render
+Memoize the force layout keyed on `scenarios.map(s => s.id + s.score).join('|')` — the current `useMemo` dep set triggers on every heartbeat.
+
+#### O5. `/status` is polled every heartbeat
+The cockpit refetches `/status` every few seconds even when nothing changed. Combine with O2 and replace with an SSE-driven delta-only update from the backend.
+
+#### O6. Repeated `sqlite3` connections in `ScenarioStore._add_column_if_missing`
+Each `ALTER TABLE` opens a fresh `aiosqlite.connect`. Consolidate migrations into a single transaction in `initialize()` — saves ~30 ms on first boot.
+
+## Applied during session
+
+| File | Change |
+| --- | --- |
+| [src/vaner/mcp/server.py](src/vaner/mcp/server.py) | Import `NotificationOptions`, pass `NotificationOptions()` in both `run_stdio` and `run_sse` (fixes D1). |
+| [src/vaner/mcp/server.py](src/vaner/mcp/server.py) | SSE Starlette wrapper now mounts `build_cockpit(...)` at `/` instead of `/cockpit/` and drops the redirect; fixes D2. Docstring updated. |
+
+### Pipeline view refactor (D7 + U1 + U2-adjacent + U5)
+
+Landed on branch `cockpit-pipeline-view` (see the "Cockpit live pipeline view"
+section of the README):
+
+- **Backend** introduces `src/vaner/events/bus.py` — a unified `EventBus` with a
+  structured `VanerEvent` dataclass (`stage`, `kind`, `payload`, `scn`, `path`,
+  `cycle_id`) plus a `cycle_scope` context var. The daemon runner, LLM helpers,
+  proxy chat completion, and `ScenarioStore._publish` all emit through it.
+  `/events/stream` now reads from the bus and supports a `?stages=` filter.
+  Closes **D7** (scenario mutations are broadcast live) and **O2** (event stream
+  covers every stage of the pipeline, not just the ponder loop).
+- **Frontend** replaces `FrontierGraph` with a two-layer view:
+  - `PipelineCanvas` renders a six-lane ribbon (Signals → Targets → Model →
+    Artefacts → Scenarios → Decisions) with live read-outs per lane and
+    particle flow between them. Closes **U1** — even a small frontier now
+    reads as a connected pipeline rather than a vertical stack.
+  - `ScenarioCluster` uses a kind-bucketed force-directed layout and adds
+    **shared-path Jaccard edges** between scenarios so scenarios without an
+    explicit parent still form a visible constellation when they touch the
+    same files. This is the "edge semantics that brings users value" — the
+    graph now mirrors the real overlap structure of the work.
+- `SystemVitals` (left-rail header) surfaces mode, cycle, model busy-state,
+  last LLM latency, model id, total cycles, artefacts written, scenarios, and
+  error count — all derived from the event bus (no polling). Together with the
+  pipeline ribbon this makes "is the model working in the background?" a
+  single-glance answer.
+- `EventStreamPanel` replaces the old `StreamPanel`: colour-coded by stage,
+  per-stage filter chips, collapsed heartbeats, and a header LLM spinner
+  counting in-flight requests.
+- **U5** ("Pin scenarios does nothing") remains tracked as D6; the pipeline
+  refactor doesn't change pinning semantics but the new cluster does visibly
+  flag pinned scenarios via the amber dot and keeps them highlighted in the
+  shared-path constellation.
+
+The backend event bus is covered by `tests/test_events/test_bus.py`,
+`tests/test_daemon/test_runner_events.py`,
+`tests/test_daemon/test_generator_events.py`,
+`tests/test_router/test_proxy_events.py`, and the updated
+`tests/test_daemon/test_http.py` (stage filter + structured envelope). The new
+frontend components are covered by `SystemVitals.test.tsx`,
+`EventStreamPanel.test.tsx`, `PipelineCanvas.test.tsx`, and
+`ScenarioCluster.test.ts` (Jaccard + layout + force tick).
+
+## Recommended priority order
+
+1. D1 (critical, already patched — add regression test, commit).
+2. D2 (critical, already patched — add regression test, commit).
+3. D3 + O1 (first-impression breakage on `vaner query`).
+4. D4 / D8 (GPU probe falls back to `nvidia-smi`).
+5. D6 (pin → pinned facts).
+6. D7 (live UI updates on MCP tool calls).
+7. D5 (form hydration after preset change).
+8. U1 / U2 / U3 (cockpit polish).
+9. D9 / D10 (naming + `--version`).
+10. O3 – O6 (perf tuning).
+
+Open a follow-up branch `cockpit-dogfood-fixes` off `cockpit-hardening-wiring` to land items 1-7 as a tight PR; park 8-10 for a separate polish PR.

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -12,13 +12,17 @@ from pathlib import Path
 from typing import Any
 
 try:
-    from mcp.server import Server
+    from mcp.server import NotificationOptions, Server
     from mcp.server.models import InitializationOptions
     from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
 
     _MCP_IMPORT_ERROR: ModuleNotFoundError | None = None
 except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
     _MCP_IMPORT_ERROR = exc
+
+    class NotificationOptions:  # type: ignore[no-redef]
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
 
     class Server:  # type: ignore[no-redef]
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:

--- a/ui/cockpit/src/App.tsx
+++ b/ui/cockpit/src/App.tsx
@@ -1,0 +1,733 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { adaptEvidence, adaptScenario } from './api/adapt'
+import {
+  deletePinnedFact,
+  expandScenario,
+  getBackendPresets,
+  getComputeDevices,
+  getImpactSummary,
+  getStatus,
+  listDecisions,
+  listPinnedFacts,
+  listSkills,
+  nudgeSkill as apiNudgeSkill,
+  sendOutcome,
+  toggleGateway,
+  togglePin as toggleScenarioPin,
+  updateBackend,
+  updateCompute,
+  updateContext,
+  updateMcp,
+} from './api/client'
+import { useBootstrap } from './api/useBootstrap'
+import { useEvents } from './api/useEvents'
+import { usePipelineEvents } from './api/usePipelineEvents'
+import { useScenarios } from './api/useScenarios'
+import type { ScoreComponent } from './components/Inspector'
+import { CommandPalette, LeftRail, MismatchBanner, SettingsDrawer, TopBar, type CommandItem } from './components/chrome'
+import { EventStreamPanel } from './components/EventStreamPanel'
+import { Inspector } from './components/Inspector'
+import { PipelineCanvas } from './components/PipelineCanvas'
+import { SystemVitals } from './components/SystemVitals'
+import { ACCENT_MAP, DEFAULT_COCKPIT_SETTINGS, KIND_COLOR } from './lib/constants'
+import type {
+  BackendPreset,
+  BackendSettings,
+  CockpitSettings,
+  ComputeDevice,
+  ComputeSettings,
+  DecisionRecordPayload,
+  ImpactSummary,
+  LimitSettings,
+  MCPSettings,
+  ScenarioApiPayload,
+  UIEvent,
+  UIPackageState,
+  UIPinnedFact,
+  UISkill,
+} from './types'
+
+const COCKPIT_BUILD_SHA = (import.meta as unknown as { env?: { VITE_COCKPIT_SHA?: string } }).env?.VITE_COCKPIT_SHA ?? ''
+
+function formatDecisionTime(assembledAt: number): string {
+  return new Date(assembledAt * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+function adaptDecisionEvent(record: DecisionRecordPayload): UIEvent {
+  return {
+    id: `decision-${record.id}`,
+    t: formatDecisionTime(record.assembled_at),
+    tag: 'decision',
+    color: 'var(--accent)',
+    msg: `${record.id} · ${record.selection_count ?? record.selections.length} selections · ${record.token_used}/${record.token_budget} tok`,
+    scn: record.id,
+  }
+}
+
+function proxyPackageFromDecision(decision: DecisionRecordPayload | null): UIPackageState | null {
+  if (!decision) {
+    return null
+  }
+  const chosen = decision.selections.filter((selection) => selection.kept).length
+  const rejected = decision.selections.filter((selection) => !selection.kept).length
+  return {
+    id: decision.id,
+    tokens: decision.token_used,
+    budget: decision.token_budget,
+    chosen,
+    partial: 0,
+    rejected,
+    compression: 0,
+  }
+}
+
+function App() {
+  const bootstrap = useBootstrap()
+  const pipeline = usePipelineEvents({ path: '/events/stream' })
+  const [cockpit, setCockpit] = useState<CockpitSettings>(DEFAULT_COCKPIT_SETTINGS)
+  const { scenarios, setScenarios, scenarioMap, setScenarioMap } = useScenarios(cockpit.topK, pipeline.events)
+  const [backend, setBackend] = useState<BackendSettings | null>(null)
+  const [compute, setCompute] = useState<ComputeSettings | null>(null)
+  const [mcp, setMcp] = useState<MCPSettings | null>(null)
+  const [limits, setLimits] = useState<LimitSettings | null>(null)
+  const [presets, setPresets] = useState<BackendPreset[]>([])
+  const [devices, setDevices] = useState<ComputeDevice[]>([])
+  const [devicesWarning, setDevicesWarning] = useState<string | null>(null)
+  const [gatewayEnabled, setGatewayEnabled] = useState<boolean>(false)
+  const [skills, setSkills] = useState<UISkill[]>([])
+  const [pinnedFacts, setPinnedFacts] = useState<UIPinnedFact[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedDecisionId, setSelectedDecisionId] = useState<string | null>(null)
+  const [paletteOpen, setPaletteOpen] = useState(false)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [toast, setToast] = useState<{ msg: string; color: string } | null>(null)
+  const [impact, setImpact] = useState<ImpactSummary>({ count: 0 })
+  const [decisions, setDecisions] = useState<DecisionRecordPayload[]>([])
+  const [activePulses, setActivePulses] = useState<Set<string>>(new Set())
+  const [bundleMismatch, setBundleMismatch] = useState(false)
+
+  const mode = bootstrap.mode
+
+  useEffect(() => {
+    if (!bootstrap.cockpit_sha || !COCKPIT_BUILD_SHA) {
+      return
+    }
+    setBundleMismatch(bootstrap.cockpit_sha !== COCKPIT_BUILD_SHA)
+  }, [bootstrap.cockpit_sha])
+
+  const handleProxyDecision = useCallback((record: DecisionRecordPayload) => {
+    setDecisions((previous) => [record, ...previous.filter((item) => item.id !== record.id)].slice(0, 100))
+  }, [])
+
+  const proxyStream = useEvents<DecisionRecordPayload>({
+    path: '/decisions/stream',
+    enabled: mode === 'proxy',
+    parse: (raw) => JSON.parse(raw) as DecisionRecordPayload,
+    toEvent: adaptDecisionEvent,
+    onPayload: handleProxyDecision,
+  })
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--accent', ACCENT_MAP[cockpit.accent])
+  }, [cockpit.accent])
+
+  useEffect(() => {
+    const pulseTarget = pipeline.events[0]?.scn
+    if (!pulseTarget) {
+      return
+    }
+    setActivePulses((previous) => new Set(previous).add(pulseTarget))
+    const timeout = window.setTimeout(() => {
+      setActivePulses((previous) => {
+        const next = new Set(previous)
+        next.delete(pulseTarget)
+        return next
+      })
+    }, 1400)
+    return () => window.clearTimeout(timeout)
+  }, [pipeline.events])
+
+  useEffect(() => {
+    if (!scenarios.length || selectedId) {
+      return
+    }
+    setSelectedId(scenarios[0].id)
+  }, [scenarios, selectedId])
+
+  useEffect(() => {
+    if (!decisions.length || selectedDecisionId) {
+      return
+    }
+    setSelectedDecisionId(decisions[0].id)
+  }, [decisions, selectedDecisionId])
+
+  const refreshStatus = useCallback(async () => {
+    const payload = await getStatus()
+    if (payload.backend) {
+      setBackend((current) => ({ ...(current ?? ({} as BackendSettings)), ...payload.backend } as BackendSettings))
+    }
+    if (payload.compute) {
+      setCompute((current) => ({ ...(current ?? ({} as ComputeSettings)), ...payload.compute } as ComputeSettings))
+    }
+    if (payload.mcp) {
+      setMcp((current) => ({ ...(current ?? ({} as MCPSettings)), ...payload.mcp } as MCPSettings))
+    }
+    if (payload.limits) {
+      setLimits((current) => ({ ...(current ?? ({} as LimitSettings)), ...payload.limits } as LimitSettings))
+    }
+    if (typeof payload.gateway_enabled === 'boolean') {
+      setGatewayEnabled(payload.gateway_enabled)
+    }
+  }, [])
+
+  const refreshDevices = useCallback(async () => {
+    try {
+      const payload = await getComputeDevices()
+      setDevices(payload.devices ?? [])
+      setDevicesWarning(payload.warning ?? null)
+    } catch {
+      setDevicesWarning('Could not enumerate compute devices.')
+    }
+  }, [])
+
+  const refreshPresets = useCallback(async () => {
+    try {
+      const payload = await getBackendPresets()
+      setPresets(payload.presets ?? [])
+    } catch {
+      setPresets([])
+    }
+  }, [])
+
+  const refreshSkillsPinned = useCallback(async () => {
+    const [skillsPayload, pinnedPayload] = await Promise.all([listSkills(), listPinnedFacts()])
+    setSkills(skillsPayload.skills)
+    setPinnedFacts(pinnedPayload.facts)
+  }, [])
+
+  const refreshProxyData = useCallback(async () => {
+    const [impactPayload, decisionsPayload] = await Promise.all([getImpactSummary(), listDecisions()])
+    setImpact(impactPayload)
+    setDecisions(decisionsPayload.items)
+  }, [])
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([refreshStatus(), refreshDevices(), refreshPresets(), refreshSkillsPinned()])
+    if (mode === 'proxy') {
+      await refreshProxyData()
+    }
+  }, [mode, refreshDevices, refreshPresets, refreshProxyData, refreshSkillsPinned, refreshStatus])
+
+  useEffect(() => {
+    refreshAll().catch(() => {
+      setToast({ msg: 'Initial load failed', color: 'var(--err)' })
+    })
+  }, [refreshAll])
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      refreshStatus().catch(() => undefined)
+      if (mode === 'proxy') {
+        getImpactSummary().then(setImpact).catch(() => undefined)
+      }
+    }, 15000)
+    return () => window.clearInterval(interval)
+  }, [mode, refreshStatus])
+
+  function showToast(msg: string, color: string) {
+    setToast({ msg, color })
+    window.setTimeout(() => setToast(null), 2200)
+  }
+
+  async function applyScenarioPayload(payload: ScenarioApiPayload | null) {
+    if (!payload) {
+      return
+    }
+
+    setScenarioMap((current) => ({ ...current, [payload.id]: payload }))
+    const adapted = adaptScenario(payload)
+    setScenarios((current) => {
+      const existing = current.find((item) => item.id === adapted.id)
+      if (existing) {
+        return current.map((item) => (item.id === adapted.id ? adapted : item))
+      }
+      return [adapted, ...current]
+    })
+  }
+
+  async function handleFeedback(id: string, result: 'useful' | 'partial' | 'irrelevant') {
+    try {
+      const response = await sendOutcome(id, result)
+      await applyScenarioPayload(response.scenario)
+      showToast(`Recorded ${result}`, result === 'useful' ? 'var(--ok)' : result === 'partial' ? 'var(--amber)' : 'var(--fg-4)')
+    } catch {
+      showToast(`Failed to record ${result}`, 'var(--err)')
+    }
+  }
+
+  async function handleTogglePin(id: string) {
+    const scenario = scenarios.find((item) => item.id === id)
+    if (!scenario) {
+      return
+    }
+    try {
+      const response = await toggleScenarioPin(id, !scenario.pinned)
+      await applyScenarioPayload(response.scenario)
+      showToast(scenario.pinned ? 'Scenario unpinned' : 'Scenario pinned', 'var(--amber)')
+    } catch {
+      showToast('Failed to update pin state', 'var(--err)')
+    }
+  }
+
+  async function handleExpand(id: string) {
+    try {
+      const response = await expandScenario(id)
+      await applyScenarioPayload(response.scenario)
+      showToast('Scenario expanded', 'var(--accent)')
+    } catch {
+      showToast('Failed to expand scenario', 'var(--err)')
+    }
+  }
+
+  async function handleUnpinFact(id: string) {
+    await deletePinnedFact(id)
+    const payload = await listPinnedFacts()
+    setPinnedFacts(payload.facts)
+  }
+
+  async function handleSkillNudge(name: string, delta: number) {
+    try {
+      const response = await apiNudgeSkill(name, delta)
+      setSkills((current) =>
+        current.map((skill) => (skill.name === response.name ? { ...skill, weight: response.weight } : skill)),
+      )
+    } catch {
+      showToast(`Failed to nudge ${name}`, 'var(--err)')
+    }
+  }
+
+  async function saveBackend(patch: Partial<BackendSettings>) {
+    try {
+      const response = await updateBackend(patch)
+      setBackend(response.backend)
+      showToast('Backend saved', 'var(--ok)')
+    } catch (error) {
+      showToast(String(error instanceof Error ? error.message : 'Failed to save backend').slice(0, 80), 'var(--err)')
+    }
+  }
+
+  async function saveCompute(patch: Partial<ComputeSettings>) {
+    try {
+      const response = await updateCompute(patch)
+      setCompute(response.compute)
+      await refreshDevices()
+      showToast('Compute saved', 'var(--ok)')
+    } catch (error) {
+      showToast(String(error instanceof Error ? error.message : 'Failed to save compute').slice(0, 80), 'var(--err)')
+    }
+  }
+
+  async function saveMcp(patch: Partial<MCPSettings>) {
+    try {
+      const response = await updateMcp(patch)
+      setMcp(response.mcp)
+      showToast('MCP saved', 'var(--ok)')
+    } catch (error) {
+      showToast(String(error instanceof Error ? error.message : 'Failed to save MCP').slice(0, 80), 'var(--err)')
+    }
+  }
+
+  async function saveContextTokens(maxContextTokens: number) {
+    try {
+      const response = await updateContext(maxContextTokens)
+      setLimits((current) => ({ ...(current ?? ({} as LimitSettings)), ...response.limits }))
+      showToast('Context limit saved', 'var(--ok)')
+    } catch (error) {
+      showToast(String(error instanceof Error ? error.message : 'Failed to save context').slice(0, 80), 'var(--err)')
+    }
+  }
+
+  async function handleToggleGateway(enabled: boolean) {
+    try {
+      await toggleGateway(enabled)
+      setGatewayEnabled(enabled)
+    } catch {
+      showToast('Failed to toggle gateway', 'var(--err)')
+    }
+  }
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      if (target && ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)) {
+        return
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        setPaletteOpen(true)
+        return
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key === ',') {
+        event.preventDefault()
+        setDrawerOpen(true)
+        return
+      }
+      if (event.key === 'Escape') {
+        setPaletteOpen(false)
+        setDrawerOpen(false)
+        return
+      }
+
+      if (mode !== 'proxy' && selectedId) {
+        const index = scenarios.findIndex((scenario) => scenario.id === selectedId)
+        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+          const next = scenarios[(index + 1 + scenarios.length) % scenarios.length]
+          if (next) {
+            setSelectedId(next.id)
+          }
+          event.preventDefault()
+        }
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+          const next = scenarios[(index - 1 + scenarios.length) % scenarios.length]
+          if (next) {
+            setSelectedId(next.id)
+          }
+          event.preventDefault()
+        }
+        if (event.key.toLowerCase() === 'u') {
+          void handleFeedback(selectedId, 'useful')
+        }
+        if (event.key.toLowerCase() === 'p') {
+          void handleFeedback(selectedId, 'partial')
+        }
+        if (event.key.toLowerCase() === 'x') {
+          void handleFeedback(selectedId, 'irrelevant')
+        }
+        if (event.key === '.' || event.key === '•') {
+          void handleTogglePin(selectedId)
+        }
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+    // handleFeedback / handleTogglePin are stable handlers defined inline;
+    // re-binding the listener on every render would churn for no benefit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, scenarios, selectedId])
+
+  const selectedScenario = scenarios.find((scenario) => scenario.id === selectedId) ?? null
+  const selectedDecision = decisions.find((decision) => decision.id === selectedDecisionId) ?? null
+
+  const evidenceById = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(scenarioMap).map(([id, payload]) => [id, adaptEvidence(payload)]),
+      ),
+    [scenarioMap],
+  )
+
+  const scoreComponentsById = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(scenarioMap).map(([id, payload]) => [
+          id,
+          (payload.score_components ?? []) as ScoreComponent[],
+        ]),
+      ),
+    [scenarioMap],
+  )
+
+  const preparedById = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(scenarioMap)
+          .filter(([, payload]) => payload.prepared_context)
+          .map(([id, payload]) => [id, payload.prepared_context ?? '']),
+      ),
+    [scenarioMap],
+  )
+
+  const packageState = mode === 'proxy' ? proxyPackageFromDecision(selectedDecision) : null
+
+  const commands = useMemo<CommandItem[]>(() => {
+    const common: CommandItem[] = [
+      { id: 'refresh', kind: 'action', label: 'Refresh cockpit data', hint: '↻', run: () => void refreshAll() },
+      { id: 'settings', kind: 'action', label: 'Open settings', hint: '⌘,', run: () => setDrawerOpen(true) },
+      {
+        id: 'clear-events',
+        kind: 'action',
+        label: 'Clear event stream',
+        run: () => (mode === 'proxy' ? proxyStream.setEvents([]) : pipeline.reset()),
+      },
+    ]
+
+    if (mode !== 'proxy' && selectedId) {
+      common.push({
+        id: 'expand-selected',
+        kind: 'action',
+        label: 'Expand selected scenario',
+        run: () => void handleExpand(selectedId),
+      })
+    }
+
+    if (mode !== 'proxy') {
+      return [
+        ...common,
+        ...scenarios.map((scenario) => ({
+          id: scenario.id,
+          kind: scenario.kind,
+          kindColor: KIND_COLOR[scenario.kind],
+          label: scenario.title,
+          keywords: `${scenario.path} ${scenario.id}`,
+          hint: scenario.score.toFixed(3),
+          run: () => setSelectedId(scenario.id),
+        })),
+      ]
+    }
+
+    return [
+      ...common,
+      ...decisions.map((decision) => ({
+        id: decision.id,
+        kind: 'decision',
+        kindColor: 'var(--accent)',
+        label: decision.id,
+        keywords: `${decision.prompt} ${decision.prompt_hash}`,
+        hint: `${decision.token_used} tok`,
+        run: () => setSelectedDecisionId(decision.id),
+      })),
+    ]
+    // handleExpand is stable and only used inside a closure captured once
+    // per command-palette render; including it would cause a render loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [decisions, mode, pipeline, proxyStream, refreshAll, scenarios, selectedId])
+
+  const streamEvents = mode === 'proxy' ? proxyStream.events : pipeline.events
+  const streamLive = mode === 'proxy' ? proxyStream.live : pipeline.live
+
+  const showScenarioPane = mode !== 'proxy'
+
+  return (
+    <div className="cockpit-root">
+      <TopBar
+        mode={mode}
+        running={streamLive}
+        onToggleRun={() => void refreshAll()}
+        packageState={packageState}
+        onOpenSettings={() => setDrawerOpen(true)}
+        onOpenPalette={() => setPaletteOpen(true)}
+      />
+
+      <LeftRail
+        mode={mode}
+        skills={skills}
+        pinned={pinnedFacts}
+        packageState={packageState}
+        onUnpin={(id) => void handleUnpinFact(id)}
+        onSkillNudge={(name, delta) => void handleSkillNudge(name, delta)}
+        scenarioCount={scenarios.length}
+        impact={impact}
+        header={
+          <SystemVitals
+            live={streamLive}
+            mode={mode}
+            cycle={pipeline.cycle}
+            model={pipeline.model}
+            scenarioCount={scenarios.length}
+            pendingLlm={pipeline.model.pending.size}
+          />
+        }
+      />
+
+      {showScenarioPane ? (
+        <div style={{ gridArea: 'graph', position: 'relative', background: 'var(--bg-0)', overflow: 'hidden' }}>
+          <div
+            style={{
+              position: 'absolute',
+              top: 16,
+              right: 16,
+              display: 'flex',
+              gap: 10,
+              zIndex: 3,
+              padding: '6px 10px',
+              background: 'var(--bg-1)',
+              border: '1px solid var(--line-1)',
+              borderRadius: 'var(--r-2)',
+            }}
+          >
+            {Object.entries(KIND_COLOR).map(([kind, color]) => (
+              <span key={kind} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ width: 8, height: 8, borderRadius: 2, background: color }} />
+                <span className="mono" style={{ fontSize: 9.5, color: 'var(--fg-3)', letterSpacing: 0.5, textTransform: 'uppercase' }}>
+                  {kind}
+                </span>
+              </span>
+            ))}
+          </div>
+          <PipelineCanvas
+            scenarios={scenarios}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+            activePulses={activePulses}
+            pinnedIds={new Set(scenarios.filter((scenario) => scenario.pinned).map((scenario) => scenario.id))}
+            signals={pipeline.signals}
+            targets={pipeline.targets}
+            artefacts={pipeline.artefacts}
+            decisions={pipeline.decisions}
+            model={pipeline.model}
+            cycle={pipeline.cycle}
+            events={pipeline.events}
+          />
+          {toast ? (
+            <div
+              style={{
+                position: 'absolute',
+                bottom: 20,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                padding: '9px 16px',
+                background: 'var(--bg-1)',
+                border: `1px solid ${toast.color}`,
+                borderRadius: 'var(--r-2)',
+                color: toast.color,
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                letterSpacing: 0.3,
+                boxShadow: '0 8px 30px rgba(0,0,0,.4)',
+                animation: 'dc-fadein .2s',
+              }}
+            >
+              {toast.msg}
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <div style={{ gridArea: 'graph', display: 'flex', flexDirection: 'column', background: 'var(--bg-1)', borderRight: '1px solid var(--line-1)', minWidth: 0 }}>
+          <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--line-hair)' }}>
+            <div className="mono" style={{ fontSize: 10, letterSpacing: 1.2, color: 'var(--fg-4)' }}>
+              DECISIONS TIMELINE
+            </div>
+            <div style={{ fontSize: 15, color: 'var(--fg-1)', fontFamily: 'var(--font-display)', marginTop: 2 }}>
+              {decisions.length} recent proxy decisions
+            </div>
+          </div>
+          <div className="scroll" style={{ flex: 1, overflow: 'auto' }}>
+            {decisions.map((decision) => (
+              <button
+                key={decision.id}
+                onClick={() => setSelectedDecisionId(decision.id)}
+                style={{
+                  width: '100%',
+                  textAlign: 'left',
+                  padding: '14px 20px',
+                  background: selectedDecisionId === decision.id ? 'color-mix(in oklch, var(--accent) 9%, var(--bg-1))' : 'transparent',
+                  border: 'none',
+                  borderBottom: '1px solid var(--line-hair)',
+                  color: 'var(--fg-1)',
+                  cursor: 'pointer',
+                }}
+              >
+                <div className="mono" style={{ fontSize: 10.5, color: 'var(--accent)', letterSpacing: 0.6 }}>
+                  {decision.id}
+                </div>
+                <div style={{ fontSize: 13, marginTop: 4, color: 'var(--fg-1)', lineHeight: 1.45 }}>
+                  {decision.prompt}
+                </div>
+                <div className="mono" style={{ fontSize: 10.5, marginTop: 6, color: 'var(--fg-4)' }}>
+                  {decision.token_used}/{decision.token_budget} tok · {decision.selection_count ?? decision.selections.length} selections
+                </div>
+              </button>
+            ))}
+            {!decisions.length ? (
+              <div style={{ padding: 20, color: 'var(--fg-4)', fontSize: 12 }}>No decisions yet.</div>
+            ) : null}
+          </div>
+        </div>
+      )}
+
+      <div
+        style={{
+          gridArea: 'stream',
+          display: 'grid',
+          gridTemplateRows: '1fr 1fr',
+          gridTemplateColumns: '1fr',
+          overflow: 'hidden',
+          minHeight: 0,
+        }}
+      >
+        <div style={{ minHeight: 0, overflow: 'hidden', borderBottom: '1px solid var(--line-1)', background: 'var(--bg-1)' }}>
+          {showScenarioPane ? (
+            <Inspector
+              scenario={selectedScenario}
+              scenarios={scenarios}
+              evidenceById={evidenceById}
+              scoreComponentsById={scoreComponentsById}
+              preparedById={preparedById}
+              onSelect={setSelectedId}
+              onFeedback={(id, result) => void handleFeedback(id, result)}
+              onPin={(id) => void handleTogglePin(id)}
+              pinnedIds={new Set(scenarios.filter((scenario) => scenario.pinned).map((scenario) => scenario.id))}
+              onClose={() => setSelectedId(null)}
+            />
+          ) : (
+            <div className="scroll" style={{ height: '100%', overflow: 'auto', padding: 18 }}>
+              <div className="mono" style={{ fontSize: 10, letterSpacing: 1.2, color: 'var(--fg-4)', marginBottom: 10 }}>
+                SELECTED DECISION
+              </div>
+              <pre
+                style={{
+                  background: 'var(--bg-inset)',
+                  border: '1px solid var(--line-hair)',
+                  borderRadius: 'var(--r-2)',
+                  padding: 12,
+                  color: 'var(--fg-2)',
+                  fontSize: 11,
+                  overflow: 'auto',
+                }}
+              >
+                {selectedDecision ? JSON.stringify(selectedDecision, null, 2) : 'No decision selected.'}
+              </pre>
+            </div>
+          )}
+        </div>
+        <div style={{ minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          <EventStreamPanel
+            title={mode === 'proxy' ? 'DECISION STREAM' : 'EVENT STREAM'}
+            subtitle={mode === 'proxy' ? 'Live proxy decisions' : 'Live daemon activity'}
+            events={streamEvents}
+            onSelect={mode === 'proxy' ? setSelectedDecisionId : setSelectedId}
+            live={streamLive}
+            pendingLlm={mode === 'proxy' ? 0 : pipeline.model.pending.size}
+          />
+        </div>
+      </div>
+
+      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} commands={commands} />
+      <SettingsDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        mode={mode}
+        backend={backend}
+        compute={compute}
+        mcp={mcp}
+        limits={limits}
+        cockpit={cockpit}
+        presets={presets}
+        devices={devices}
+        devicesWarning={devicesWarning}
+        gatewayEnabled={gatewayEnabled}
+        onSaveBackend={saveBackend}
+        onSaveCompute={saveCompute}
+        onSaveMcp={saveMcp}
+        onSaveContext={saveContextTokens}
+        onPatchCockpit={(patch) => setCockpit((current) => ({ ...current, ...patch }))}
+        onToggleGateway={mode === 'proxy' ? handleToggleGateway : undefined}
+      />
+      {bundleMismatch ? <MismatchBanner onReload={() => window.location.reload()} /> : null}
+    </div>
+  )
+}
+
+export default App

--- a/ui/cockpit/src/api/usePipelineEvents.ts
+++ b/ui/cockpit/src/api/usePipelineEvents.ts
@@ -1,0 +1,412 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import { openEventSource } from './client'
+import type { PipelineStage, UIEvent } from '../types'
+
+/** Shape emitted by `/events/stream` after the unified event bus refactor. */
+export interface PipelineEventPayload {
+  id: string
+  ts: number
+  stage: PipelineStage
+  kind: string
+  payload: Record<string, unknown>
+  scn: string | null
+  path: string | null
+  cycle_id: string | null
+  // Legacy envelope preserved for one release.
+  t: string
+  tag: string
+  color: string
+  msg: string
+}
+
+export interface PipelineEvent extends UIEvent {
+  stage: PipelineStage
+  kind: string
+  ts: number
+  path: string | null
+  cycleId: string | null
+  payload: Record<string, unknown>
+}
+
+export interface SignalRow {
+  cycleId: string | null
+  ts: number
+  fsScan: number
+  gitChanged: number
+  msg: string
+}
+
+export interface TargetRow {
+  cycleId: string | null
+  ts: number
+  count: number
+  paths: string[]
+}
+
+export interface ArtefactRow {
+  id: string
+  ts: number
+  kind: string
+  path: string
+  cycleId: string | null
+}
+
+export interface DecisionRow {
+  id: string
+  ts: number
+  decisionId: string
+  selectionCount: number
+  cacheTier: string
+}
+
+export interface ModelState {
+  /** Currently pending requests keyed by request id. */
+  pending: Map<string, { path: string | null; model: string; startedAt: number }>
+  /** Last completed response. */
+  lastLatencyMs: number | null
+  lastModel: string | null
+  recentLatencies: number[]
+  totalRequests: number
+  totalErrors: number
+}
+
+export interface CycleState {
+  current: { cycleId: string; startedAt: number } | null
+  lastFinished: { cycleId: string; written: number; durationMs: number; ts: number } | null
+  totalCycles: number
+  artefactsWritten: number
+}
+
+const MAX_EVENTS = 200
+const MAX_ROWS = 20
+const LATENCY_WINDOW = 20
+
+function adaptLegacyEvent(payload: PipelineEventPayload): PipelineEvent {
+  return {
+    id: payload.id,
+    t: payload.t ?? new Date((payload.ts ?? Date.now() / 1000) * 1000).toLocaleTimeString(),
+    tag: payload.tag ?? payload.kind?.split('.')[0] ?? payload.stage,
+    color: payload.color ?? 'var(--fg-3)',
+    msg: payload.msg ?? `${payload.stage}:${payload.kind}`,
+    scn: payload.scn ?? null,
+    stage: payload.stage,
+    kind: payload.kind,
+    ts: payload.ts,
+    path: payload.path ?? null,
+    cycleId: payload.cycle_id ?? null,
+    payload: payload.payload ?? {},
+  }
+}
+
+interface Particle {
+  id: string
+  from: PipelineStage
+  to: PipelineStage
+  createdAt: number
+  color: string
+}
+
+const LANE_TRANSITIONS: Partial<Record<string, PipelineStage[]>> = {
+  'signal.ingest': ['signals', 'targets'],
+  'target.planned': ['targets', 'model'],
+  'llm.request': ['targets', 'model'],
+  'llm.response': ['model', 'artefacts'],
+  'artefact.upsert': ['artefacts', 'scenarios'],
+  'decision.recorded': ['scenarios', 'decisions'],
+}
+
+interface UsePipelineEventsOptions {
+  path?: string
+  stages?: PipelineStage[]
+  enabled?: boolean
+}
+
+export interface UsePipelineEventsResult {
+  events: PipelineEvent[]
+  live: boolean
+  signals: SignalRow[]
+  targets: TargetRow[]
+  artefacts: ArtefactRow[]
+  decisions: DecisionRow[]
+  model: ModelState
+  cycle: CycleState
+  particles: Particle[]
+  reset: () => void
+}
+
+/**
+ * Subscribe to the unified `/events/stream` and maintain derived per-lane
+ * state for the pipeline canvas. A single upstream subscription feeds every
+ * lane/panel so particles, vitals, and the event list stay in lock-step.
+ */
+export function usePipelineEvents({
+  path = '/events/stream',
+  stages,
+  enabled = true,
+}: UsePipelineEventsOptions = {}): UsePipelineEventsResult {
+  const [events, setEvents] = useState<PipelineEvent[]>([])
+  const [live, setLive] = useState(false)
+  const [signals, setSignals] = useState<SignalRow[]>([])
+  const [targets, setTargets] = useState<TargetRow[]>([])
+  const [artefacts, setArtefacts] = useState<ArtefactRow[]>([])
+  const [decisions, setDecisions] = useState<DecisionRow[]>([])
+  const [model, setModel] = useState<ModelState>(() => ({
+    pending: new Map(),
+    lastLatencyMs: null,
+    lastModel: null,
+    recentLatencies: [],
+    totalRequests: 0,
+    totalErrors: 0,
+  }))
+  const [cycle, setCycle] = useState<CycleState>({
+    current: null,
+    lastFinished: null,
+    totalCycles: 0,
+    artefactsWritten: 0,
+  })
+  const [particles, setParticles] = useState<Particle[]>([])
+
+  const retryRef = useRef<number | undefined>(undefined)
+
+  useEffect(() => {
+    if (!enabled) {
+      setLive(false)
+      return
+    }
+
+    const url = stages && stages.length ? `${path}?stages=${stages.join(',')}` : path
+    let source: EventSource | null = null
+    let closed = false
+    let attempt = 0
+
+    const connect = () => {
+      if (closed || document.visibilityState === 'hidden') {
+        return
+      }
+
+      source = openEventSource(url)
+      source.onopen = () => {
+        attempt = 0
+        setLive(true)
+      }
+      source.onerror = () => {
+        setLive(false)
+        source?.close()
+        const nextDelay = Math.min(5000, 500 * 2 ** attempt)
+        attempt += 1
+        retryRef.current = window.setTimeout(connect, nextDelay)
+      }
+      source.onmessage = (message) => {
+        try {
+          const raw = JSON.parse(message.data) as PipelineEventPayload
+          if (!raw.stage && !raw.kind) {
+            // Drop messages that don't look like the new envelope.
+            return
+          }
+          const event = adaptLegacyEvent(raw)
+          setEvents((prev) => [event, ...prev].slice(0, MAX_EVENTS))
+          applyEvent(event)
+        } catch {
+          // Ignore malformed events.
+        }
+      }
+    }
+
+    const applyEvent = (event: PipelineEvent) => {
+      const lanePair = LANE_TRANSITIONS[event.kind]
+      if (lanePair) {
+        const [from, to] = lanePair
+        setParticles((prev) => [
+          ...prev.slice(-60),
+          {
+            id: `${event.id}-${from}-${to}`,
+            from,
+            to,
+            createdAt: performance.now(),
+            color: event.color,
+          },
+        ])
+      }
+
+      switch (event.kind) {
+        case 'cycle.start':
+          setCycle((prev) => ({
+            ...prev,
+            current: { cycleId: event.cycleId ?? event.id, startedAt: event.ts },
+          }))
+          break
+        case 'cycle.end':
+          setCycle((prev) => ({
+            current: null,
+            lastFinished: {
+              cycleId: event.cycleId ?? event.id,
+              written: Number(event.payload.written ?? 0),
+              durationMs: Number(event.payload.duration_ms ?? 0),
+              ts: event.ts,
+            },
+            totalCycles: prev.totalCycles + 1,
+            artefactsWritten: prev.artefactsWritten + Number(event.payload.written ?? 0),
+          }))
+          break
+        case 'signal.ingest':
+          setSignals((prev) =>
+            [
+              {
+                cycleId: event.cycleId,
+                ts: event.ts,
+                fsScan: Number(event.payload.fs_scan ?? 0),
+                gitChanged: Number(event.payload.git_changed ?? 0),
+                msg: event.msg,
+              },
+              ...prev,
+            ].slice(0, MAX_ROWS),
+          )
+          break
+        case 'target.planned':
+          setTargets((prev) =>
+            [
+              {
+                cycleId: event.cycleId,
+                ts: event.ts,
+                count: Number(event.payload.count ?? 0),
+                paths: (event.payload.paths as string[] | undefined) ?? [],
+              },
+              ...prev,
+            ].slice(0, MAX_ROWS),
+          )
+          break
+        case 'artefact.upsert':
+          setArtefacts((prev) =>
+            [
+              {
+                id: event.id,
+                ts: event.ts,
+                kind: String(event.payload.kind ?? 'artefact'),
+                path: event.path ?? String(event.payload.key ?? ''),
+                cycleId: event.cycleId,
+              },
+              ...prev,
+            ].slice(0, MAX_ROWS),
+          )
+          break
+        case 'decision.recorded':
+          setDecisions((prev) =>
+            [
+              {
+                id: event.id,
+                ts: event.ts,
+                decisionId: String(event.payload.decision_id ?? 'decision'),
+                selectionCount: Number(event.payload.selection_count ?? 0),
+                cacheTier: String(event.payload.cache_tier ?? ''),
+              },
+              ...prev,
+            ].slice(0, MAX_ROWS),
+          )
+          break
+        case 'llm.request':
+          setModel((prev) => {
+            const next = new Map(prev.pending)
+            next.set(event.id, {
+              path: event.path,
+              model: String(event.payload.model ?? 'model'),
+              startedAt: event.ts,
+            })
+            return {
+              ...prev,
+              pending: next,
+              totalRequests: prev.totalRequests + 1,
+              lastModel: String(event.payload.model ?? prev.lastModel ?? 'model'),
+            }
+          })
+          break
+        case 'llm.response': {
+          const requestId = String(event.payload.request_id ?? '')
+          const latencyMs = Number(event.payload.latency_ms ?? 0)
+          const ok = event.payload.ok !== false
+          setModel((prev) => {
+            const next = new Map(prev.pending)
+            if (requestId) {
+              next.delete(requestId)
+            }
+            return {
+              ...prev,
+              pending: next,
+              lastLatencyMs: latencyMs,
+              lastModel: String(event.payload.model ?? prev.lastModel ?? 'model'),
+              recentLatencies: [...prev.recentLatencies, latencyMs].slice(-LATENCY_WINDOW),
+              totalErrors: prev.totalErrors + (ok ? 0 : 1),
+            }
+          })
+          break
+        }
+        default:
+          break
+      }
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        setLive(false)
+        source?.close()
+        source = null
+        if (retryRef.current) {
+          window.clearTimeout(retryRef.current)
+        }
+        return
+      }
+
+      connect()
+    }
+
+    connect()
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      closed = true
+      setLive(false)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      source?.close()
+      if (retryRef.current) {
+        window.clearTimeout(retryRef.current)
+      }
+    }
+  }, [enabled, path, stages])
+
+  // Garbage-collect stale particles (>2s old) so the canvas stays fluid.
+  useEffect(() => {
+    if (!particles.length) {
+      return
+    }
+    const timer = window.setInterval(() => {
+      const now = performance.now()
+      setParticles((prev) => prev.filter((particle) => now - particle.createdAt < 2000))
+    }, 500)
+    return () => window.clearInterval(timer)
+  }, [particles.length])
+
+  return useMemo(
+    () => ({
+      events,
+      live,
+      signals,
+      targets,
+      artefacts,
+      decisions,
+      model,
+      cycle,
+      particles,
+      reset: () => {
+        setEvents([])
+        setSignals([])
+        setTargets([])
+        setArtefacts([])
+        setDecisions([])
+        setParticles([])
+      },
+    }),
+    [events, live, signals, targets, artefacts, decisions, model, cycle, particles],
+  )
+}
+
+export { adaptLegacyEvent }

--- a/ui/cockpit/src/components/EventStreamPanel.test.tsx
+++ b/ui/cockpit/src/components/EventStreamPanel.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EventStreamPanel } from './EventStreamPanel'
+import type { PipelineEvent } from '../api/usePipelineEvents'
+
+function event(partial: Partial<PipelineEvent> & { id: string; kind: string; stage: PipelineEvent['stage'] }): PipelineEvent {
+  return {
+    id: partial.id,
+    t: '00:00.00',
+    tag: partial.kind.split('.')[0],
+    color: 'var(--fg-3)',
+    msg: partial.msg ?? `${partial.stage}:${partial.kind}`,
+    scn: partial.scn ?? null,
+    stage: partial.stage,
+    kind: partial.kind,
+    ts: partial.ts ?? 0,
+    path: partial.path ?? null,
+    cycleId: partial.cycleId ?? null,
+    payload: partial.payload ?? {},
+  }
+}
+
+describe('EventStreamPanel', () => {
+  it('renders events coloured by stage and shows a tailing indicator', () => {
+    render(
+      <EventStreamPanel
+        title="EVENT STREAM"
+        subtitle="Live"
+        events={[
+          event({ id: 'a', kind: 'llm.request', stage: 'model' }),
+          event({ id: 'b', kind: 'artefact.upsert', stage: 'artefacts' }),
+        ]}
+        onSelect={() => undefined}
+        live
+      />,
+    )
+
+    expect(screen.getByText('tailing')).toBeInTheDocument()
+    expect(screen.getByText(/model:llm.request/)).toBeInTheDocument()
+    expect(screen.getByText(/artefacts:artefact.upsert/)).toBeInTheDocument()
+  })
+
+  it('filters events by stage when a chip is toggled', () => {
+    render(
+      <EventStreamPanel
+        title="EVENT STREAM"
+        subtitle="Live"
+        events={[
+          event({ id: 'a', kind: 'llm.request', stage: 'model' }),
+          event({ id: 'b', kind: 'artefact.upsert', stage: 'artefacts' }),
+        ]}
+        onSelect={() => undefined}
+        live
+      />,
+    )
+
+    const modelChip = screen.getByRole('button', { name: /^model$/i })
+    fireEvent.click(modelChip)
+
+    expect(screen.queryByText(/artefacts:artefact.upsert/)).toBeNull()
+    expect(screen.getByText(/model:llm.request/)).toBeInTheDocument()
+  })
+
+  it('invokes onSelect with the scenario id when an event row is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <EventStreamPanel
+        title="EVENT STREAM"
+        subtitle="Live"
+        events={[
+          event({
+            id: 'a',
+            kind: 'artefact.upsert',
+            stage: 'artefacts',
+            scn: 'scn_123',
+            msg: 'scn_123 upsert',
+          }),
+        ]}
+        onSelect={onSelect}
+        live
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /scn_123/i }))
+    expect(onSelect).toHaveBeenCalledWith('scn_123')
+  })
+
+  it('shows a spinner indicator when pendingLlm > 0', () => {
+    const { container } = render(
+      <EventStreamPanel
+        title="EVENT STREAM"
+        subtitle="Live"
+        events={[]}
+        onSelect={() => undefined}
+        live
+        pendingLlm={2}
+      />,
+    )
+    expect(screen.getByText(/llm×2/)).toBeInTheDocument()
+    // Spinner is an unlabelled span; just assert the waiting marker didn't
+    // replace it.
+    expect(container.textContent).not.toContain('waiting')
+  })
+})

--- a/ui/cockpit/src/components/EventStreamPanel.tsx
+++ b/ui/cockpit/src/components/EventStreamPanel.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type { PipelineEvent } from '../api/usePipelineEvents'
+import type { PipelineStage, UIEvent } from '../types'
+
+export type StreamEvent = PipelineEvent | UIEvent
+
+const STAGE_COLORS: Record<PipelineStage, string> = {
+  signals: 'var(--fg-3)',
+  targets: 'var(--accent-soft)',
+  model: 'var(--amber)',
+  artefacts: 'var(--kind-refactor)',
+  scenarios: 'var(--accent)',
+  decisions: 'var(--kind-research)',
+  system: 'var(--fg-4)',
+}
+
+const STAGE_ORDER: PipelineStage[] = [
+  'signals',
+  'targets',
+  'model',
+  'artefacts',
+  'scenarios',
+  'decisions',
+  'system',
+]
+
+function resolveStage(event: StreamEvent): PipelineStage | null {
+  if ('stage' in event && event.stage) {
+    return event.stage
+  }
+  return null
+}
+
+export interface EventStreamPanelProps {
+  title: string
+  subtitle: string
+  events: StreamEvent[]
+  onSelect: (id: string) => void
+  live: boolean
+  /** When true, subsequent heartbeat events collapse into a single row. */
+  collapseHeartbeats?: boolean
+  /** Optional count of in-flight LLM requests to render a spinner in the header. */
+  pendingLlm?: number
+}
+
+export function EventStreamPanel({
+  title,
+  subtitle,
+  events,
+  onSelect,
+  live,
+  collapseHeartbeats = true,
+  pendingLlm = 0,
+}: EventStreamPanelProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [filter, setFilter] = useState<Set<PipelineStage>>(new Set())
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0
+    }
+  }, [events.length])
+
+  const filtered = useMemo(() => {
+    if (!filter.size) {
+      return events
+    }
+    return events.filter((event) => {
+      const stage = resolveStage(event)
+      return stage ? filter.has(stage) : false
+    })
+  }, [events, filter])
+
+  const rows = useMemo(() => {
+    if (!collapseHeartbeats) {
+      return filtered.map((event) => ({ event, collapsedCount: 0 }))
+    }
+    const out: Array<{ event: StreamEvent; collapsedCount: number }> = []
+    let cluster: { event: StreamEvent; collapsedCount: number } | null = null
+    for (const event of filtered) {
+      const isHeartbeat = (event.tag === 'keepalive' || event.kind === 'cycle.start' || event.kind === 'cycle.end') && !event.scn
+      if (isHeartbeat && cluster && cluster.event.tag === event.tag) {
+        cluster.collapsedCount += 1
+        continue
+      }
+      cluster = { event, collapsedCount: 0 }
+      out.push(cluster)
+    }
+    return out
+  }, [filtered, collapseHeartbeats])
+
+  const available = useMemo(() => {
+    const present = new Set<PipelineStage>()
+    for (const event of events) {
+      const stage = resolveStage(event)
+      if (stage) {
+        present.add(stage)
+      }
+    }
+    return STAGE_ORDER.filter((stage) => present.has(stage))
+  }, [events])
+
+  return (
+    <div
+      style={{
+        borderLeft: '1px solid var(--line-1)',
+        background: 'var(--bg-1)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: '100%',
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px 10px',
+          borderBottom: '1px solid var(--line-hair)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 10,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: 'var(--fg-4)' }}>
+            {title}
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--fg-1)', marginTop: 2, fontFamily: 'var(--font-display)' }}>
+            {subtitle}
+          </div>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {pendingLlm > 0 ? (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--amber)' }}>
+              <span
+                aria-hidden
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  border: '1.5px solid var(--amber)',
+                  borderTopColor: 'transparent',
+                  animation: 'dc-spin 0.8s linear infinite',
+                }}
+              />
+              <span className="mono" style={{ fontSize: 9.5 }}>llm×{pendingLlm}</span>
+            </span>
+          ) : null}
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+            <span
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: live ? 'var(--ok)' : 'var(--fg-4)',
+                boxShadow: live ? '0 0 8px var(--ok)' : 'none',
+              }}
+            />
+            <span className="mono" style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+              {live ? 'tailing' : 'waiting'}
+            </span>
+          </span>
+        </div>
+      </div>
+
+      {available.length ? (
+        <div
+          role="toolbar"
+          aria-label="Filter event stream by stage"
+          style={{
+            display: 'flex',
+            gap: 4,
+            padding: '8px 12px',
+            borderBottom: '1px solid var(--line-hair)',
+            overflowX: 'auto',
+          }}
+        >
+          <FilterChip
+            label="all"
+            active={filter.size === 0}
+            color="var(--fg-3)"
+            onClick={() => setFilter(new Set())}
+          />
+          {available.map((stage) => (
+            <FilterChip
+              key={stage}
+              label={stage}
+              active={filter.has(stage)}
+              color={STAGE_COLORS[stage]}
+              onClick={() =>
+                setFilter((prev) => {
+                  const next = new Set(prev)
+                  if (next.has(stage)) {
+                    next.delete(stage)
+                  } else {
+                    next.add(stage)
+                  }
+                  return next
+                })
+              }
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <div
+        ref={scrollRef}
+        className="scroll"
+        style={{ flex: 1, overflow: 'auto', fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.5 }}
+      >
+        {rows.map(({ event, collapsedCount }, index) => {
+          const stage = resolveStage(event)
+          const color = stage ? STAGE_COLORS[stage] : event.color
+          return (
+            <button
+              key={event.id}
+              type="button"
+              onClick={() => (event.scn ? onSelect(event.scn) : undefined)}
+              style={{
+                width: '100%',
+                textAlign: 'left',
+                padding: '6px 12px 6px 16px',
+                borderBottom: '1px solid var(--line-hair)',
+                borderLeft: `2px solid ${color}`,
+                background: index === 0 ? 'color-mix(in oklch, var(--accent) 7%, transparent)' : 'transparent',
+                color: 'var(--fg-1)',
+                cursor: event.scn ? 'pointer' : 'default',
+                display: 'grid',
+                gridTemplateColumns: 'auto auto 1fr auto',
+                alignItems: 'baseline',
+                gap: 8,
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+              }}
+              aria-label={`${stage ?? event.tag} event ${event.msg}`}
+            >
+              <span style={{ color: 'var(--fg-4)', fontSize: 10 }}>{event.t}</span>
+              <span
+                style={{
+                  color,
+                  textTransform: 'uppercase',
+                  letterSpacing: 0.6,
+                  fontSize: 9.5,
+                  minWidth: 64,
+                }}
+              >
+                {stage ?? event.tag}
+              </span>
+              <span style={{ color: 'var(--fg-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {event.msg}
+              </span>
+              {collapsedCount > 0 ? (
+                <span className="mono" style={{ fontSize: 9.5, color: 'var(--fg-4)' }}>
+                  ×{collapsedCount + 1}
+                </span>
+              ) : event.scn ? (
+                <span className="mono" style={{ fontSize: 9.5, color: 'var(--fg-4)' }}>
+                  ↗
+                </span>
+              ) : (
+                <span />
+              )}
+            </button>
+          )
+        })}
+        {!rows.length ? (
+          <div style={{ padding: 18, color: 'var(--fg-4)', fontSize: 12 }}>
+            {filter.size ? 'No events match the active filter.' : 'No events yet.'}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+interface FilterChipProps {
+  label: string
+  active: boolean
+  color: string
+  onClick: () => void
+}
+
+function FilterChip({ label, active, color, onClick }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="mono"
+      aria-pressed={active}
+      style={{
+        padding: '3px 9px',
+        borderRadius: 'var(--r-1)',
+        border: `1px solid ${active ? color : 'var(--line-1)'}`,
+        background: active ? `color-mix(in oklch, ${color} 18%, transparent)` : 'transparent',
+        color: active ? 'var(--fg-1)' : 'var(--fg-3)',
+        fontSize: 10,
+        letterSpacing: 0.6,
+        textTransform: 'uppercase',
+        cursor: 'pointer',
+      }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/ui/cockpit/src/components/PipelineCanvas.test.tsx
+++ b/ui/cockpit/src/components/PipelineCanvas.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { PipelineCanvas } from './PipelineCanvas'
+import type {
+  ArtefactRow,
+  CycleState,
+  DecisionRow,
+  ModelState,
+  PipelineEvent,
+  SignalRow,
+  TargetRow,
+} from '../api/usePipelineEvents'
+
+function model(overrides: Partial<ModelState> = {}): ModelState {
+  return {
+    pending: overrides.pending ?? new Map(),
+    lastLatencyMs: overrides.lastLatencyMs ?? null,
+    lastModel: overrides.lastModel ?? null,
+    recentLatencies: overrides.recentLatencies ?? [],
+    totalRequests: overrides.totalRequests ?? 0,
+    totalErrors: overrides.totalErrors ?? 0,
+  }
+}
+
+function cycle(overrides: Partial<CycleState> = {}): CycleState {
+  return {
+    current: overrides.current ?? null,
+    lastFinished: overrides.lastFinished ?? null,
+    totalCycles: overrides.totalCycles ?? 0,
+    artefactsWritten: overrides.artefactsWritten ?? 0,
+  }
+}
+
+const SIGNALS: SignalRow[] = [
+  { cycleId: 'c1', ts: 0, fsScan: 5, gitChanged: 2, msg: 'scan' },
+]
+const TARGETS: TargetRow[] = [
+  { cycleId: 'c1', ts: 0, count: 4, paths: ['src/api.py', 'src/util.py'] },
+]
+const ARTEFACTS: ArtefactRow[] = [
+  { id: 'ev1', ts: 0, kind: 'file_summary', path: 'src/api.py', cycleId: 'c1' },
+]
+const DECISIONS: DecisionRow[] = [
+  { id: 'ev2', ts: 0, decisionId: 'dec_1', selectionCount: 3, cacheTier: 'warm' },
+]
+const EVENTS: PipelineEvent[] = []
+
+describe('PipelineCanvas', () => {
+  it('renders all six pipeline lanes', () => {
+    render(
+      <PipelineCanvas
+        scenarios={[]}
+        selectedId={null}
+        onSelect={() => undefined}
+        activePulses={new Set()}
+        pinnedIds={new Set()}
+        signals={SIGNALS}
+        targets={TARGETS}
+        artefacts={ARTEFACTS}
+        decisions={DECISIONS}
+        model={model()}
+        cycle={cycle()}
+        events={EVENTS}
+      />,
+    )
+
+    for (const label of ['SIGNALS', 'TARGETS', 'MODEL', 'ARTEFACTS', 'SCENARIOS', 'DECISIONS']) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  })
+
+  it('shows the latest target path in the targets lane', () => {
+    render(
+      <PipelineCanvas
+        scenarios={[]}
+        selectedId={null}
+        onSelect={() => undefined}
+        activePulses={new Set()}
+        pinnedIds={new Set()}
+        signals={SIGNALS}
+        targets={TARGETS}
+        artefacts={ARTEFACTS}
+        decisions={DECISIONS}
+        model={model()}
+        cycle={cycle()}
+        events={EVENTS}
+      />,
+    )
+
+    expect(screen.getAllByText('src/api.py').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText(/4 planned/)).toBeInTheDocument()
+  })
+
+  it('renders the empty state when no scenarios exist', () => {
+    render(
+      <PipelineCanvas
+        scenarios={[]}
+        selectedId={null}
+        onSelect={() => undefined}
+        activePulses={new Set()}
+        pinnedIds={new Set()}
+        signals={[]}
+        targets={[]}
+        artefacts={[]}
+        decisions={[]}
+        model={model()}
+        cycle={cycle()}
+        events={EVENTS}
+      />,
+    )
+
+    expect(screen.getByText(/Waiting for the daemon/)).toBeInTheDocument()
+  })
+
+  it('flashes the model lane with a spinner while LLM requests are pending', () => {
+    const pending = new Map([
+      ['ev-1', { path: 'src/a.py', model: 'qwen', startedAt: Date.now() / 1000 }],
+    ])
+    render(
+      <PipelineCanvas
+        scenarios={[]}
+        selectedId={null}
+        onSelect={() => undefined}
+        activePulses={new Set()}
+        pinnedIds={new Set()}
+        signals={SIGNALS}
+        targets={TARGETS}
+        artefacts={ARTEFACTS}
+        decisions={DECISIONS}
+        model={model({ pending, lastModel: 'qwen' })}
+        cycle={cycle()}
+        events={EVENTS}
+      />,
+    )
+
+    expect(screen.getByText(/1 in flight/)).toBeInTheDocument()
+  })
+})

--- a/ui/cockpit/src/components/PipelineCanvas.tsx
+++ b/ui/cockpit/src/components/PipelineCanvas.tsx
@@ -1,0 +1,525 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type {
+  ArtefactRow,
+  CycleState,
+  DecisionRow,
+  ModelState,
+  PipelineEvent,
+  SignalRow,
+  TargetRow,
+} from '../api/usePipelineEvents'
+import type { PipelineStage, UIScenario } from '../types'
+import { ScenarioCluster } from './ScenarioCluster'
+
+interface LaneConfig {
+  id: PipelineStage
+  label: string
+  sub: string
+  accent: string
+}
+
+const LANES: LaneConfig[] = [
+  { id: 'signals', label: 'SIGNALS', sub: 'ingest', accent: 'var(--fg-3)' },
+  { id: 'targets', label: 'TARGETS', sub: 'planner', accent: 'var(--accent-soft)' },
+  { id: 'model', label: 'MODEL', sub: 'llm', accent: 'var(--amber)' },
+  { id: 'artefacts', label: 'ARTEFACTS', sub: 'store', accent: 'var(--kind-refactor)' },
+  { id: 'scenarios', label: 'SCENARIOS', sub: 'frontier', accent: 'var(--accent)' },
+  { id: 'decisions', label: 'DECISIONS', sub: 'proxy', accent: 'var(--kind-research)' },
+]
+
+export interface PipelineCanvasProps {
+  scenarios: UIScenario[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+  activePulses: Set<string>
+  pinnedIds: Set<string>
+  signals: SignalRow[]
+  targets: TargetRow[]
+  artefacts: ArtefactRow[]
+  decisions: DecisionRow[]
+  model: ModelState
+  cycle: CycleState
+  events: PipelineEvent[]
+}
+
+/**
+ * Top ribbon + scenario cluster that together form the cockpit's pipeline
+ * view.
+ *
+ * The six-lane ribbon mirrors the daemon's real control flow:
+ *   Signals → Targets → Model → Artefacts → Scenarios → Decisions
+ *
+ * Each lane owns a small live read-out of recent activity (latest path, count,
+ * latency, etc.) and flashes when a fresh event for its stage arrives. The
+ * scenario cluster underneath shows the actual graph of scenarios with
+ * shared-path Jaccard edges — the concrete "connected structure" users can
+ * see while the daemon works.
+ */
+export function PipelineCanvas({
+  scenarios,
+  selectedId,
+  onSelect,
+  activePulses,
+  pinnedIds,
+  signals,
+  targets,
+  artefacts,
+  decisions,
+  model,
+  cycle,
+  events,
+}: PipelineCanvasProps) {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'grid',
+        gridTemplateRows: 'auto minmax(0, 1fr)',
+        background: 'var(--bg-0)',
+      }}
+    >
+      <PipelineRibbon
+        signals={signals}
+        targets={targets}
+        artefacts={artefacts}
+        decisions={decisions}
+        model={model}
+        cycle={cycle}
+        events={events}
+        scenarios={scenarios}
+      />
+
+      <div style={{ position: 'relative', minHeight: 0 }}>
+        <div style={{ position: 'absolute', top: 14, left: 20, zIndex: 3 }}>
+          <div className="mono" style={{ fontSize: 10, letterSpacing: 1.2, color: 'var(--fg-4)' }}>
+            SCENARIO CLUSTER
+          </div>
+          <div style={{ fontSize: 15, color: 'var(--fg-1)', fontFamily: 'var(--font-display)', marginTop: 2 }}>
+            {scenarios.length} scenarios · shared-path edges · drag to reposition
+          </div>
+        </div>
+        <ScenarioCluster
+          scenarios={scenarios}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          activePulses={activePulses}
+          pinnedIds={pinnedIds}
+          emptyHint="Waiting for the daemon to produce scenarios. Trigger a cycle (Files change or run `vaner ponder once`) to see nodes appear here."
+        />
+      </div>
+    </div>
+  )
+}
+
+interface PipelineRibbonProps {
+  signals: SignalRow[]
+  targets: TargetRow[]
+  artefacts: ArtefactRow[]
+  decisions: DecisionRow[]
+  model: ModelState
+  cycle: CycleState
+  events: PipelineEvent[]
+  scenarios: UIScenario[]
+}
+
+function PipelineRibbon({
+  signals,
+  targets,
+  artefacts,
+  decisions,
+  model,
+  cycle,
+  events,
+  scenarios,
+}: PipelineRibbonProps) {
+  const ribbonRef = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState({ w: 1000, h: 140 })
+
+  useEffect(() => {
+    const element = ribbonRef.current
+    if (!element) {
+      return
+    }
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setSize({ w: entry.contentRect.width, h: entry.contentRect.height })
+      }
+    })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  const lastByStage = useMemo(() => {
+    const map = new Map<PipelineStage, number>()
+    for (const event of events) {
+      if (!map.has(event.stage)) {
+        map.set(event.stage, event.ts * 1000)
+      }
+    }
+    return map
+  }, [events])
+
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 400)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  const pendingLlm = model.pending.size
+
+  return (
+    <div
+      ref={ribbonRef}
+      style={{
+        position: 'relative',
+        borderBottom: '1px solid var(--line-1)',
+        background: 'linear-gradient(180deg, var(--bg-1), var(--bg-0))',
+        padding: '14px 20px 12px',
+        overflow: 'hidden',
+      }}
+      aria-label="Pipeline ribbon"
+    >
+      <ParticleTrack width={size.w - 40} events={events} />
+      <div
+        style={{
+          position: 'relative',
+          display: 'grid',
+          gridTemplateColumns: `repeat(${LANES.length}, minmax(0, 1fr))`,
+          gap: 12,
+          zIndex: 1,
+        }}
+      >
+        {LANES.map((lane) => {
+          const last = lastByStage.get(lane.id)
+          const recent = last ? now - last < 1500 : false
+          const busy = lane.id === 'model' && pendingLlm > 0
+          return (
+            <Lane
+              key={lane.id}
+              lane={lane}
+              active={recent || busy}
+              content={laneContent(lane.id, {
+                signals,
+                targets,
+                artefacts,
+                decisions,
+                model,
+                cycle,
+                scenarios,
+                pendingLlm,
+              })}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+interface LaneProps {
+  lane: LaneConfig
+  active: boolean
+  content: React.ReactNode
+}
+
+function Lane({ lane, active, content }: LaneProps) {
+  return (
+    <div
+      data-lane={lane.id}
+      style={{
+        position: 'relative',
+        padding: '10px 12px',
+        border: `1px solid ${active ? lane.accent : 'var(--line-1)'}`,
+        borderRadius: 'var(--r-2)',
+        background: active
+          ? `color-mix(in oklch, ${lane.accent} 10%, var(--bg-1))`
+          : 'var(--bg-1)',
+        minHeight: 78,
+        transition: 'background .3s, border-color .3s',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+        <span className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: lane.accent }}>
+          {lane.label}
+        </span>
+        <span className="mono" style={{ fontSize: 9, color: 'var(--fg-4)' }}>
+          {lane.sub}
+        </span>
+      </div>
+      <div style={{ marginTop: 6, fontSize: 11, color: 'var(--fg-2)', lineHeight: 1.45 }}>{content}</div>
+    </div>
+  )
+}
+
+interface LaneContext {
+  signals: SignalRow[]
+  targets: TargetRow[]
+  artefacts: ArtefactRow[]
+  decisions: DecisionRow[]
+  model: ModelState
+  cycle: CycleState
+  scenarios: UIScenario[]
+  pendingLlm: number
+}
+
+function laneContent(stage: PipelineStage, ctx: LaneContext): React.ReactNode {
+  switch (stage) {
+    case 'signals': {
+      const last = ctx.signals[0]
+      if (!last) {
+        return <FaintLine text="awaiting signals" />
+      }
+      return (
+        <div className="mono" style={{ fontSize: 10.5 }}>
+          <div>fs {last.fsScan} · git {last.gitChanged}</div>
+          <div style={{ color: 'var(--fg-4)' }}>{ctx.signals.length} bursts</div>
+        </div>
+      )
+    }
+    case 'targets': {
+      const last = ctx.targets[0]
+      if (!last) {
+        return <FaintLine text="no targets planned" />
+      }
+      return (
+        <div className="mono" style={{ fontSize: 10.5 }}>
+          <div>{last.count} planned</div>
+          <Truncated text={last.paths[0] ?? ''} muted />
+        </div>
+      )
+    }
+    case 'model': {
+      if (ctx.pendingLlm > 0) {
+        return (
+          <div className="mono" style={{ fontSize: 10.5, color: 'var(--amber)' }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+              <Spinner />
+              <span>{ctx.pendingLlm} in flight</span>
+            </span>
+            <Truncated text={ctx.model.lastModel ?? 'model'} muted />
+          </div>
+        )
+      }
+      return (
+        <div className="mono" style={{ fontSize: 10.5 }}>
+          <div>{ctx.model.lastLatencyMs ? `${ctx.model.lastLatencyMs.toFixed(0)}ms last` : 'standby'}</div>
+          <Truncated text={ctx.model.lastModel ?? '—'} muted />
+        </div>
+      )
+    }
+    case 'artefacts': {
+      const last = ctx.artefacts[0]
+      if (!last) {
+        return <FaintLine text="no artefacts yet" />
+      }
+      return (
+        <div className="mono" style={{ fontSize: 10.5 }}>
+          <div>{ctx.cycle.artefactsWritten} written</div>
+          <Truncated text={last.path} muted />
+        </div>
+      )
+    }
+    case 'scenarios': {
+      return (
+        <div className="mono" style={{ fontSize: 10.5 }}>
+          <div>{ctx.scenarios.length} on frontier</div>
+          <div style={{ color: 'var(--fg-4)' }}>
+            {ctx.scenarios.filter((scenario) => scenario.pinned).length} pinned
+          </div>
+        </div>
+      )
+    }
+    case 'decisions': {
+      const last = ctx.decisions[0]
+      if (!last) {
+        return <FaintLine text="no proxy decisions" />
+      }
+      return (
+        <div className="mono" style={{ fontSize: 10.5 }}>
+          <div>{last.decisionId}</div>
+          <div style={{ color: 'var(--fg-4)' }}>
+            {last.selectionCount} sel · {last.cacheTier || '—'}
+          </div>
+        </div>
+      )
+    }
+    default:
+      return null
+  }
+}
+
+function Spinner() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: 9,
+        height: 9,
+        borderRadius: '50%',
+        border: '1.5px solid var(--amber)',
+        borderTopColor: 'transparent',
+        animation: 'dc-spin 0.8s linear infinite',
+        display: 'inline-block',
+      }}
+    />
+  )
+}
+
+function FaintLine({ text }: { text: string }) {
+  return (
+    <span className="mono" style={{ fontSize: 10.5, color: 'var(--fg-4)' }}>
+      {text}
+    </span>
+  )
+}
+
+function Truncated({ text, muted }: { text: string; muted?: boolean }) {
+  return (
+    <div
+      title={text}
+      style={{
+        color: muted ? 'var(--fg-4)' : 'var(--fg-2)',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        maxWidth: '100%',
+      }}
+    >
+      {text || '—'}
+    </div>
+  )
+}
+
+interface ParticleTrackProps {
+  width: number
+  events: PipelineEvent[]
+}
+
+interface TrackParticle {
+  id: string
+  fromIndex: number
+  toIndex: number
+  color: string
+  createdAt: number
+}
+
+const KIND_TRANSITIONS: Record<string, [PipelineStage, PipelineStage]> = {
+  'signal.ingest': ['signals', 'targets'],
+  'target.planned': ['targets', 'model'],
+  'llm.request': ['targets', 'model'],
+  'llm.response': ['model', 'artefacts'],
+  'artefact.upsert': ['artefacts', 'scenarios'],
+  'decision.recorded': ['scenarios', 'decisions'],
+}
+
+/**
+ * SVG layer that renders short-lived particles flowing left-to-right between
+ * lanes as new events arrive on the bus. Each particle lasts ~1.2s so the
+ * ribbon always feels "alive" during an active cycle without piling up.
+ */
+function ParticleTrack({ width, events }: ParticleTrackProps) {
+  const particlesRef = useRef<TrackParticle[]>([])
+  const lastSeenRef = useRef<string | null>(null)
+  const [now, setNow] = useState(() =>
+    typeof performance !== 'undefined' ? performance.now() : 0,
+  )
+
+  useEffect(() => {
+    if (!events.length) {
+      return
+    }
+    const next: TrackParticle[] = []
+    for (const event of events.slice(0, 15)) {
+      if (event.id === lastSeenRef.current) {
+        break
+      }
+      const transition = KIND_TRANSITIONS[event.kind]
+      if (!transition) {
+        continue
+      }
+      const fromIndex = LANES.findIndex((lane) => lane.id === transition[0])
+      const toIndex = LANES.findIndex((lane) => lane.id === transition[1])
+      if (fromIndex < 0 || toIndex < 0) {
+        continue
+      }
+      next.push({
+        id: `${event.id}-particle`,
+        fromIndex,
+        toIndex,
+        color: event.color,
+        createdAt: performance.now(),
+      })
+    }
+    lastSeenRef.current = events[0].id
+    if (next.length) {
+      particlesRef.current = [...particlesRef.current.slice(-40), ...next]
+      setNow(performance.now())
+    }
+  }, [events])
+
+  useEffect(() => {
+    let frame = 0
+    const tick = (time: number) => {
+      const active = particlesRef.current.filter((particle) => time - particle.createdAt < 1500)
+      particlesRef.current = active
+      if (active.length) {
+        setNow(time)
+      }
+      frame = requestAnimationFrame(tick)
+    }
+    frame = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  if (!width || !LANES.length) {
+    return null
+  }
+
+  const laneWidth = width / LANES.length
+  const trackY = 48
+
+  return (
+    <svg
+      width={width}
+      height={78}
+      style={{
+        position: 'absolute',
+        top: 6,
+        left: 20,
+        pointerEvents: 'none',
+        opacity: 0.8,
+      }}
+      aria-hidden
+    >
+      {LANES.slice(0, -1).map((_, index) => (
+        <line
+          key={index}
+          x1={laneWidth * (index + 0.5)}
+          y1={trackY}
+          x2={laneWidth * (index + 1.5)}
+          y2={trackY}
+          stroke="var(--line-1)"
+          strokeWidth={0.6}
+          strokeDasharray="2 4"
+        />
+      ))}
+      {particlesRef.current.map((particle) => {
+        const age = Math.min(1, (now - particle.createdAt) / 1100)
+        const x = laneWidth * (particle.fromIndex + 0.5 + (particle.toIndex - particle.fromIndex) * age)
+        const fade = 1 - Math.abs(0.5 - age) * 1.8
+        return (
+          <circle
+            key={particle.id}
+            cx={x}
+            cy={trackY}
+            r={3}
+            fill={particle.color}
+            opacity={Math.max(0.15, fade)}
+          />
+        )
+      })}
+    </svg>
+  )
+}

--- a/ui/cockpit/src/components/ScenarioCluster.test.ts
+++ b/ui/cockpit/src/components/ScenarioCluster.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeEdges, initialLayout, jaccard, scenarioPaths, tickForces } from './ScenarioCluster'
+import type { UIScenario } from '../types'
+
+function scenario(overrides: Partial<UIScenario>): UIScenario {
+  return {
+    id: 'x',
+    kind: 'research',
+    title: 'x',
+    score: 0.5,
+    freshness: 'fresh',
+    depth: 0,
+    parent: null,
+    path: 'x.py',
+    skill: null,
+    decisionState: 'pending',
+    reason: 'because',
+    entities: [],
+    pinned: false,
+    ...overrides,
+  }
+}
+
+describe('jaccard', () => {
+  it('returns 0 for disjoint sets', () => {
+    expect(jaccard(new Set(['a']), new Set(['b']))).toBe(0)
+  })
+
+  it('returns 1 for identical sets', () => {
+    expect(jaccard(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(1)
+  })
+
+  it('computes partial overlap correctly', () => {
+    expect(jaccard(new Set(['a', 'b']), new Set(['a', 'c']))).toBeCloseTo(1 / 3, 5)
+  })
+
+  it('returns 0 when either set is empty', () => {
+    expect(jaccard(new Set(), new Set(['a']))).toBe(0)
+  })
+})
+
+describe('scenarioPaths', () => {
+  it('includes both path and entities', () => {
+    const paths = scenarioPaths(
+      scenario({ id: 'a', path: 'src/main.py', entities: ['src/util.py', 'README.md'] }),
+    )
+    expect(paths).toEqual(new Set(['src/main.py', 'src/util.py', 'README.md']))
+  })
+})
+
+describe('computeEdges', () => {
+  it('includes explicit parent edges regardless of path overlap', () => {
+    const edges = computeEdges([
+      scenario({ id: 'root', path: 'root.py' }),
+      scenario({ id: 'child', parent: 'root', path: 'child.py' }),
+    ])
+    expect(edges).toContainEqual(
+      expect.objectContaining({ from: 'root', to: 'child', kind: 'parent' }),
+    )
+  })
+
+  it('derives shared-path edges above the threshold', () => {
+    const edges = computeEdges([
+      scenario({ id: 'a', path: 'src/api.py', entities: ['src/util.py'] }),
+      scenario({ id: 'b', path: 'src/api.py', entities: ['src/util.py'] }),
+    ])
+    const sharedEdges = edges.filter((edge) => edge.kind === 'shared-path')
+    expect(sharedEdges.length).toBeGreaterThan(0)
+    expect(sharedEdges[0].weight).toBeGreaterThan(0.5)
+  })
+
+  it('omits shared-path edges below the threshold', () => {
+    const edges = computeEdges(
+      [
+        scenario({ id: 'a', path: 'src/a.py' }),
+        scenario({ id: 'b', path: 'src/b.py' }),
+      ],
+      { threshold: 0.5 },
+    )
+    expect(edges.filter((edge) => edge.kind === 'shared-path')).toHaveLength(0)
+  })
+
+  it('limits shared-path edges per node', () => {
+    const scenarios = Array.from({ length: 8 }, (_, index) =>
+      scenario({ id: `s${index}`, path: 'shared.py', entities: ['e.py'] }),
+    )
+    const edges = computeEdges(scenarios, { threshold: 0.1, maxPerNode: 2 })
+    const shared = edges.filter((edge) => edge.kind === 'shared-path')
+    // Each of the 8 nodes contributes up to ``maxPerNode`` outbound edges
+    // before dedup; the total shared-path edges must be well below the
+    // quadratic ceiling of ``n*(n-1)/2`` (28).
+    expect(shared.length).toBeLessThanOrEqual(16)
+  })
+})
+
+describe('initialLayout', () => {
+  it('places every scenario within the viewport bounds', () => {
+    const scenarios = [
+      scenario({ id: 'a', kind: 'research' }),
+      scenario({ id: 'b', kind: 'change' }),
+      scenario({ id: 'c', kind: 'debug' }),
+    ]
+    const positions = initialLayout(scenarios, 800, 600)
+    for (const id of ['a', 'b', 'c']) {
+      expect(positions[id]).toBeDefined()
+      expect(positions[id].x).toBeGreaterThan(0)
+      expect(positions[id].y).toBeGreaterThan(0)
+      expect(positions[id].x).toBeLessThan(800)
+      expect(positions[id].y).toBeLessThan(600)
+    }
+  })
+
+  it('buckets scenarios of the same kind into the same angular sector', () => {
+    const scenarios = [
+      scenario({ id: 'a', kind: 'research', score: 0.6 }),
+      scenario({ id: 'b', kind: 'research', score: 0.7 }),
+      scenario({ id: 'c', kind: 'debug', score: 0.8 }),
+    ]
+    const positions = initialLayout(scenarios, 800, 600)
+    const angle = (id: string) =>
+      Math.atan2(positions[id].y - 300, positions[id].x - 400)
+    const researchGap = Math.abs(angle('a') - angle('b'))
+    const crossKindGap = Math.abs(angle('a') - angle('c'))
+    expect(researchGap).toBeLessThan(crossKindGap)
+  })
+})
+
+describe('tickForces', () => {
+  it('keeps parent-linked nodes within a bounded range after several ticks', () => {
+    const scenarios = [
+      scenario({ id: 'root' }),
+      scenario({ id: 'child', parent: 'root' }),
+    ]
+    const positions = initialLayout(scenarios, 800, 600)
+    const edges = computeEdges(scenarios)
+    for (let tick = 0; tick < 60; tick += 1) {
+      tickForces(positions, edges, { width: 800, height: 600 })
+    }
+    const dx = positions.root.x - positions.child.x
+    const dy = positions.root.y - positions.child.y
+    const distance = Math.sqrt(dx * dx + dy * dy)
+    expect(distance).toBeGreaterThan(40)
+    expect(distance).toBeLessThan(400)
+  })
+
+  it('does not move nodes marked as manual', () => {
+    const scenarios = [scenario({ id: 'a' }), scenario({ id: 'b' })]
+    const positions = initialLayout(scenarios, 800, 600)
+    positions.a.x = 100
+    positions.a.y = 100
+    positions.a._manual = true
+    const edges = computeEdges(scenarios)
+    for (let tick = 0; tick < 10; tick += 1) {
+      tickForces(positions, edges, { width: 800, height: 600 })
+    }
+    expect(positions.a.x).toBe(100)
+    expect(positions.a.y).toBe(100)
+  })
+})

--- a/ui/cockpit/src/components/ScenarioCluster.tsx
+++ b/ui/cockpit/src/components/ScenarioCluster.tsx
@@ -1,0 +1,636 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { KIND_COLOR } from '../lib/constants'
+import type { UIScenario, UIScenarioKind } from '../types'
+
+export type ClusterPosition = { x: number; y: number; vx?: number; vy?: number; _manual?: boolean }
+
+export interface ScenarioEdge {
+  from: string
+  to: string
+  weight: number
+  kind: 'parent' | 'shared-path'
+}
+
+/**
+ * Jaccard similarity between two sets of path strings. Used to derive
+ * implicit edges between scenarios that touch the same files even when they
+ * don't share an explicit parent/child relationship.
+ */
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (!a.size || !b.size) {
+    return 0
+  }
+  let intersection = 0
+  for (const item of a) {
+    if (b.has(item)) {
+      intersection += 1
+    }
+  }
+  const union = a.size + b.size - intersection
+  return union > 0 ? intersection / union : 0
+}
+
+/**
+ * Extract the set of file paths associated with a scenario. We read from the
+ * ``entities`` array first (which surfaces touched files), then fall back to
+ * the scenario's primary path so that even scenarios without entities can
+ * form implicit shared-path edges with their direct neighbours.
+ */
+export function scenarioPaths(scenario: UIScenario): Set<string> {
+  const paths = new Set<string>()
+  if (scenario.path) {
+    paths.add(scenario.path)
+  }
+  for (const entity of scenario.entities ?? []) {
+    if (typeof entity === 'string' && entity) {
+      paths.add(entity)
+    }
+  }
+  return paths
+}
+
+/**
+ * Compute scenario edges.
+ *
+ * Two sources are combined:
+ *  1. Explicit ``parent`` links (rendered with a solid curve).
+ *  2. Shared-path Jaccard overlap above ``threshold`` — limited to the top
+ *     ``maxPerNode`` partners per scenario to keep the cluster legible on
+ *     large frontiers.
+ */
+export function computeEdges(
+  scenarios: UIScenario[],
+  options: { threshold?: number; maxPerNode?: number } = {},
+): ScenarioEdge[] {
+  const threshold = options.threshold ?? 0.2
+  const maxPerNode = options.maxPerNode ?? 3
+  const edges: ScenarioEdge[] = []
+  const seen = new Set<string>()
+
+  for (const scenario of scenarios) {
+    if (scenario.parent && scenarios.some((other) => other.id === scenario.parent)) {
+      const key = `${scenario.parent}|${scenario.id}`
+      if (!seen.has(key)) {
+        seen.add(key)
+        edges.push({ from: scenario.parent, to: scenario.id, weight: 1, kind: 'parent' })
+      }
+    }
+  }
+
+  const paths = scenarios.map((scenario) => ({ id: scenario.id, paths: scenarioPaths(scenario) }))
+  for (let i = 0; i < paths.length; i += 1) {
+    const candidates: Array<{ other: string; weight: number }> = []
+    for (let j = 0; j < paths.length; j += 1) {
+      if (i === j) {
+        continue
+      }
+      const weight = jaccard(paths[i].paths, paths[j].paths)
+      if (weight >= threshold) {
+        candidates.push({ other: paths[j].id, weight })
+      }
+    }
+    candidates.sort((a, b) => b.weight - a.weight)
+    for (const candidate of candidates.slice(0, maxPerNode)) {
+      const key = [paths[i].id, candidate.other].sort().join('|')
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
+      edges.push({
+        from: paths[i].id,
+        to: candidate.other,
+        weight: candidate.weight,
+        kind: 'shared-path',
+      })
+    }
+  }
+
+  return edges
+}
+
+/**
+ * Kind-bucketed initial layout. Scenarios with the same ``kind`` get placed in
+ * the same angular sector around the cluster centre; scenarios without a
+ * parent still form a visible constellation rather than stacking in a single
+ * column at x=0 the way the legacy tree layout did.
+ */
+export function initialLayout(
+  scenarios: UIScenario[],
+  width: number,
+  height: number,
+): Record<string, ClusterPosition> {
+  const positions: Record<string, ClusterPosition> = {}
+  const kinds = Array.from(new Set(scenarios.map((scenario) => scenario.kind))) as UIScenarioKind[]
+  const centerX = width / 2
+  const centerY = height / 2
+  const radius = Math.min(width, height) * 0.35
+
+  if (kinds.length === 0) {
+    return positions
+  }
+
+  const byKind = new Map<UIScenarioKind, UIScenario[]>()
+  for (const kind of kinds) {
+    byKind.set(kind, [])
+  }
+  for (const scenario of scenarios) {
+    byKind.get(scenario.kind)?.push(scenario)
+  }
+
+  kinds.forEach((kind, kindIndex) => {
+    const bucket = byKind.get(kind) ?? []
+    const sorted = [...bucket].sort((a, b) => b.score - a.score)
+    const kindAngle = (kindIndex / kinds.length) * Math.PI * 2
+    sorted.forEach((scenario, index) => {
+      const localRadius = radius * (0.25 + 0.75 * (1 - scenario.score))
+      const jitter = ((scenario.id.charCodeAt(0) % 7) - 3) * 0.04
+      const spread = sorted.length > 1 ? ((index / (sorted.length - 1)) - 0.5) * 0.7 : 0
+      const angle = kindAngle + spread + jitter
+      positions[scenario.id] = {
+        x: centerX + localRadius * Math.cos(angle),
+        y: centerY + localRadius * Math.sin(angle),
+        vx: 0,
+        vy: 0,
+      }
+    })
+  })
+
+  return positions
+}
+
+/**
+ * Run one tick of a lightweight force-directed layout.
+ *
+ * Forces:
+ *   - Coulomb-style repulsion between every pair (keeps nodes from stacking).
+ *   - Hooke-style attraction along every edge (clusters share-path neighbours).
+ *   - Weak centering gravity so orphan clusters don't drift off-screen.
+ *
+ * The output is mutated in place to avoid allocation churn in the animation
+ * loop.
+ */
+export function tickForces(
+  positions: Record<string, ClusterPosition>,
+  edges: ScenarioEdge[],
+  options: { width: number; height: number; dt?: number },
+) {
+  const dt = options.dt ?? 0.6
+  const centerX = options.width / 2
+  const centerY = options.height / 2
+  const ids = Object.keys(positions)
+
+  for (const id of ids) {
+    const position = positions[id]
+    if (!position._manual) {
+      position.vx = (position.vx ?? 0) * 0.85
+      position.vy = (position.vy ?? 0) * 0.85
+    }
+  }
+
+  for (let i = 0; i < ids.length; i += 1) {
+    const a = positions[ids[i]]
+    for (let j = i + 1; j < ids.length; j += 1) {
+      const b = positions[ids[j]]
+      const dx = b.x - a.x
+      const dy = b.y - a.y
+      const distanceSquared = dx * dx + dy * dy + 0.01
+      const distance = Math.sqrt(distanceSquared)
+      const repulsion = 2400 / distanceSquared
+      const fx = (dx / distance) * repulsion
+      const fy = (dy / distance) * repulsion
+      if (!a._manual) {
+        a.vx = (a.vx ?? 0) - fx
+        a.vy = (a.vy ?? 0) - fy
+      }
+      if (!b._manual) {
+        b.vx = (b.vx ?? 0) + fx
+        b.vy = (b.vy ?? 0) + fy
+      }
+    }
+  }
+
+  for (const edge of edges) {
+    const a = positions[edge.from]
+    const b = positions[edge.to]
+    if (!a || !b) {
+      continue
+    }
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const distance = Math.sqrt(dx * dx + dy * dy) || 1
+    const rest = edge.kind === 'parent' ? 130 : 160
+    const stiffness = edge.kind === 'parent' ? 0.04 : 0.02 * edge.weight
+    const delta = distance - rest
+    const fx = (dx / distance) * delta * stiffness
+    const fy = (dy / distance) * delta * stiffness
+    if (!a._manual) {
+      a.vx = (a.vx ?? 0) + fx
+      a.vy = (a.vy ?? 0) + fy
+    }
+    if (!b._manual) {
+      b.vx = (b.vx ?? 0) - fx
+      b.vy = (b.vy ?? 0) - fy
+    }
+  }
+
+  for (const id of ids) {
+    const position = positions[id]
+    if (position._manual) {
+      continue
+    }
+    position.vx = (position.vx ?? 0) + (centerX - position.x) * 0.0008
+    position.vy = (position.vy ?? 0) + (centerY - position.y) * 0.0008
+    position.x += (position.vx ?? 0) * dt
+    position.y += (position.vy ?? 0) * dt
+  }
+}
+
+interface ScenarioClusterProps {
+  scenarios: UIScenario[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+  activePulses: Set<string>
+  pinnedIds: Set<string>
+  /** When provided, surfaces a hint in the empty state. */
+  emptyHint?: string
+}
+
+export function ScenarioCluster({
+  scenarios,
+  selectedId,
+  onSelect,
+  activePulses,
+  pinnedIds,
+  emptyHint,
+}: ScenarioClusterProps) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState({ w: 800, h: 520 })
+  const posRef = useRef<Record<string, ClusterPosition>>({})
+  const edgesRef = useRef<ScenarioEdge[]>([])
+  const [, forceTick] = useState(0)
+  const [view, setView] = useState({ x: 0, y: 0, scale: 1 })
+  const dragRef = useRef<{ id: string; moved: boolean } | null>(null)
+
+  useEffect(() => {
+    const element = wrapRef.current
+    if (!element) {
+      return
+    }
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setSize({ w: entry.contentRect.width, h: entry.contentRect.height })
+      }
+    })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    edgesRef.current = computeEdges(scenarios)
+    const previous = posRef.current
+    const fresh = initialLayout(scenarios, size.w || 800, size.h || 520)
+    for (const id of Object.keys(fresh)) {
+      if (previous[id]) {
+        fresh[id] = { ...fresh[id], ...previous[id] }
+      }
+    }
+    posRef.current = fresh
+    forceTick((value) => value + 1)
+  }, [scenarios, size.h, size.w])
+
+  useEffect(() => {
+    let frame = 0
+    let last = performance.now()
+    const tick = (time: number) => {
+      const dt = Math.min(0.05, (time - last) / 1000)
+      last = time
+      tickForces(posRef.current, edgesRef.current, { width: size.w, height: size.h, dt: dt * 60 })
+      forceTick((value) => value + 1)
+      frame = requestAnimationFrame(tick)
+    }
+    frame = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(frame)
+  }, [size.h, size.w])
+
+  useEffect(() => {
+    const element = wrapRef.current
+    if (!element) {
+      return
+    }
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault()
+      if (event.ctrlKey || event.metaKey || Math.abs(event.deltaY) > 40) {
+        const rect = element.getBoundingClientRect()
+        const px = event.clientX - rect.left
+        const py = event.clientY - rect.top
+        setView((current) => {
+          const nextScale = Math.max(0.3, Math.min(2.5, current.scale * Math.exp(-event.deltaY * 0.006)))
+          const factor = nextScale / current.scale
+          return { x: px - (px - current.x) * factor, y: py - (py - current.y) * factor, scale: nextScale }
+        })
+      } else {
+        setView((current) => ({ ...current, x: current.x - event.deltaX, y: current.y - event.deltaY }))
+      }
+    }
+    let panning: { x: number; y: number } | null = null
+    const onPointerDown = (event: PointerEvent) => {
+      if ((event.target as HTMLElement).closest('[data-cluster-node]')) {
+        return
+      }
+      panning = { x: event.clientX, y: event.clientY }
+      element.style.cursor = 'grabbing'
+    }
+    const onPointerMove = (event: PointerEvent) => {
+      if (!panning) {
+        return
+      }
+      const dx = event.clientX - panning.x
+      const dy = event.clientY - panning.y
+      panning = { x: event.clientX, y: event.clientY }
+      setView((current) => ({ ...current, x: current.x + dx, y: current.y + dy }))
+    }
+    const onPointerUp = () => {
+      panning = null
+      element.style.cursor = 'grab'
+    }
+    element.addEventListener('wheel', onWheel, { passive: false })
+    element.addEventListener('pointerdown', onPointerDown)
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+    return () => {
+      element.removeEventListener('wheel', onWheel)
+      element.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+    }
+  }, [])
+
+  const onNodePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>, id: string) => {
+      event.stopPropagation()
+      const startClient = { x: event.clientX, y: event.clientY }
+      const startPos = { ...posRef.current[id] }
+      const startView = view
+      dragRef.current = { id, moved: false }
+      const move = (pointerEvent: PointerEvent) => {
+        const dx = (pointerEvent.clientX - startClient.x) / startView.scale
+        const dy = (pointerEvent.clientY - startClient.y) / startView.scale
+        const position = posRef.current[id]
+        position.x = startPos.x + dx
+        position.y = startPos.y + dy
+        position.vx = 0
+        position.vy = 0
+        position._manual = true
+        if (Math.abs(dx) + Math.abs(dy) > 3 && dragRef.current) {
+          dragRef.current.moved = true
+        }
+        forceTick((value) => value + 1)
+      }
+      const up = () => {
+        window.removeEventListener('pointermove', move)
+        window.removeEventListener('pointerup', up)
+        if (dragRef.current && !dragRef.current.moved) {
+          onSelect(id)
+        }
+        dragRef.current = null
+      }
+      window.addEventListener('pointermove', move)
+      window.addEventListener('pointerup', up)
+    },
+    [onSelect, view],
+  )
+
+  const highlight = useMemo(() => {
+    if (!selectedId) {
+      return new Set<string>()
+    }
+    const result = new Set<string>([selectedId])
+    // ``edgesRef.current`` is a ref set synchronously by the earlier effect
+    // when ``scenarios`` changes; recomputing on ``scenarios`` keeps the
+    // highlight in sync without depending on the ref itself.
+    for (const edge of edgesRef.current) {
+      if (edge.from === selectedId) {
+        result.add(edge.to)
+      }
+      if (edge.to === selectedId) {
+        result.add(edge.from)
+      }
+    }
+    return result
+    // ``scenarios`` drives ``edgesRef.current`` via the effect above; we need
+    // to recompute when it changes even though the linter doesn't see the
+    // indirect dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedId, scenarios])
+
+  const positions = posRef.current
+
+  if (!scenarios.length) {
+    return (
+      <div
+        ref={wrapRef}
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--fg-4)',
+          fontSize: 12,
+          fontFamily: 'var(--font-mono)',
+          padding: 24,
+          textAlign: 'center',
+        }}
+      >
+        {emptyHint ?? 'No scenarios yet — the daemon will populate this cluster as it ponders.'}
+      </div>
+    )
+  }
+
+  return (
+    <div ref={wrapRef} style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden', cursor: 'grab' }}>
+      <svg width={size.w} height={size.h} style={{ position: 'absolute', inset: 0, pointerEvents: 'none', opacity: 0.35 }}>
+        <defs>
+          <pattern id="cluster-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="var(--line-hair)" strokeWidth="0.5" />
+          </pattern>
+        </defs>
+        <rect width={size.w} height={size.h} fill="url(#cluster-grid)" />
+      </svg>
+
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          transform: `translate3d(${view.x}px, ${view.y}px, 0) scale(${view.scale})`,
+          transformOrigin: '0 0',
+        }}
+      >
+        <svg width={size.w} height={size.h} style={{ position: 'absolute', inset: 0, overflow: 'visible' }}>
+          {edgesRef.current.map((edge) => {
+            const from = positions[edge.from]
+            const to = positions[edge.to]
+            if (!from || !to) {
+              return null
+            }
+            const highlighted = selectedId && (edge.from === selectedId || edge.to === selectedId)
+            const dashed = edge.kind === 'shared-path'
+            const strokeWidth = edge.kind === 'parent' ? 1.3 : Math.max(0.6, 1 + edge.weight * 1.6)
+            const opacity = highlighted ? 0.95 : 0.3 + edge.weight * 0.4
+            const color = highlighted ? 'var(--accent)' : edge.kind === 'parent' ? 'var(--line-2)' : 'var(--accent-soft)'
+            return (
+              <line
+                key={`${edge.from}-${edge.to}-${edge.kind}`}
+                x1={from.x}
+                y1={from.y}
+                x2={to.x}
+                y2={to.y}
+                stroke={color}
+                strokeWidth={strokeWidth}
+                strokeDasharray={dashed ? '3 4' : undefined}
+                opacity={opacity}
+              />
+            )
+          })}
+        </svg>
+
+        {scenarios.map((scenario) => {
+          const position = positions[scenario.id]
+          if (!position) {
+            return null
+          }
+          const color = KIND_COLOR[scenario.kind]
+          const radius = 8 + scenario.score * 14
+          const selected = selectedId === scenario.id
+          const pulse = activePulses.has(scenario.id)
+          const chosen = scenario.decisionState === 'chosen'
+          const rejected = scenario.decisionState === 'rejected'
+          const pinned = pinnedIds.has(scenario.id)
+          const dim = Boolean(selectedId && !highlight.has(scenario.id))
+
+          return (
+            <div
+              key={scenario.id}
+              data-cluster-node
+              data-scenario-id={scenario.id}
+              onPointerDown={(event) => onNodePointerDown(event, scenario.id)}
+              style={{
+                position: 'absolute',
+                left: position.x - radius,
+                top: position.y - radius,
+                width: radius * 2,
+                height: radius * 2,
+                borderRadius: '50%',
+                cursor: 'pointer',
+                background: rejected ? 'transparent' : `color-mix(in oklch, ${color} 18%, transparent)`,
+                border: `1.5px solid ${color}`,
+                opacity: rejected ? 0.35 : dim ? 0.35 : 1,
+                boxShadow: selected
+                  ? `0 0 0 3px var(--bg-0), 0 0 0 5px ${color}, 0 0 26px ${color}80`
+                  : chosen
+                    ? `0 0 18px ${color}80`
+                    : 'none',
+                transition: 'box-shadow .2s, opacity .2s',
+                animation: pulse ? 'dc-pulse 1.2s infinite' : 'none',
+              }}
+            >
+              {chosen ? <div style={{ position: 'absolute', inset: '30%', borderRadius: '50%', background: color }} /> : null}
+              {pinned ? (
+                <div
+                  aria-label="pinned"
+                  style={{
+                    position: 'absolute',
+                    top: -8,
+                    right: -8,
+                    width: 12,
+                    height: 12,
+                    borderRadius: '50%',
+                    background: 'var(--amber)',
+                    border: '2px solid var(--bg-0)',
+                  }}
+                />
+              ) : null}
+              <div
+                className="mono"
+                style={{
+                  position: 'absolute',
+                  top: '110%',
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  whiteSpace: 'nowrap',
+                  fontSize: 9.5,
+                  color: selected ? 'var(--fg-1)' : 'var(--fg-3)',
+                  marginTop: 4,
+                  pointerEvents: 'none',
+                  maxWidth: 180,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {scenario.title.length > 24 ? `${scenario.title.slice(0, 22)}…` : scenario.title}
+              </div>
+              <div
+                className="mono"
+                style={{
+                  position: 'absolute',
+                  bottom: '110%',
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  whiteSpace: 'nowrap',
+                  fontSize: 9.5,
+                  color,
+                  marginBottom: 3,
+                  pointerEvents: 'none',
+                  fontWeight: 500,
+                }}
+              >
+                {scenario.score.toFixed(3)}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 12,
+          right: 12,
+          display: 'flex',
+          gap: 2,
+          background: 'var(--bg-1)',
+          border: '1px solid var(--line-1)',
+          borderRadius: 'var(--r-2)',
+          padding: 2,
+          zIndex: 3,
+        }}
+      >
+        <button onClick={() => setView((current) => ({ ...current, scale: Math.min(2.5, current.scale * 1.2) }))} style={clusterBtn} aria-label="zoom in">
+          +
+        </button>
+        <button onClick={() => setView((current) => ({ ...current, scale: Math.max(0.3, current.scale * 0.83) }))} style={clusterBtn} aria-label="zoom out">
+          −
+        </button>
+        <button onClick={() => setView({ x: 0, y: 0, scale: 1 })} style={{ ...clusterBtn, paddingLeft: 8, paddingRight: 8 }} aria-label="reset view">
+          ⟲
+        </button>
+        <span className="mono" style={{ alignSelf: 'center', padding: '0 8px', fontSize: 10.5, color: 'var(--fg-3)' }}>
+          {Math.round(view.scale * 100)}%
+        </span>
+      </div>
+    </div>
+  )
+}
+
+const clusterBtn: React.CSSProperties = {
+  background: 'var(--bg-2)',
+  border: 'none',
+  color: 'var(--fg-1)',
+  padding: '5px 10px',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 13,
+  cursor: 'pointer',
+  borderRadius: 'var(--r-1)',
+  minWidth: 28,
+}

--- a/ui/cockpit/src/components/SystemVitals.test.tsx
+++ b/ui/cockpit/src/components/SystemVitals.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { SystemVitals } from './SystemVitals'
+import type { CycleState, ModelState } from '../api/usePipelineEvents'
+
+function makeModel(overrides: Partial<ModelState> = {}): ModelState {
+  return {
+    pending: overrides.pending ?? new Map(),
+    lastLatencyMs: overrides.lastLatencyMs ?? null,
+    lastModel: overrides.lastModel ?? null,
+    recentLatencies: overrides.recentLatencies ?? [],
+    totalRequests: overrides.totalRequests ?? 0,
+    totalErrors: overrides.totalErrors ?? 0,
+  }
+}
+
+function makeCycle(overrides: Partial<CycleState> = {}): CycleState {
+  return {
+    current: overrides.current ?? null,
+    lastFinished: overrides.lastFinished ?? null,
+    totalCycles: overrides.totalCycles ?? 0,
+    artefactsWritten: overrides.artefactsWritten ?? 0,
+  }
+}
+
+describe('SystemVitals', () => {
+  it('shows "running" while a cycle is in flight', () => {
+    render(
+      <SystemVitals
+        live
+        mode="daemon"
+        cycle={makeCycle({ current: { cycleId: 'c1', startedAt: Date.now() / 1000 } })}
+        model={makeModel()}
+        scenarioCount={3}
+        pendingLlm={0}
+      />,
+    )
+    expect(screen.getByText(/running/)).toBeInTheDocument()
+  })
+
+  it('shows model busy with a spinner when requests are pending', () => {
+    render(
+      <SystemVitals
+        live
+        mode="daemon"
+        cycle={makeCycle()}
+        model={makeModel({ lastModel: 'qwen2.5-coder' })}
+        scenarioCount={3}
+        pendingLlm={2}
+      />,
+    )
+    expect(screen.getByText(/busy · 2/)).toBeInTheDocument()
+  })
+
+  it('renders an offline badge when SSE is disconnected', () => {
+    render(
+      <SystemVitals
+        live={false}
+        mode="daemon"
+        cycle={makeCycle()}
+        model={makeModel()}
+        scenarioCount={0}
+        pendingLlm={0}
+      />,
+    )
+    expect(screen.getByText('offline')).toBeInTheDocument()
+  })
+
+  it('reports error count when LLM failures accumulate', () => {
+    render(
+      <SystemVitals
+        live
+        mode="daemon"
+        cycle={makeCycle()}
+        model={makeModel({ totalErrors: 3 })}
+        scenarioCount={0}
+        pendingLlm={0}
+      />,
+    )
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText(/llm errors/)).toBeInTheDocument()
+  })
+})

--- a/ui/cockpit/src/components/SystemVitals.tsx
+++ b/ui/cockpit/src/components/SystemVitals.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react'
+
+import type { CycleState, ModelState } from '../api/usePipelineEvents'
+
+export interface SystemVitalsProps {
+  live: boolean
+  mode: string
+  cycle: CycleState
+  model: ModelState
+  scenarioCount: number
+  pendingLlm: number
+}
+
+function formatDuration(ms: number | null | undefined): string {
+  if (!ms || ms < 0) {
+    return '—'
+  }
+  if (ms < 1000) {
+    return `${ms.toFixed(0)}ms`
+  }
+  if (ms < 60_000) {
+    return `${(ms / 1000).toFixed(2)}s`
+  }
+  const minutes = Math.floor(ms / 60_000)
+  const seconds = Math.floor((ms % 60_000) / 1000)
+  return `${minutes}m${seconds.toString().padStart(2, '0')}`
+}
+
+function ema(values: number[]): number {
+  if (!values.length) {
+    return 0
+  }
+  const alpha = 2 / (values.length + 1)
+  return values.reduce((acc, value, index) => (index === 0 ? value : alpha * value + (1 - alpha) * acc), 0)
+}
+
+/**
+ * Compact live-vitals panel surfacing daemon / model / cycle state.
+ *
+ * Rendered in the left rail above the skills panel so the user can see in one
+ * glance whether the cockpit SSE is tailing, whether a daemon cycle is in
+ * flight, whether the model is currently busy, and the recent LLM latency.
+ * All values are derived from the unified event bus — nothing is polled.
+ */
+export function SystemVitals({ live, mode, cycle, model, scenarioCount, pendingLlm }: SystemVitalsProps) {
+  const [now, setNow] = useState(() => Date.now() / 1000)
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now() / 1000), 500)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  const avgLatency = ema(model.recentLatencies)
+  const running = cycle.current !== null
+  const elapsedCycleMs = running ? Math.max(0, (now - cycle.current!.startedAt) * 1000) : null
+
+  return (
+    <div
+      style={{
+        padding: '14px 16px 12px',
+        borderBottom: '1px solid var(--line-hair)',
+        background: 'var(--bg-0)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+      }}
+      aria-label="System vitals"
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: 'var(--fg-4)' }}>
+          SYSTEM VITALS
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span
+            aria-hidden
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: live ? 'var(--ok)' : 'var(--err)',
+              boxShadow: live ? '0 0 8px var(--ok)' : 'none',
+              animation: live ? 'dc-pulse 1.4s infinite' : 'none',
+            }}
+          />
+          <span className="mono" style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            {live ? 'live' : 'offline'}
+          </span>
+        </div>
+      </div>
+
+      <VitalRow label="mode" value={mode} />
+      <VitalRow
+        label="cycle"
+        emphasize={running}
+        value={
+          running ? (
+            <span style={{ color: 'var(--accent)' }}>
+              running · {formatDuration(elapsedCycleMs)}
+            </span>
+          ) : cycle.lastFinished ? (
+            <span>
+              idle · last {formatDuration(cycle.lastFinished.durationMs)}
+            </span>
+          ) : (
+            'waiting'
+          )
+        }
+      />
+      <VitalRow
+        label="model"
+        emphasize={pendingLlm > 0}
+        value={
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            {pendingLlm > 0 ? (
+              <span
+                aria-hidden
+                style={{
+                  width: 9,
+                  height: 9,
+                  borderRadius: '50%',
+                  border: '1.5px solid var(--amber)',
+                  borderTopColor: 'transparent',
+                  animation: 'dc-spin 0.8s linear infinite',
+                  display: 'inline-block',
+                }}
+              />
+            ) : null}
+            <span style={{ color: pendingLlm > 0 ? 'var(--amber)' : 'var(--fg-2)' }}>
+              {pendingLlm > 0 ? `busy · ${pendingLlm}` : model.lastModel ? 'idle' : 'standby'}
+            </span>
+          </span>
+        }
+      />
+      <VitalRow label="last latency" value={formatDuration(model.lastLatencyMs)} />
+      <VitalRow label="ema latency" value={formatDuration(avgLatency || null)} />
+      <VitalRow label="model id" value={model.lastModel ?? '—'} mono title={model.lastModel ?? undefined} />
+      <VitalRow label="cycles" value={`${cycle.totalCycles}`} />
+      <VitalRow label="artefacts" value={`${cycle.artefactsWritten}`} />
+      <VitalRow label="scenarios" value={`${scenarioCount}`} />
+      {model.totalErrors > 0 ? (
+        <VitalRow
+          label="llm errors"
+          value={<span style={{ color: 'var(--err)' }}>{model.totalErrors}</span>}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+interface VitalRowProps {
+  label: string
+  value: React.ReactNode
+  emphasize?: boolean
+  mono?: boolean
+  title?: string
+}
+
+function VitalRow({ label, value, emphasize, mono, title }: VitalRowProps) {
+  return (
+    <div
+      title={title}
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        gap: 8,
+        fontFamily: 'var(--font-mono)',
+        fontSize: 10.5,
+        color: emphasize ? 'var(--fg-1)' : 'var(--fg-2)',
+        letterSpacing: 0.2,
+      }}
+    >
+      <span style={{ color: 'var(--fg-4)' }}>{label}</span>
+      <span
+        style={{
+          maxWidth: 160,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          textAlign: 'right',
+          fontVariantNumeric: mono ? 'tabular-nums' : undefined,
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/ui/cockpit/src/components/chrome.tsx
+++ b/ui/cockpit/src/components/chrome.tsx
@@ -1,0 +1,1089 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type {
+  BackendPreset,
+  BackendSettings,
+  CockpitSettings,
+  ComputeDevice,
+  ComputeSettings,
+  ImpactSummary,
+  LimitSettings,
+  MCPSettings,
+  UIMode,
+  UIPackageState,
+  UIPinnedFact,
+  UISkill,
+} from '../types'
+
+export interface CommandItem {
+  id: string
+  kind: string
+  kindColor?: string
+  label: string
+  keywords?: string
+  hint?: string
+  run: () => void
+}
+
+interface TopBarProps {
+  running: boolean
+  onToggleRun: () => void
+  packageState: UIPackageState | null
+  onOpenSettings: () => void
+  onOpenPalette: () => void
+  mode: UIMode
+}
+
+const MODE_LABEL: Record<UIMode, string> = {
+  daemon: 'DAEMON',
+  proxy: 'PROXY',
+  mcp: 'MCP',
+}
+
+export function TopBar({ running, onToggleRun, packageState, onOpenSettings, onOpenPalette, mode }: TopBarProps) {
+  return (
+    <div
+      style={{
+        gridArea: 'top',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+        padding: '0 20px',
+        borderBottom: '1px solid var(--line-1)',
+        background: 'var(--bg-1)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <svg width="22" height="22" viewBox="0 0 22 22">
+          <circle cx="11" cy="11" r="9" fill="none" stroke="var(--accent)" strokeWidth="1.4" />
+          <circle cx="11" cy="11" r="4" fill="var(--accent)" />
+          <circle cx="18" cy="6" r="1.6" fill="var(--amber)" />
+          <path d="M11 11 L18 6" stroke="var(--amber)" strokeWidth="0.9" />
+        </svg>
+        <span className="editorial" style={{ fontSize: 19, letterSpacing: -0.3 }}>
+          Vaner
+        </span>
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--fg-4)', letterSpacing: 1, marginLeft: 2 }}>
+          COCKPIT · {MODE_LABEL[mode]}
+        </span>
+      </div>
+
+      <div style={{ flex: 1 }} />
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: '50%',
+              background: running ? 'var(--ok)' : 'var(--fg-4)',
+              boxShadow: running ? '0 0 10px var(--ok)' : 'none',
+              animation: running ? 'dc-pulse 1.4s infinite' : 'none',
+            }}
+          />
+          <span className="mono" style={{ fontSize: 10.5, letterSpacing: 0.8, color: 'var(--fg-2)' }}>
+            {running ? 'LIVE' : 'RETRYING'}
+          </span>
+        </div>
+        <button onClick={onToggleRun} style={headerBtn}>
+          ↻ refresh
+        </button>
+        {packageState ? (
+          <>
+            <div style={{ width: 1, height: 20, background: 'var(--line-1)' }} />
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span className="mono" style={{ fontSize: 10, color: 'var(--fg-4)', letterSpacing: 0.6 }}>
+                PKG
+              </span>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--amber)', fontWeight: 500 }}>
+                {packageState.id}
+              </span>
+              <span className="mono" style={{ fontSize: 10.5, color: 'var(--fg-3)' }}>
+                {packageState.tokens.toLocaleString()} / {packageState.budget.toLocaleString()} tok
+              </span>
+            </div>
+          </>
+        ) : null}
+        <button onClick={onOpenPalette} style={headerBtn} title="Command palette (Ctrl/Cmd+K)">
+          ⌘K
+        </button>
+        <button onClick={onOpenSettings} style={headerBtn} title="Settings">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3">
+            <circle cx="6" cy="6" r="1.5" />
+            <path d="M6 1v1.5M6 9.5V11M11 6H9.5M2.5 6H1M9.5 2.5 8.5 3.5M3.5 8.5 2.5 9.5M9.5 9.5 8.5 8.5M3.5 3.5 2.5 2.5" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const headerBtn: React.CSSProperties = {
+  background: 'var(--bg-2)',
+  border: '1px solid var(--line-1)',
+  color: 'var(--fg-2)',
+  padding: '6px 10px',
+  borderRadius: 'var(--r-1)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10.5,
+  cursor: 'pointer',
+  letterSpacing: 0.4,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 5,
+}
+
+interface LeftRailProps {
+  mode: UIMode
+  skills: UISkill[]
+  pinned: UIPinnedFact[]
+  packageState: UIPackageState | null
+  onUnpin: (id: string) => void
+  onSkillNudge: (name: string, delta: number) => void
+  scenarioCount: number
+  impact?: ImpactSummary
+  header?: React.ReactNode
+}
+
+export function LeftRail({
+  mode,
+  skills,
+  pinned,
+  packageState,
+  onUnpin,
+  onSkillNudge,
+  scenarioCount,
+  impact,
+  header,
+}: LeftRailProps) {
+  return (
+    <div
+      style={{
+        gridArea: 'rail',
+        borderRight: '1px solid var(--line-1)',
+        background: 'var(--bg-1)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden auto',
+      }}
+    >
+      {header}
+      <div style={{ padding: '16px 16px 10px' }}>
+        <div className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: 'var(--fg-4)', marginBottom: 10 }}>
+          {mode === 'proxy' ? 'PROXY' : 'FRONTIER'}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+          <span style={{ fontFamily: 'var(--font-display)', fontSize: 28, color: 'var(--fg-1)', fontVariantNumeric: 'tabular-nums' }}>
+            {mode === 'proxy' ? (impact?.count ?? 0) : scenarioCount}
+          </span>
+          {packageState ? (
+            <span className="mono" style={{ fontSize: 10.5, color: 'var(--amber)' }}>
+              {packageState.chosen} chosen
+            </span>
+          ) : null}
+        </div>
+        <div className="mono" style={{ fontSize: 10.5, color: 'var(--fg-3)', marginTop: 2 }}>
+          {mode === 'proxy' ? 'recent proxy decisions' : 'open scenarios'}
+        </div>
+      </div>
+
+      <div style={{ padding: '4px 16px 14px', borderBottom: '1px solid var(--line-hair)' }}>
+        <div className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: 'var(--fg-4)', marginBottom: 10 }}>
+          {mode === 'proxy' ? 'IMPACT' : 'SKILLS'}
+        </div>
+        {mode !== 'proxy' ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+            {skills.map((skill) => (
+              <div key={skill.name} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontFamily: 'var(--font-display)', fontSize: 12, color: 'var(--fg-1)' }}>{skill.name}</div>
+                  <div style={{ fontSize: 10.5, color: 'var(--fg-4)', marginTop: 2 }}>{skill.desc}</div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 6 }}>
+                    <div style={{ flex: 1, height: 3, background: 'var(--bg-inset)', borderRadius: 2 }}>
+                      <div
+                        style={{
+                          width: `${skill.weight * 100}%`,
+                          height: '100%',
+                          background: 'var(--accent)',
+                          borderRadius: 2,
+                          transition: 'width .4s ease',
+                        }}
+                      />
+                    </div>
+                    <span
+                      className="mono"
+                      style={{ fontSize: 10, color: 'var(--fg-3)', fontVariantNumeric: 'tabular-nums', minWidth: 30, textAlign: 'right' }}
+                    >
+                      {(skill.weight * 100).toFixed(0)}%
+                    </span>
+                  </div>
+                </div>
+                <button
+                  onClick={() => onSkillNudge(skill.name, -0.04)}
+                  style={skillNudgeBtn}
+                  title={`Nudge ${skill.name} down`}
+                  aria-label={`Nudge ${skill.name} down`}
+                >
+                  −
+                </button>
+                <button
+                  onClick={() => onSkillNudge(skill.name, 0.04)}
+                  style={skillNudgeBtn}
+                  title={`Nudge ${skill.name} up`}
+                  aria-label={`Nudge ${skill.name} up`}
+                >
+                  +
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 10.5 }}>
+            <Row k="count" v={impact?.count ?? 0} />
+            <Row k="latency gain" v={`${Number(impact?.mean_latency_gain_ms ?? 0).toFixed(2)} ms`} />
+            <Row k="char delta" v={Number(impact?.mean_char_delta ?? 0).toFixed(2)} />
+            <Row k="idle used" v={`${Number(impact?.idle_seconds_used ?? 0).toFixed(2)} s`} />
+          </div>
+        )}
+      </div>
+
+      <div style={{ padding: '14px 16px 10px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+          <span className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: 'var(--fg-4)' }}>
+            PINNED CONTEXT
+          </span>
+          <span className="mono" style={{ fontSize: 10, color: 'var(--amber)' }}>
+            {pinned.length}
+          </span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {pinned.map((fact) => (
+            <div
+              key={fact.id}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 8,
+                padding: '8px 10px',
+                background: 'var(--bg-2)',
+                border: '1px solid var(--line-hair)',
+                borderRadius: 'var(--r-1)',
+                fontSize: 11.5,
+                color: 'var(--fg-2)',
+                lineHeight: 1.45,
+              }}
+            >
+              <span style={{ color: 'var(--amber)', flexShrink: 0, marginTop: 2 }}>◆</span>
+              <span style={{ flex: 1 }}>{fact.text}</span>
+              <button
+                onClick={() => onUnpin(fact.id)}
+                style={{ background: 'transparent', border: 'none', color: 'var(--fg-4)', cursor: 'pointer', padding: 0, fontSize: 13, lineHeight: 1 }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+          {!pinned.length ? (
+            <div style={{ fontSize: 11.5, color: 'var(--fg-4)', padding: '6px 0', fontStyle: 'italic' }}>
+              No pinned facts. Pin scenarios or add notes to always include.
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div style={{ flex: 1 }} />
+
+      {packageState ? (
+        <div style={{ padding: '14px 16px', borderTop: '1px solid var(--line-hair)', background: 'var(--bg-0)' }}>
+          <div className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: 'var(--fg-4)', marginBottom: 8 }}>
+            CURRENT PACKAGE
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--fg-2)' }}>
+            <Row k="id" v={packageState.id} />
+            <Row k="tokens" v={`${packageState.tokens.toLocaleString()} / ${packageState.budget.toLocaleString()}`} />
+            <Row k="chosen" v={packageState.chosen} />
+            <Row k="partial" v={packageState.partial} />
+            <Row k="rejected" v={packageState.rejected} />
+            <Row k="compression" v={`${(packageState.compression * 100).toFixed(0)}%`} />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+const skillNudgeBtn: React.CSSProperties = {
+  background: 'var(--bg-2)',
+  border: '1px solid var(--line-hair)',
+  color: 'var(--fg-3)',
+  padding: '2px 6px',
+  borderRadius: 'var(--r-1)',
+  cursor: 'pointer',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+  lineHeight: 1,
+}
+
+function Row({ k, v }: { k: string; v: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+      <span style={{ color: 'var(--fg-4)' }}>{k}</span>
+      <span>{v}</span>
+    </div>
+  )
+}
+
+interface StreamPanelProps {
+  title: string
+  subtitle: string
+  events: Array<{ id: string; t: string; tag: string; color: string; msg: string; scn: string | null }>
+  onSelect: (id: string) => void
+  live: boolean
+}
+
+export function StreamPanel({ title, subtitle, events, onSelect, live }: StreamPanelProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0
+    }
+  }, [events.length])
+
+  return (
+    <div
+      style={{
+        gridArea: 'stream',
+        borderLeft: '1px solid var(--line-1)',
+        background: 'var(--bg-1)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: '14px 16px 10px',
+          borderBottom: '1px solid var(--line-hair)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div>
+          <div className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: 'var(--fg-4)' }}>
+            {title}
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--fg-1)', marginTop: 2, fontFamily: 'var(--font-display)' }}>
+            {subtitle}
+          </div>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+          <span style={{ width: 6, height: 6, borderRadius: '50%', background: live ? 'var(--ok)' : 'var(--fg-4)', boxShadow: live ? '0 0 8px var(--ok)' : 'none' }} />
+          <span className="mono" style={{ fontSize: 10, color: 'var(--fg-3)' }}>
+            {live ? 'tailing' : 'waiting'}
+          </span>
+        </div>
+      </div>
+      <div ref={scrollRef} className="scroll" style={{ flex: 1, overflow: 'auto', fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.5 }}>
+        {events.map((event, index) => (
+          <div
+            key={event.id}
+            style={{
+              padding: '6px 16px',
+              borderBottom: '1px solid var(--line-hair)',
+              display: 'flex',
+              gap: 8,
+              cursor: event.scn ? 'pointer' : 'default',
+              opacity: index > 3 ? 0.9 - index * 0.02 : 1,
+              transition: 'opacity .2s',
+              background: index === 0 ? 'color-mix(in oklch, var(--accent) 7%, transparent)' : 'transparent',
+            }}
+            onClick={() => event.scn && onSelect(event.scn)}
+          >
+            <span style={{ color: 'var(--fg-4)', minWidth: 52 }}>{event.t}</span>
+            <span style={{ color: event.color, minWidth: 62 }}>{event.tag}</span>
+            <span style={{ color: 'var(--fg-2)', flex: 1 }}>{event.msg}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface CommandPaletteProps {
+  open: boolean
+  onClose: () => void
+  commands: CommandItem[]
+}
+
+export function CommandPalette({ open, onClose, commands }: CommandPaletteProps) {
+  const [query, setQuery] = useState('')
+  const [index, setIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    setQuery('')
+    setIndex(0)
+    window.setTimeout(() => inputRef.current?.focus(), 20)
+  }, [open])
+
+  const filtered = useMemo(() => {
+    const normalized = query.toLowerCase().trim()
+    return commands.filter(
+      (command) =>
+        !normalized ||
+        command.label.toLowerCase().includes(normalized) ||
+        (command.keywords ?? '').toLowerCase().includes(normalized),
+    )
+  }, [commands, query])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      } else if (event.key === 'ArrowDown') {
+        setIndex((current) => Math.min(filtered.length - 1, current + 1))
+        event.preventDefault()
+      } else if (event.key === 'ArrowUp') {
+        setIndex((current) => Math.max(0, current - 1))
+        event.preventDefault()
+      } else if (event.key === 'Enter') {
+        const command = filtered[index]
+        if (command) {
+          command.run()
+          onClose()
+        }
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [filtered, index, onClose, open])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,.55)',
+        zIndex: 100,
+        display: 'flex',
+        justifyContent: 'center',
+        paddingTop: '12vh',
+        backdropFilter: 'blur(4px)',
+      }}
+    >
+      <div
+        onClick={(event) => event.stopPropagation()}
+        style={{
+          width: 560,
+          maxHeight: 420,
+          background: 'var(--bg-1)',
+          border: '1px solid var(--line-1)',
+          borderRadius: 'var(--r-3)',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          boxShadow: '0 24px 80px rgba(0,0,0,.6)',
+        }}
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value)
+            setIndex(0)
+          }}
+          placeholder="type a command or scenario…"
+          style={{
+            padding: '16px 20px',
+            background: 'transparent',
+            border: 'none',
+            outline: 'none',
+            color: 'var(--fg-1)',
+            fontFamily: 'var(--font-display)',
+            fontSize: 15,
+            borderBottom: '1px solid var(--line-hair)',
+          }}
+        />
+        <div className="scroll" style={{ overflow: 'auto', flex: 1 }}>
+          {filtered.map((command, itemIndex) => (
+            <div
+              key={command.id}
+              onMouseEnter={() => setIndex(itemIndex)}
+              onClick={() => {
+                command.run()
+                onClose()
+              }}
+              style={{
+                padding: '10px 20px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                background: itemIndex === index ? 'color-mix(in oklch, var(--accent) 14%, var(--bg-1))' : 'transparent',
+                cursor: 'pointer',
+                borderLeft: itemIndex === index ? '2px solid var(--accent)' : '2px solid transparent',
+              }}
+            >
+              <span
+                className="mono"
+                style={{ fontSize: 9.5, letterSpacing: 0.6, color: command.kindColor ?? 'var(--fg-4)', minWidth: 56, textTransform: 'uppercase' }}
+              >
+                {command.kind}
+              </span>
+              <span style={{ fontSize: 13, color: 'var(--fg-1)', flex: 1 }}>{command.label}</span>
+              {command.hint ? (
+                <span className="mono" style={{ fontSize: 10, color: 'var(--fg-4)' }}>
+                  {command.hint}
+                </span>
+              ) : null}
+            </div>
+          ))}
+          {!filtered.length ? <div style={{ padding: 20, color: 'var(--fg-4)', fontSize: 12 }}>no matches.</div> : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface SettingsDrawerProps {
+  open: boolean
+  onClose: () => void
+  mode: UIMode
+  backend: BackendSettings | null
+  compute: ComputeSettings | null
+  mcp: MCPSettings | null
+  limits: LimitSettings | null
+  cockpit: CockpitSettings
+  presets: BackendPreset[]
+  devices: ComputeDevice[]
+  devicesWarning: string | null
+  gatewayEnabled: boolean
+  onSaveBackend: (patch: Partial<BackendSettings>) => Promise<void>
+  onSaveCompute: (patch: Partial<ComputeSettings>) => Promise<void>
+  onSaveMcp: (patch: Partial<MCPSettings>) => Promise<void>
+  onSaveContext: (maxContextTokens: number) => Promise<void>
+  onPatchCockpit: (patch: Partial<CockpitSettings>) => void
+  onToggleGateway?: (enabled: boolean) => Promise<void>
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--line-hair)' }}>
+      <div className="mono" style={{ fontSize: 9.5, letterSpacing: 1.2, color: 'var(--fg-4)', marginBottom: 12 }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0', gap: 16 }}>
+      <span style={{ fontSize: 12.5, color: 'var(--fg-2)' }}>{label}</span>
+      {children}
+    </div>
+  )
+}
+
+const inputStyle: React.CSSProperties = {
+  background: 'var(--bg-inset)',
+  border: '1px solid var(--line-1)',
+  borderRadius: 'var(--r-1)',
+  color: 'var(--fg-1)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+  padding: '5px 8px',
+  minWidth: 160,
+}
+
+function TextInput({
+  value,
+  onCommit,
+  placeholder,
+  width,
+}: {
+  value: string
+  onCommit: (value: string) => void
+  placeholder?: string
+  width?: number
+}) {
+  const [local, setLocal] = useState(value)
+  useEffect(() => setLocal(value), [value])
+  return (
+    <input
+      value={local}
+      onChange={(event) => setLocal(event.target.value)}
+      onBlur={() => local !== value && onCommit(local)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          ;(event.target as HTMLInputElement).blur()
+        }
+      }}
+      placeholder={placeholder}
+      style={{ ...inputStyle, width: width ?? 180 }}
+    />
+  )
+}
+
+function NumberInput({
+  value,
+  onCommit,
+  min,
+  max,
+  step,
+  width,
+}: {
+  value: number | null
+  onCommit: (value: number | null) => void
+  min?: number
+  max?: number
+  step?: number
+  width?: number
+}) {
+  const [local, setLocal] = useState<string>(value == null ? '' : String(value))
+  useEffect(() => setLocal(value == null ? '' : String(value)), [value])
+  return (
+    <input
+      type="number"
+      value={local}
+      min={min}
+      max={max}
+      step={step}
+      onChange={(event) => setLocal(event.target.value)}
+      onBlur={() => {
+        const parsed = local === '' ? null : Number(local)
+        if (parsed !== value && (parsed == null || Number.isFinite(parsed))) {
+          onCommit(parsed)
+        }
+      }}
+      style={{ ...inputStyle, width: width ?? 120 }}
+    />
+  )
+}
+
+function SelectInput<T extends string>({
+  value,
+  options,
+  onChange,
+  width,
+}: {
+  value: T
+  options: Array<{ value: T; label: string }>
+  onChange: (value: T) => void
+  width?: number
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(event) => onChange(event.target.value as T)}
+      style={{ ...inputStyle, width: width ?? 180 }}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function Seg({
+  value,
+  options,
+  onChange,
+}: {
+  value: string
+  options: string[]
+  onChange: (value: string) => void
+}) {
+  return (
+    <div style={{ display: 'flex', background: 'var(--bg-inset)', borderRadius: 'var(--r-1)', padding: 2 }}>
+      {options.map((option) => (
+        <button
+          key={option}
+          onClick={() => onChange(option)}
+          style={{
+            padding: '4px 10px',
+            background: value === option ? 'var(--accent)' : 'transparent',
+            color: value === option ? '#fff' : 'var(--fg-2)',
+            border: 'none',
+            borderRadius: 'calc(var(--r-1) - 2px)',
+            cursor: 'pointer',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10.5,
+            letterSpacing: 0.3,
+          }}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function SettingsDrawer(props: SettingsDrawerProps) {
+  const {
+    open,
+    onClose,
+    mode,
+    backend,
+    compute,
+    mcp,
+    limits,
+    cockpit,
+    presets,
+    devices,
+    devicesWarning,
+    gatewayEnabled,
+    onSaveBackend,
+    onSaveCompute,
+    onSaveMcp,
+    onSaveContext,
+    onPatchCockpit,
+    onToggleGateway,
+  } = props
+
+  if (!open) {
+    return null
+  }
+
+  const presetMatch = presets.find(
+    (preset) => backend && preset.base_url === backend.base_url && (preset.default_model === backend.model || preset.default_model === ''),
+  )
+  const activePresetName = presetMatch?.name ?? backend?.name ?? 'custom'
+
+  return (
+    <div
+      onClick={onClose}
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,.5)', zIndex: 90, display: 'flex', justifyContent: 'flex-end' }}
+    >
+      <div
+        onClick={(event) => event.stopPropagation()}
+        style={{ width: 420, height: '100%', background: 'var(--bg-1)', borderLeft: '1px solid var(--line-1)', display: 'flex', flexDirection: 'column' }}
+      >
+        <div
+          style={{
+            padding: '16px 20px',
+            borderBottom: '1px solid var(--line-hair)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div>
+            <div className="editorial" style={{ fontSize: 20, color: 'var(--fg-1)' }}>
+              Settings
+            </div>
+            <div className="mono" style={{ fontSize: 10, color: 'var(--fg-4)', marginTop: 2 }}>
+              {mode} · saves to .vaner/config.toml
+            </div>
+          </div>
+          <button onClick={onClose} style={{ background: 'transparent', border: 'none', color: 'var(--fg-3)', fontSize: 20, cursor: 'pointer' }}>
+            ×
+          </button>
+        </div>
+        <div className="scroll" style={{ flex: 1, overflow: 'auto' }}>
+          <Section title="BACKEND">
+            <Field label="Preset">
+              <SelectInput
+                value={activePresetName}
+                options={[
+                  { value: 'custom', label: 'custom' },
+                  ...presets.map((preset) => ({ value: preset.name, label: preset.name })),
+                ]}
+                onChange={(name) => {
+                  if (name === 'custom') return
+                  const preset = presets.find((item) => item.name === name)
+                  if (!preset) return
+                  void onSaveBackend({
+                    name: preset.name,
+                    base_url: preset.base_url,
+                    model: preset.default_model,
+                    api_key_env: preset.api_key_env,
+                  })
+                }}
+              />
+            </Field>
+            <Field label="Base URL">
+              <TextInput
+                value={backend?.base_url ?? ''}
+                onCommit={(value) => void onSaveBackend({ base_url: value, name: 'custom' })}
+                placeholder="http://127.0.0.1:11434/v1"
+              />
+            </Field>
+            <Field label="Model">
+              <TextInput
+                value={backend?.model ?? ''}
+                onCommit={(value) => void onSaveBackend({ model: value })}
+                placeholder="qwen2.5-coder:7b"
+              />
+            </Field>
+            <Field label="API key env var">
+              <TextInput
+                value={backend?.api_key_env ?? ''}
+                onCommit={(value) => void onSaveBackend({ api_key_env: value })}
+                placeholder="OPENAI_API_KEY"
+              />
+            </Field>
+            <Field label="Prefer local backend">
+              <Seg
+                value={backend?.prefer_local ? 'on' : 'off'}
+                options={['off', 'on']}
+                onChange={(value) => void onSaveBackend({ prefer_local: value === 'on' })}
+              />
+            </Field>
+            <Field label="Fallback enabled">
+              <Seg
+                value={backend?.fallback_enabled ? 'on' : 'off'}
+                options={['off', 'on']}
+                onChange={(value) => void onSaveBackend({ fallback_enabled: value === 'on' })}
+              />
+            </Field>
+            {backend?.fallback_enabled ? (
+              <>
+                <Field label="Fallback base URL">
+                  <TextInput
+                    value={backend?.fallback_base_url ?? ''}
+                    onCommit={(value) => void onSaveBackend({ fallback_base_url: value })}
+                    placeholder="https://api.openai.com/v1"
+                  />
+                </Field>
+                <Field label="Fallback model">
+                  <TextInput
+                    value={backend?.fallback_model ?? ''}
+                    onCommit={(value) => void onSaveBackend({ fallback_model: value })}
+                  />
+                </Field>
+                <Field label="Remote budget / hour">
+                  <NumberInput
+                    value={backend?.remote_budget_per_hour ?? 60}
+                    onCommit={(value) => value != null && void onSaveBackend({ remote_budget_per_hour: value })}
+                    min={0}
+                  />
+                </Field>
+              </>
+            ) : null}
+          </Section>
+
+          <Section title="COMPUTE">
+            <Field label="Device">
+              <SelectInput
+                value={compute?.device ?? 'cpu'}
+                options={[
+                  { value: 'auto', label: 'auto' },
+                  ...devices.map((device) => ({ value: device.id, label: device.label })),
+                ]}
+                onChange={(device) => void onSaveCompute({ device })}
+              />
+            </Field>
+            {devicesWarning ? (
+              <div style={{ fontSize: 10.5, color: 'var(--amber)', padding: '0 0 4px', fontFamily: 'var(--font-mono)' }}>
+                {devicesWarning}
+              </div>
+            ) : null}
+            <Field label={`CPU fraction · ${((compute?.cpu_fraction ?? 0) * 100).toFixed(0)}%`}>
+              <input
+                type="range"
+                min="0.05"
+                max="1"
+                step="0.05"
+                value={compute?.cpu_fraction ?? 0.2}
+                onChange={(event) => void onSaveCompute({ cpu_fraction: Number(event.target.value) })}
+                style={{ width: 180 }}
+              />
+            </Field>
+            <Field label={`GPU mem fraction · ${((compute?.gpu_memory_fraction ?? 0) * 100).toFixed(0)}%`}>
+              <input
+                type="range"
+                min="0.05"
+                max="1"
+                step="0.05"
+                value={compute?.gpu_memory_fraction ?? 0.5}
+                onChange={(event) => void onSaveCompute({ gpu_memory_fraction: Number(event.target.value) })}
+                style={{ width: 180 }}
+              />
+            </Field>
+            <Field label="Idle only">
+              <Seg
+                value={compute?.idle_only ? 'on' : 'off'}
+                options={['off', 'on']}
+                onChange={(value) => void onSaveCompute({ idle_only: value === 'on' })}
+              />
+            </Field>
+            <Field label="Exploration concurrency">
+              <NumberInput
+                value={compute?.exploration_concurrency ?? 4}
+                onCommit={(value) => value != null && void onSaveCompute({ exploration_concurrency: value })}
+                min={1}
+                max={32}
+              />
+            </Field>
+            <Field label="Max precompute parallel">
+              <NumberInput
+                value={compute?.max_parallel_precompute ?? 1}
+                onCommit={(value) => value != null && void onSaveCompute({ max_parallel_precompute: value })}
+                min={1}
+                max={16}
+              />
+            </Field>
+            <Field label="Max cycle seconds">
+              <NumberInput
+                value={compute?.max_cycle_seconds ?? 300}
+                onCommit={(value) => value != null && void onSaveCompute({ max_cycle_seconds: value })}
+                min={0}
+              />
+            </Field>
+            <Field label="Max session minutes">
+              <NumberInput
+                value={compute?.max_session_minutes ?? null}
+                onCommit={(value) => void onSaveCompute({ max_session_minutes: value })}
+                min={0}
+              />
+            </Field>
+          </Section>
+
+          <Section title="CONTEXT">
+            <Field label="Max context tokens">
+              <NumberInput
+                value={limits?.max_context_tokens ?? 4096}
+                onCommit={(value) => value != null && void onSaveContext(value)}
+                min={256}
+                max={1_000_000}
+                step={256}
+              />
+            </Field>
+            <Field label="Top-k streamed (cockpit only)">
+              <NumberInput
+                value={cockpit.topK}
+                onCommit={(value) => value != null && onPatchCockpit({ topK: value })}
+                min={3}
+                max={40}
+              />
+            </Field>
+          </Section>
+
+          <Section title="MCP">
+            <Field label="Transport">
+              <Seg
+                value={mcp?.transport ?? 'stdio'}
+                options={['stdio', 'sse']}
+                onChange={(value) => void onSaveMcp({ transport: value as MCPSettings['transport'] })}
+              />
+            </Field>
+            <Field label="HTTP host">
+              <TextInput
+                value={mcp?.http_host ?? '127.0.0.1'}
+                onCommit={(value) => void onSaveMcp({ http_host: value })}
+              />
+            </Field>
+            <Field label="HTTP port">
+              <NumberInput
+                value={mcp?.http_port ?? 8472}
+                onCommit={(value) => value != null && void onSaveMcp({ http_port: value })}
+                min={1024}
+                max={65535}
+              />
+            </Field>
+          </Section>
+
+          <Section title="APPEARANCE">
+            <Field label="Dense mode">
+              <Seg
+                value={cockpit.density}
+                options={['relaxed', 'dense']}
+                onChange={(value) => onPatchCockpit({ density: value as CockpitSettings['density'] })}
+              />
+            </Field>
+            <Field label="Accent">
+              <Seg
+                value={cockpit.accent}
+                options={['violet', 'amber', 'teal']}
+                onChange={(value) => onPatchCockpit({ accent: value as CockpitSettings['accent'] })}
+              />
+            </Field>
+            <Field label="Reduce motion">
+              <Seg
+                value={cockpit.reduceMotion ? 'on' : 'off'}
+                options={['off', 'on']}
+                onChange={(value) => onPatchCockpit({ reduceMotion: value === 'on' })}
+              />
+            </Field>
+            {mode === 'proxy' && onToggleGateway ? (
+              <Field label="Gateway">
+                <Seg
+                  value={gatewayEnabled ? 'enabled' : 'disabled'}
+                  options={['enabled', 'disabled']}
+                  onChange={(value) => void onToggleGateway(value === 'enabled')}
+                />
+              </Field>
+            ) : null}
+          </Section>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface MismatchBannerProps {
+  onReload: () => void
+}
+
+export function MismatchBanner({ onReload }: MismatchBannerProps) {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 20,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: 'var(--bg-1)',
+        border: '1px solid var(--amber)',
+        color: 'var(--amber)',
+        borderRadius: 'var(--r-2)',
+        padding: '10px 16px',
+        zIndex: 120,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        boxShadow: '0 10px 40px rgba(0,0,0,.4)',
+      }}
+      role="alert"
+    >
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>
+        Cockpit bundle out of date — the running server serves an older build.
+      </span>
+      <button
+        onClick={onReload}
+        style={{
+          background: 'transparent',
+          border: '1px solid var(--amber)',
+          color: 'var(--amber)',
+          padding: '4px 10px',
+          borderRadius: 'var(--r-1)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 10.5,
+          cursor: 'pointer',
+        }}
+      >
+        reload
+      </button>
+    </div>
+  )
+}

--- a/ui/cockpit/src/styles/tokens.css
+++ b/ui/cockpit/src/styles/tokens.css
@@ -1,0 +1,213 @@
+@import "@fontsource/space-grotesk/400.css";
+@import "@fontsource/space-grotesk/500.css";
+@import "@fontsource/space-grotesk/600.css";
+@import "@fontsource/space-grotesk/700.css";
+@import "@fontsource/instrument-serif/400.css";
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/500.css";
+@import "@fontsource/jetbrains-mono/600.css";
+
+:root {
+  --bg-0: oklch(0.18 0.006 280);
+  --bg-1: oklch(0.22 0.007 280);
+  --bg-2: oklch(0.26 0.008 280);
+  --bg-3: oklch(0.3 0.009 280);
+  --bg-inset: oklch(0.15 0.005 280);
+
+  --line-1: oklch(0.32 0.008 280);
+  --line-2: oklch(0.4 0.01 280);
+  --line-hair: oklch(0.28 0.007 280);
+
+  --fg-1: oklch(0.96 0.005 90);
+  --fg-2: oklch(0.78 0.008 90);
+  --fg-3: oklch(0.6 0.01 90);
+  --fg-4: oklch(0.45 0.01 90);
+
+  --accent: oklch(0.72 0.095 310);
+  --accent-soft: oklch(0.56 0.07 310);
+  --accent-glow: oklch(0.72 0.095 310 / 0.35);
+  --accent-bg: oklch(0.3 0.05 310 / 0.4);
+
+  --amber: oklch(0.8 0.13 75);
+  --amber-soft: oklch(0.62 0.1 75);
+  --amber-bg: oklch(0.35 0.06 75 / 0.35);
+
+  --ok: oklch(0.78 0.09 150);
+  --warn: oklch(0.78 0.12 75);
+  --err: oklch(0.68 0.16 25);
+  --muted: oklch(0.55 0.01 280);
+
+  --kind-research: oklch(0.72 0.095 310);
+  --kind-explain: oklch(0.8 0.11 85);
+  --kind-debug: oklch(0.72 0.1 25);
+  --kind-change: oklch(0.74 0.08 220);
+  --kind-refactor: oklch(0.76 0.08 150);
+
+  --font-display: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  --font-editorial: "Instrument Serif", "Times New Roman", serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "Menlo", monospace;
+
+  --r-1: 3px;
+  --r-2: 6px;
+  --r-3: 10px;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 6px 20px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+  --shadow-lg: 0 20px 60px rgba(0, 0, 0, 0.5), 0 4px 10px rgba(0, 0, 0, 0.25);
+
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-0);
+  color: var(--fg-1);
+  font-family: var(--font-display);
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.tabular {
+  font-variant-numeric: tabular-nums;
+}
+
+.editorial {
+  font-family: var(--font-editorial);
+  letter-spacing: -0.01em;
+}
+
+.hair {
+  height: 1px;
+  background: var(--line-hair);
+}
+
+.vhair {
+  width: 1px;
+  background: var(--line-hair);
+}
+
+@keyframes dc-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--accent-glow);
+  }
+  50% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
+
+@keyframes dc-pulse-amber {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 oklch(0.8 0.13 75 / 0.35);
+  }
+  50% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
+
+@keyframes dc-flow {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: -12;
+  }
+}
+
+@keyframes dc-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@keyframes dc-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes dc-flow-particle {
+  0% {
+    offset-distance: 0%;
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  85% {
+    opacity: 1;
+  }
+  100% {
+    offset-distance: 100%;
+    opacity: 0;
+  }
+}
+
+@keyframes dc-lane-flash {
+  0% {
+    background: color-mix(in oklch, var(--accent) 24%, transparent);
+  }
+  100% {
+    background: transparent;
+  }
+}
+
+@keyframes dc-fadein {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 4px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+.scroll::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scroll::-webkit-scrollbar-thumb {
+  background: var(--line-2);
+  border-radius: 4px;
+}
+
+.scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--fg-4);
+}

--- a/ui/cockpit/src/test/setup.ts
+++ b/ui/cockpit/src/test/setup.ts
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom/vitest'
+
+class MockResizeObserver {
+  observe(): void {
+    // noop
+  }
+  unobserve(): void {
+    // noop
+  }
+  disconnect(): void {
+    // noop
+  }
+}
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  ;(globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
+    MockResizeObserver
+}

--- a/ui/cockpit/src/types.ts
+++ b/ui/cockpit/src/types.ts
@@ -1,0 +1,222 @@
+export type UIScenarioKind = 'research' | 'explain' | 'change' | 'debug' | 'refactor'
+export type UIFreshness = 'fresh' | 'recent' | 'stale'
+export type UIDecisionState = 'active' | 'chosen' | 'partial' | 'rejected' | 'pending' | 'idle'
+export type UIAccent = 'violet' | 'amber' | 'teal'
+export type UIMode = 'daemon' | 'proxy' | 'mcp'
+
+export interface UIScenario {
+  id: string
+  kind: UIScenarioKind
+  title: string
+  score: number
+  freshness: UIFreshness
+  depth: number
+  parent: string | null
+  path: string
+  skill: string | null
+  decisionState: UIDecisionState
+  reason: string
+  entities: string[]
+  pinned: boolean
+}
+
+export interface UIEvidence {
+  file: string
+  lines: string | null
+  note: string
+  startLine: number | null
+  endLine: number | null
+}
+
+export interface UISkill {
+  name: string
+  desc: string
+  weight: number
+}
+
+export interface UIPinnedFact {
+  id: string
+  text: string
+}
+
+export type PipelineStage =
+  | 'signals'
+  | 'targets'
+  | 'model'
+  | 'artefacts'
+  | 'scenarios'
+  | 'decisions'
+  | 'system'
+
+export interface UIEvent {
+  id: string
+  t: string
+  tag: string
+  color: string
+  msg: string
+  scn: string | null
+  stage?: PipelineStage
+  kind?: string
+  ts?: number
+  path?: string | null
+  cycleId?: string | null
+  payload?: Record<string, unknown>
+}
+
+export interface UIPackageState {
+  id: string
+  tokens: number
+  budget: number
+  chosen: number
+  partial: number
+  rejected: number
+  compression: number
+}
+
+export interface BackendSettings {
+  name: string
+  base_url: string
+  model: string
+  api_key_env: string
+  prefer_local: boolean
+  fallback_enabled: boolean
+  fallback_base_url: string
+  fallback_model: string
+  fallback_api_key_env: string
+  remote_budget_per_hour: number
+}
+
+export interface ComputeSettings {
+  device: string
+  cpu_fraction: number
+  gpu_memory_fraction: number
+  idle_only: boolean
+  idle_cpu_threshold: number
+  idle_gpu_threshold: number
+  embedding_device: string | null
+  exploration_concurrency: number
+  max_parallel_precompute: number
+  max_cycle_seconds: number
+  max_session_minutes: number | null
+}
+
+export interface MCPSettings {
+  transport: 'stdio' | 'sse'
+  http_host: string
+  http_port: number
+}
+
+export interface LimitSettings {
+  max_age_seconds: number
+  max_context_tokens: number
+}
+
+export interface CockpitSettings {
+  density: 'relaxed' | 'dense'
+  accent: UIAccent
+  reduceMotion: boolean
+  topK: number
+  gatewayEnabled: boolean
+}
+
+export interface BackendPreset {
+  name: string
+  base_url: string
+  default_model: string
+  api_key_env: string
+}
+
+export interface ComputeDevice {
+  id: string
+  label: string
+  kind: string
+  total_memory_bytes?: number
+}
+
+export interface BootstrapPayload {
+  mode: UIMode
+  version?: string
+  cockpit_sha?: string
+}
+
+export interface StatusPayload {
+  health: string
+  mode?: UIMode
+  gateway_enabled?: boolean
+  compute: Partial<ComputeSettings> & { device?: string }
+  backend?: Partial<BackendSettings>
+  mcp?: Partial<MCPSettings>
+  limits?: Partial<LimitSettings>
+  scenario_counts?: {
+    fresh: number
+    recent: number
+    stale: number
+    total: number
+  }
+  top_scenario?: string | null
+}
+
+export interface ImpactSummary {
+  count: number
+  mean_latency_gain_ms?: number
+  mean_char_delta?: number
+  idle_seconds_used?: number
+}
+
+export interface DecisionRecordPayload {
+  id: string
+  prompt: string
+  prompt_hash: string
+  assembled_at: number
+  cache_tier: string
+  partial_similarity: number
+  token_budget: number
+  token_used: number
+  notes: string[]
+  selection_count?: number
+  selections: Array<{
+    artefact_key: string
+    source_path: string
+    final_score: number
+    token_count: number
+    stale: boolean
+    kept: boolean
+    drop_reason?: string | null
+    rationale: string
+  }>
+}
+
+export interface ScenarioApiPayload {
+  id: string
+  kind: UIScenarioKind
+  score: number
+  freshness: UIFreshness
+  entities: string[]
+  evidence: Array<{
+    key?: string
+    source_path?: string
+    excerpt?: string
+    weight?: number
+    start_line?: number | null
+    end_line?: number | null
+  }>
+  prepared_context?: string
+  coverage_gaps?: string[]
+  last_outcome?: string | null
+  memory_state?: string
+  pinned?: number | boolean
+  title?: string
+  path?: string
+  depth?: number
+  parent?: string | null
+  skill?: string | null
+  decision_state?: UIDecisionState
+  reason?: string
+  score_components?: Array<{ label: string; value: number; description?: string }>
+}
+
+declare global {
+  interface Window {
+    __VANER_MODE__?: string
+  }
+}


### PR DESCRIPTION
## Summary

Transforms the cockpit from a stacked-column scenario list into a proper
real-time pipeline view that mirrors the daemon's actual control flow. Every
lane is driven by a new unified event bus (`src/vaner/events/bus.py`).

- **Backend event bus** (`VanerEvent`, `EventBus`, `cycle_scope`) with
  emitters in the daemon runner, LLM helpers, proxy chat completion, and
  `ScenarioStore._publish`. `/events/stream` now returns structured
  envelopes (with legacy fields kept for one release) and accepts a
  `?stages=` filter.
- **PipelineCanvas** renders a six-lane ribbon (Signals → Targets → Model →
  Artefacts → Scenarios → Decisions) with per-lane live read-outs and
  inter-lane particle flow. LLM lane shows a spinner while requests are
  in flight.
- **ScenarioCluster** replaces `FrontierGraph`. Kind-bucketed
  force-directed layout + shared-path **Jaccard** edges so scenarios
  without explicit parents still form a visible constellation when they
  touch the same files.
- **SystemVitals** (left rail) surfaces live cycle/model state, latency
  EMA, error counts — all event-driven, no polling.
- **EventStreamPanel** replaces `StreamPanel`: stage-coloured rows, filter
  chips, heartbeat collapse, in-flight LLM counter.

Closes the remaining cockpit items in the dogfood report (D7, U1) and
upgrades event-stream coverage (O2). Docs and README updated.

## Test plan

- [x] `npm test` in `ui/cockpit` — 35/35 passing (7 new tests across
  `PipelineCanvas`, `ScenarioCluster`, `SystemVitals`, `EventStreamPanel`).
- [x] `npm run lint` in `ui/cockpit` — clean.
- [x] `npx tsc -b` and `npm run build` in `ui/cockpit` — clean.
- [x] `pytest tests/test_events tests/test_daemon tests/test_router` — 78
  passing.
- [x] `pytest tests/test_cli/test_mcp_command.py` — 3/3 passing after
  restoring the optional-`mcp` import fallback (fixes macOS CI).
- [x] `ruff check src tests` — clean.
- [ ] Verify CI green on this branch before merging.
- [ ] Smoke-test end-to-end: `vaner daemon start`, open cockpit, confirm
  particles flow across lanes when a cycle runs and the model lane shows
  a spinner while an LLM summary is pending.


Made with [Cursor](https://cursor.com)