### PR TITLE
feat(plugin): ship supported Claude Code plugin + same-repo marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,28 @@
+{
+  "name": "vaner",
+  "owner": {
+    "name": "Borgels Olsen Holding ApS",
+    "email": "support@vaner.ai"
+  },
+  "metadata": {
+    "description": "Vaner — predictive context middleware for AI coding workflows.",
+    "version": "0.6.2"
+  },
+  "plugins": [
+    {
+      "name": "vaner",
+      "source": "./plugins/vaner",
+      "description": "MCP server, feedback skill, and bootstrap hook for Vaner.",
+      "version": "0.6.2",
+      "category": "developer-tools",
+      "tags": ["mcp", "context", "retrieval", "scenarios", "vaner"],
+      "homepage": "https://vaner.ai",
+      "repository": "https://github.com/Borgels/Vaner",
+      "license": "Apache-2.0",
+      "author": {
+        "name": "Borgels Olsen Holding ApS",
+        "email": "support@vaner.ai"
+      }
+    }
+  ]
+}

--- a/.github/workflows/validate-claude-plugin.yml
+++ b/.github/workflows/validate-claude-plugin.yml
@@ -1,0 +1,73 @@
+name: Validate Claude Plugin
+
+on:
+  pull_request:
+    paths:
+      - "plugins/**"
+      - ".claude-plugin/**"
+      - "src/vaner/defaults/skills/vaner-feedback/**"
+      - "pyproject.toml"
+      - "scripts/sync-plugin-skill.sh"
+      - "scripts/bump-plugin-version.sh"
+      - ".github/workflows/validate-claude-plugin.yml"
+  push:
+    branches: [main]
+    paths:
+      - "plugins/**"
+      - ".claude-plugin/**"
+      - "src/vaner/defaults/skills/vaner-feedback/**"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@latest
+
+      - name: Skill parity (defaults ↔ plugin)
+        run: bash scripts/sync-plugin-skill.sh --check
+
+      - name: Version parity (pyproject ↔ plugin.json ↔ marketplace.json)
+        run: bash scripts/bump-plugin-version.sh --check
+
+      - name: Shell syntax check (hook script)
+        run: bash -n plugins/vaner/scripts/check-vaner.sh
+
+      - name: JSON well-formedness
+        run: |
+          set -euo pipefail
+          for f in \
+            .claude-plugin/marketplace.json \
+            plugins/vaner/.claude-plugin/plugin.json \
+            plugins/vaner/.mcp.json \
+            plugins/vaner/hooks/hooks.json; do
+            python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$f"
+          done
+
+      - name: Hook produces valid JSON when vaner is absent
+        run: |
+          set -euo pipefail
+          out=$(PATH=/tmp:/usr/bin:/bin bash plugins/vaner/scripts/check-vaner.sh)
+          printf '%s' "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['hookSpecificOutput']['hookEventName']=='SessionStart'; assert 'additionalContext' in d['hookSpecificOutput']"
+
+      - name: claude plugin validate
+        run: claude plugin validate ./plugins/vaner

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,7 @@ eval/
 !src/vaner/eval/**
 scripts/*
 !scripts/install.sh
+!scripts/sync-plugin-skill.sh
+!scripts/bump-plugin-version.sh
 infra/
 apps/vaner-daemon/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,17 @@ repos:
     rev: v8.30.1
     hooks:
       - id: gitleaks
+  - repo: local
+    hooks:
+      - id: vaner-plugin-skill-parity
+        name: vaner plugin feedback-skill parity
+        entry: scripts/sync-plugin-skill.sh --check
+        language: system
+        pass_filenames: false
+        files: ^(src/vaner/defaults/skills/vaner-feedback/SKILL\.md|plugins/vaner/skills/vaner-feedback/SKILL\.md)$
+      - id: vaner-plugin-version-parity
+        name: vaner plugin version parity
+        entry: scripts/bump-plugin-version.sh --check
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|plugins/vaner/\.claude-plugin/plugin\.json|\.claude-plugin/marketplace\.json)$

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,6 +42,10 @@ Vaner is a local-first predictive context engine for coding assistants.
   - `vaner why [decision-id] [--list|--verbose|--json]`
   - `vaner query --explain [--verbose|--json]`
 
+## Claude Code plugin packaging
+
+Vaner ships a Claude Code plugin under `plugins/vaner/`, catalogued by a repo-root marketplace at `.claude-plugin/marketplace.json`. The plugin is a thin wrapper — it registers the `vaner` MCP server, the `vaner-feedback` skill, and a SessionStart hook that checks whether the `vaner` CLI is on PATH. The actual code still ships via PyPI and `scripts/install.sh`; the plugin only wires Claude Code to the installed CLI. Version parity between `pyproject.toml`, `plugins/vaner/.claude-plugin/plugin.json`, and the marketplace entry is enforced by `scripts/bump-plugin-version.sh` (pre-commit and CI).
+
 ## More details
 
 Detailed architecture docs live at `https://docs.vaner.ai/architecture`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-- _TBD_
+- Added a supported Claude Code plugin (`plugins/vaner/`) distributed via a same-repo marketplace at `.claude-plugin/marketplace.json`. Claude Code users can now install Vaner with `/plugin marketplace add Borgels/Vaner` followed by `/plugin install vaner@vaner`. The plugin bundles the Vaner MCP server, the `vaner-feedback` skill (now namespaced as `/vaner:vaner-feedback`), a `/vaner:install` skill that wraps the canonical installer behind a Bash-tool permission prompt, and a SessionStart hook that reports when the `vaner` CLI is missing from PATH.
 
 ## [0.6.2] - 2026-04-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ CI checks on pull requests and pushes:
 
 Pull requests are expected to pass required CI checks before merge.
 
+## Claude Code Plugin
+
+The Claude Code plugin lives under `plugins/vaner/` and is catalogued by `.claude-plugin/marketplace.json`. Two parity rules are enforced in pre-commit and CI:
+
+1. **Skill content parity.** `plugins/vaner/skills/vaner-feedback/SKILL.md` must be byte-identical to `src/vaner/defaults/skills/vaner-feedback/SKILL.md`. Run `scripts/sync-plugin-skill.sh --write` after editing either.
+2. **Version parity.** `pyproject.toml::project.version`, `plugins/vaner/.claude-plugin/plugin.json::version`, and `.claude-plugin/marketplace.json::plugins[0].version` must match. After bumping `pyproject.toml`, run `scripts/bump-plugin-version.sh --write`.
+
+Claude Code uses `plugin.json::version` to decide whether to propagate updates to installed users, so a missed bump strands everyone on the previous version. CI fails the PR if either parity check fails.
+
 ## Dependency and Supply-Chain Hygiene
 
 Direct dependencies are declared in `pyproject.toml`.

--- a/README.md
+++ b/README.md
@@ -159,9 +159,12 @@ Vaner exposes context to your agent over [MCP](https://modelcontextprotocol.io/)
 
 | Client | One command |
 | --- | --- |
-| Claude Code | `claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .` |
+| Claude Code (plugin, recommended) | `/plugin marketplace add Borgels/Vaner` then `/plugin install vaner@vaner` |
+| Claude Code (manual MCP) | `claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .` |
 | Codex CLI   | `codex mcp add vaner -- vaner mcp --path .` |
 | Cursor / VS Code / Zed / Windsurf / Continue / Claude Desktop / Cline / Roo | see [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp) |
+
+The Claude Code plugin bundles the MCP server, the `vaner-feedback` skill (namespaced as `/vaner:vaner-feedback`), and a SessionStart hook that detects whether the `vaner` CLI is installed. See [docs/claude-plugin.md](docs/claude-plugin.md) for details.
 
 Or let Vaner write the config file for you:
 

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -1,0 +1,75 @@
+# Vaner Claude Code plugin
+
+Vaner ships a supported [Claude Code plugin](https://code.claude.com/docs/en/plugins) that bundles the Vaner MCP server, the `vaner-feedback` skill, and a bootstrap hook into one installable unit.
+
+## What's in the plugin
+
+| Component | Location in the plugin | Effect in Claude Code |
+| --- | --- | --- |
+| MCP server | `plugins/vaner/.mcp.json` | Registers an MCP server named `vaner`. Tools appear as `mcp__vaner__search`, `mcp__vaner__resolve`, `mcp__vaner__expand`, `mcp__vaner__suggest`, `mcp__vaner__feedback`, `mcp__vaner__status`, `mcp__vaner__explain`, `mcp__vaner__warm`, `mcp__vaner__inspect`, `mcp__vaner__debug__trace`. |
+| Feedback skill | `plugins/vaner/skills/vaner-feedback/SKILL.md` | Invokable as `/vaner:vaner-feedback`. Guides the agent through reporting scenario outcomes via `vaner.feedback`. |
+| Install skill | `plugins/vaner/skills/install/SKILL.md` | Invokable as `/vaner:install`. Runs the canonical installer under the Bash tool's permission prompt when the `vaner` CLI is not yet installed. |
+| SessionStart hook | `plugins/vaner/hooks/hooks.json` + `scripts/check-vaner.sh` | On each new session, detects whether `vaner` is on PATH. If missing, injects an `additionalContext` message directing the user at the installer; otherwise silent. |
+
+## Install
+
+```text
+/plugin marketplace add Borgels/Vaner
+/plugin install vaner@vaner
+```
+
+That's it — the plugin is cached to `~/.claude/plugins/cache/vaner/` and enabled for the chosen scope. If the `vaner` CLI is not on PATH, the next session will tell you how to install it (or you can run `/vaner:install`).
+
+### Prerequisite: the `vaner` CLI
+
+The plugin wires Claude Code *to* the Vaner CLI; it does not bundle it. Install the CLI once with the canonical installer:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash -s -- --yes
+```
+
+Or invoke `/vaner:install` from inside Claude Code — the skill wraps the same command behind a permission prompt.
+
+## Update
+
+```text
+/plugin update vaner@vaner
+```
+
+Update propagation is driven by `plugins/vaner/.claude-plugin/plugin.json::version`. Vaner's repo keeps that field in lockstep with `pyproject.toml` via `scripts/bump-plugin-version.sh`, so every tagged Vaner release becomes a plugin update.
+
+## Uninstall
+
+```text
+/plugin uninstall vaner@vaner
+```
+
+If you previously ran `vaner init`, you may also want to clean up the pre-plugin managed skill copy:
+
+```bash
+rm -rf ~/.claude/skills/vaner
+```
+
+## Relationship with `vaner init`
+
+`vaner init` still works and still writes a managed feedback skill to `~/.claude/skills/vaner/vaner-feedback/SKILL.md` plus a per-repo `.cursor/mcp.json`. For Claude Code users the plugin supersedes both — the plugin-shipped skill resolves as `/vaner:vaner-feedback` (namespaced), and the plugin's `.mcp.json` registers the MCP server at the user scope. The standalone skill can coexist harmlessly (contents are byte-identical and CI-enforced) or be removed.
+
+For Cursor, Codex CLI, and other clients that don't support Claude Code plugins, continue using `vaner init` / the per-client instructions at [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp).
+
+## Troubleshooting
+
+- **`/mcp` does not show a `vaner` server.** Confirm `command -v vaner` works in the same shell you launched Claude Code from. The plugin's `.mcp.json` calls `vaner` directly; if it isn't on PATH, the server cannot start and the SessionStart hook will have told you so at session start.
+- **MCP tools run against the wrong repo.** The plugin launches `vaner mcp` with Claude Code's session working directory, and Vaner resolves its repo root from `$PWD`. If you started Claude Code from outside your project, `cd` into it first and open a new session.
+- **Skill does not appear as `/vaner:vaner-feedback`.** Run `/plugin list` to confirm `vaner@vaner` is installed and enabled. If you had a pre-plugin `~/.claude/skills/vaner/vaner-feedback/SKILL.md`, the plugin takes precedence.
+
+## For plugin developers working on Vaner itself
+
+- Test locally without a marketplace roundtrip:
+  ```bash
+  claude --plugin-dir ./plugins/vaner
+  ```
+- Validate:
+  ```bash
+  claude plugin validate ./plugins/vaner
+  ```
+- CI enforces skill parity (`scripts/sync-plugin-skill.sh --check`) and version parity (`scripts/bump-plugin-version.sh --check`). Update both via the `--write` mode after editing the canonical skill or bumping `pyproject.toml`.

--- a/plugins/vaner/.claude-plugin/plugin.json
+++ b/plugins/vaner/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "vaner",
+  "version": "0.6.2",
+  "description": "Vaner: predictive context middleware for AI coding workflows. Bundles the Vaner MCP server (search, expand, resolve, feedback, and more), the vaner-feedback skill, and a SessionStart hook that checks for the `vaner` CLI.",
+  "author": {
+    "name": "Borgels Olsen Holding ApS",
+    "email": "support@vaner.ai",
+    "url": "https://vaner.ai"
+  },
+  "homepage": "https://vaner.ai",
+  "repository": "https://github.com/Borgels/Vaner",
+  "license": "Apache-2.0",
+  "keywords": ["mcp", "context", "retrieval", "scenarios", "vaner"]
+}

--- a/plugins/vaner/.mcp.json
+++ b/plugins/vaner/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "vaner": {
+      "command": "vaner",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/plugins/vaner/hooks/hooks.json
+++ b/plugins/vaner/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/check-vaner.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/vaner/scripts/check-vaner.sh
+++ b/plugins/vaner/scripts/check-vaner.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Vaner SessionStart hook.
+#
+# Detects whether the `vaner` CLI is on PATH. If present, exits silently so the
+# bundled MCP server can start. If missing, emits SessionStart additionalContext
+# pointing the user at the canonical installer and the `/vaner:install` skill.
+# Never auto-runs network fetches; always exits 0 so session startup is not
+# blocked.
+set -u
+
+if command -v vaner >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Python 3.8+ is ubiquitous on macOS/Linux; Vaner itself requires 3.11+. Using
+# python3 avoids taking a jq dependency just to build a small JSON document.
+python3 - <<'PY'
+import json
+import sys
+
+message = (
+    "The Vaner plugin is enabled, but the `vaner` CLI is not on PATH, so the "
+    "bundled MCP server cannot start. Vaner provides predictive context tools "
+    "(`mcp__vaner__search`, `mcp__vaner__resolve`, `mcp__vaner__expand`, "
+    "`mcp__vaner__feedback`, and more).\n\n"
+    "To install Vaner, the user can run:\n\n"
+    "    curl -fsSL https://vaner.ai/install.sh | bash -s -- --yes\n\n"
+    "Or, with explicit consent, invoke `/vaner:install` which wraps the same "
+    "installer behind the Bash tool's permission prompt.\n\n"
+    "After installing, restart Claude Code so the MCP server is registered."
+)
+
+payload = {
+    "continue": True,
+    "suppressOutput": True,
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": message,
+    },
+}
+
+json.dump(payload, sys.stdout)
+sys.stdout.write("\n")
+PY
+
+exit 0

--- a/plugins/vaner/skills/install/SKILL.md
+++ b/plugins/vaner/skills/install/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: install
+description: Install the Vaner CLI by invoking the canonical install.sh with the user's explicit consent. Use when the user asks to install Vaner or when the SessionStart hook reports that `vaner` is not on PATH.
+---
+
+When the user invokes `/vaner:install`:
+
+1. Confirm they want to install. Explain that this will download and execute the official installer from `https://vaner.ai/install.sh`. The Bash tool will prompt for its own permission before running; describe what will happen first.
+2. Run:
+
+   ```
+   curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash -s -- --yes
+   ```
+
+3. After the install completes, verify success with `command -v vaner` and `vaner --version`.
+4. Advise the user to restart Claude Code so the bundled Vaner MCP server is registered for new sessions.
+
+Do not run this skill automatically. It performs a network fetch and executes the downloaded script, so it requires an explicit user request — either a direct `/vaner:install` invocation or a clear "install Vaner" instruction.

--- a/plugins/vaner/skills/vaner-feedback/SKILL.md
+++ b/plugins/vaner/skills/vaner-feedback/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: vaner-feedback
+description: Report scenario outcomes back to Vaner after completing a task.
+tags: [vaner, feedback]
+vaner:
+  kind: research
+  feedback: auto
+x-vaner-managed: true
+---
+
+Use this skill when finishing a task that used Vaner MCP scenarios.
+
+1. Keep the `resolution_id` returned by `vaner.resolve`, and note any item ids you want to praise or reject from `vaner.expand` / `vaner.search`.
+2. Call `vaner.feedback` with `rating` (`useful` | `partial` | `wrong` | `irrelevant`) and include `resolution_id` plus any optional `correction`, `preferred_items`, or `rejected_items`.
+3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and improve future scenario ranking.

--- a/scripts/bump-plugin-version.sh
+++ b/scripts/bump-plugin-version.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Keep the Claude Code plugin's version aligned with pyproject.toml.
+#
+# Sources of truth:
+#   pyproject.toml::project.version  (authoritative)
+#   plugins/vaner/.claude-plugin/plugin.json::version
+#   .claude-plugin/marketplace.json::plugins[0].version
+#
+# Claude Code uses plugin.json::version to decide whether to propagate updates
+# to installed users, so drift silently strands them on old versions.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 --check | --write" >&2
+  exit 2
+}
+
+[[ $# -eq 1 ]] || usage
+
+MODE="$1"
+case "$MODE" in
+  --check|--write) ;;
+  *) usage ;;
+esac
+
+PLUGIN_JSON="plugins/vaner/.claude-plugin/plugin.json"
+MARKETPLACE_JSON=".claude-plugin/marketplace.json"
+
+python3 - "$MODE" "$PLUGIN_JSON" "$MARKETPLACE_JSON" <<'PY'
+import json
+import pathlib
+import sys
+import tomllib
+
+mode, plugin_path, marketplace_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+source_version = pyproject["project"]["version"]
+
+def load(path: str) -> dict:
+    return json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+
+def dump(path: str, doc: dict) -> None:
+    pathlib.Path(path).write_text(
+        json.dumps(doc, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+plugin = load(plugin_path)
+marketplace = load(marketplace_path)
+
+def plugin_entry(doc: dict) -> dict:
+    for entry in doc.get("plugins", []):
+        if entry.get("name") == "vaner":
+            return entry
+    raise SystemExit(f"no 'vaner' entry in {marketplace_path}")
+
+entry = plugin_entry(marketplace)
+
+if mode == "--check":
+    errors = []
+    if plugin.get("version") != source_version:
+        errors.append(
+            f"{plugin_path}::version = {plugin.get('version')!r}, "
+            f"expected {source_version!r}"
+        )
+    if entry.get("version") != source_version:
+        errors.append(
+            f"{marketplace_path}::plugins[name=vaner].version = "
+            f"{entry.get('version')!r}, expected {source_version!r}"
+        )
+    if errors:
+        print("version parity failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(f"run: scripts/bump-plugin-version.sh --write", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+
+plugin["version"] = source_version
+entry["version"] = source_version
+dump(plugin_path, plugin)
+dump(marketplace_path, marketplace)
+print(f"synced plugin version to {source_version}")
+PY

--- a/scripts/sync-plugin-skill.sh
+++ b/scripts/sync-plugin-skill.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Keep plugins/vaner/skills/vaner-feedback/SKILL.md byte-identical to the
+# canonical copy under src/vaner/defaults/skills/. Symlinks break after the
+# plugin is copied to ~/.claude/plugins/cache/, so we copy and enforce parity.
+set -euo pipefail
+
+SRC="src/vaner/defaults/skills/vaner-feedback/SKILL.md"
+DST="plugins/vaner/skills/vaner-feedback/SKILL.md"
+
+usage() {
+  echo "usage: $0 --check | --write" >&2
+  exit 2
+}
+
+[[ $# -eq 1 ]] || usage
+
+case "$1" in
+  --check)
+    if [[ ! -f "$DST" ]]; then
+      echo "missing: $DST (run: $0 --write)" >&2
+      exit 1
+    fi
+    if ! diff -q "$SRC" "$DST" >/dev/null; then
+      echo "out of sync: $SRC vs $DST" >&2
+      echo "run: $0 --write" >&2
+      exit 1
+    fi
+    ;;
+  --write)
+    mkdir -p "$(dirname "$DST")"
+    cp "$SRC" "$DST"
+    ;;
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Ships Vaner as a native Claude Code plugin distributed from a same-repo marketplace. Users can install with \`/plugin marketplace add Borgels/vaner\` then \`/plugin install vaner@vaner\` instead of hand-wiring \`claude mcp add\` and copying a skill file.
- Plugin bundles the Vaner MCP server (\`.mcp.json\` invoking \`vaner mcp\` with no \`--path\` so it inherits the session cwd), the \`vaner-feedback\` skill namespaced as \`/vaner:vaner-feedback\`, a new \`/vaner:install\` skill that wraps \`install.sh\` behind the Bash-tool permission prompt, and a SessionStart hook that detects whether the \`vaner\` CLI is on PATH and injects install instructions via \`additionalContext\` when missing.
- Parity with the upstream Python package is enforced by two new scripts (\`scripts/sync-plugin-skill.sh\`, \`scripts/bump-plugin-version.sh\`) run from pre-commit and the new \`.github/workflows/validate-claude-plugin.yml\` CI workflow. \`pyproject.toml::project.version\`, \`plugins/vaner/.claude-plugin/plugin.json::version\`, and \`.claude-plugin/marketplace.json::plugins[0].version\` must stay aligned or CI fails.

## Why copy, not symlink

Claude Code copies plugins into \`~/.claude/plugins/cache/\` before loading. A symlink whose target lives outside the plugin root (e.g., \`plugins/vaner/skills/vaner-feedback/SKILL.md\` → \`../../../src/vaner/defaults/skills/...\`) would break after install because the target is not copied. Plugin ships a byte-copy of the canonical \`SKILL.md\`; CI rejects any drift.

## Why no \`cwd\` in \`.mcp.json\`

Claude Code launches plugin MCP servers with the session's working directory by default, and \`vaner mcp\` already resolves the repo root from \`\$PWD\`. Setting \`cwd: \"\${CLAUDE_PLUGIN_ROOT}\"\` would pin every session to the plugin cache dir and break per-repo context. Confirmed empirically — \`vaner mcp\` prints \`repo=\$PWD\` at startup under the plugin loader.

## Interaction with existing \`vaner init\`

\`vaner init\` is unchanged for this PR. The standalone skill copy it writes to \`~/.claude/skills/vaner/\` coexists harmlessly with the namespaced plugin skill (identical content, CI-enforced); the plugin takes precedence when both are installed. A v2 polish could teach \`vaner init\` to detect plugin installation and skip the Claude Code skill write.

## Test plan

Automated (added in this PR, green locally):

- [x] \`claude plugin validate ./plugins/vaner\` passes on CLI 2.1.116.
- [x] \`bash scripts/sync-plugin-skill.sh --check\` passes; drift is detected when either SKILL.md is perturbed.
- [x] \`bash scripts/bump-plugin-version.sh --check\` passes across all three version sources.
- [x] \`pre-commit run vaner-plugin-skill-parity\` and \`vaner-plugin-version-parity\` both pass.
- [x] JSON well-formedness verified for \`plugin.json\`, \`.mcp.json\`, \`hooks.json\`, \`marketplace.json\`.

Manual smoke (run locally):

- [x] \`claude --plugin-dir ./plugins/vaner --print\` headless session loads the plugin, registers the \`vaner\` MCP server, and reports bundled tools.
- [x] Renaming \`vaner\` out of PATH and reloading surfaces the SessionStart hook's \`additionalContext\` in the model's response; restoring the binary restores normal operation.
- [x] \`vaner mcp\` logs \`repo=\$PWD\` at startup when invoked with no \`--path\`, confirming the session-cwd assumption.

To reproduce:

\`\`\`bash
# From a checkout of this branch:
claude plugin validate ./plugins/vaner
claude --plugin-dir ./plugins/vaner --print "list the mcp servers available"

# Simulate missing binary:
mv \$(which vaner) /tmp/vaner-away
claude --plugin-dir ./plugins/vaner --print "is vaner installed?"
mv /tmp/vaner-away \$(dirname \$(which python3))/../bin/vaner
\`\`\`

## Follow-ups (not in this PR)

- Submit the plugin to the official Anthropic marketplace via \`claude.ai/settings/plugins/submit\` once a tagged release is cut with matching versions.
- Teach \`vaner init\` to detect plugin installation and skip the standalone Claude skill write.
- Windows: SessionStart hook is bash-only. Add a \`.ps1\` sibling and matcher after v1 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)