### PR TITLE
feat(plugin): inject canonical primer on SessionStart + add /vaner:next

### DIFF
--- a/.github/workflows/validate-claude-plugin.yml
+++ b/.github/workflows/validate-claude-plugin.yml
@@ -6,8 +6,10 @@ on:
       - "plugins/**"
       - ".claude-plugin/**"
       - "src/vaner/defaults/skills/vaner-feedback/**"
+      - "src/vaner/defaults/prompts/agent-primer.md"
       - "pyproject.toml"
       - "scripts/sync-plugin-skill.sh"
+      - "scripts/sync-plugin-primer.sh"
       - "scripts/bump-plugin-version.sh"
       - ".github/workflows/validate-claude-plugin.yml"
   push:
@@ -16,6 +18,7 @@ on:
       - "plugins/**"
       - ".claude-plugin/**"
       - "src/vaner/defaults/skills/vaner-feedback/**"
+      - "src/vaner/defaults/prompts/agent-primer.md"
       - "pyproject.toml"
 
 permissions:
@@ -46,6 +49,9 @@ jobs:
       - name: Skill parity (defaults ↔ plugin)
         run: bash scripts/sync-plugin-skill.sh --check
 
+      - name: Primer parity (defaults ↔ plugin)
+        run: bash scripts/sync-plugin-primer.sh --check
+
       - name: Version parity (pyproject ↔ plugin.json ↔ marketplace.json)
         run: bash scripts/bump-plugin-version.sh --check
 
@@ -67,7 +73,18 @@ jobs:
         run: |
           set -euo pipefail
           out=$(PATH=/tmp:/usr/bin:/bin bash plugins/vaner/scripts/check-vaner.sh)
-          printf '%s' "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['hookSpecificOutput']['hookEventName']=='SessionStart'; assert 'additionalContext' in d['hookSpecificOutput']"
+          printf '%s' "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['hookSpecificOutput']['hookEventName']=='SessionStart'; assert 'additionalContext' in d['hookSpecificOutput']; assert 'install.sh' in d['hookSpecificOutput']['additionalContext']"
+
+      - name: Hook produces valid JSON with canonical primer when vaner is present
+        run: |
+          set -euo pipefail
+          # Simulate the plugin's runtime environment: fake a `vaner` on PATH
+          # and set CLAUDE_PLUGIN_ROOT so the hook finds the vendored primer.
+          tmpdir=$(mktemp -d)
+          printf '#!/usr/bin/env bash\nexit 0\n' > "$tmpdir/vaner"
+          chmod +x "$tmpdir/vaner"
+          out=$(CLAUDE_PLUGIN_ROOT="$PWD/plugins/vaner" PATH="$tmpdir:$PATH" bash plugins/vaner/scripts/check-vaner.sh)
+          printf '%s' "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); ctx=d['hookSpecificOutput']['additionalContext']; assert 'Using Vaner' in ctx; assert 'vaner.resolve' in ctx; assert 'vaner.feedback' in ctx"
 
       - name: claude plugin validate
         run: claude plugin validate ./plugins/vaner

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ eval/
 scripts/*
 !scripts/install.sh
 !scripts/sync-plugin-skill.sh
+!scripts/sync-plugin-primer.sh
 !scripts/bump-plugin-version.sh
 infra/
 apps/vaner-daemon/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,9 @@ repos:
         language: system
         pass_filenames: false
         files: ^(pyproject\.toml|plugins/vaner/\.claude-plugin/plugin\.json|\.claude-plugin/marketplace\.json)$
+      - id: vaner-plugin-primer-parity
+        name: vaner plugin primer parity
+        entry: scripts/sync-plugin-primer.sh --check
+        language: system
+        pass_filenames: false
+        files: ^(src/vaner/defaults/prompts/agent-primer\.md|plugins/vaner/prompts/agent-primer\.md)$

--- a/plugins/vaner/prompts/agent-primer.md
+++ b/plugins/vaner/prompts/agent-primer.md
@@ -1,0 +1,13 @@
+# Using Vaner
+
+Vaner is a local-first predictive context engine available to you as an MCP server. It prepares evidence-backed context packages in the background and exposes them through the `vaner.*` tool family (`vaner.resolve`, `vaner.search`, `vaner.expand`, `vaner.suggest`, `vaner.feedback`, `vaner.status`, `vaner.explain`, `vaner.warm`, `vaner.inspect`, `vaner.debug.trace`).
+
+Use Vaner when it can reduce uncertainty, prepare likely context, or continue an existing path. Do not call it mechanically when the task is trivial or self-contained.
+
+Operational patterns:
+
+1. **Prepared context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
+2. **Fallback and branches.** Use `vaner.search` when `vaner.resolve` confidence is weak or the task requires a retrieval style it did not cover. Use `vaner.expand` to explore adjacent scenarios without recomputing everything.
+3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
+
+Treat Vaner as a supplement, not a replacement for reading code. Skip it entirely for one-line changes, pure reformatting, or questions already answered in the open conversation.

--- a/plugins/vaner/scripts/check-vaner.sh
+++ b/plugins/vaner/scripts/check-vaner.sh
@@ -1,19 +1,55 @@
 #!/usr/bin/env bash
 # Vaner SessionStart hook.
 #
-# Detects whether the `vaner` CLI is on PATH. If present, exits silently so the
-# bundled MCP server can start. If missing, emits SessionStart additionalContext
-# pointing the user at the canonical installer and the `/vaner:install` skill.
+# On every session:
+#   1. Detect whether the `vaner` CLI is on PATH.
+#   2. Emit SessionStart additionalContext with:
+#        - the canonical Vaner usage primer when vaner is installed, so the
+#          model actually uses the MCP tools well (prepared context early,
+#          search/expand as fallback/branch, feedback at the end), or
+#        - installer pointers (the curl one-liner and `/vaner:install`) when
+#          the CLI is missing so the MCP server can't start.
 # Never auto-runs network fetches; always exits 0 so session startup is not
 # blocked.
 set -u
 
-if command -v vaner >/dev/null 2>&1; then
-  exit 0
-fi
+# Located relative to the plugin root. `${CLAUDE_PLUGIN_ROOT}` is exported by
+# Claude Code when the hook is invoked from the plugin loader.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+PRIMER_FILE="${PLUGIN_ROOT}/prompts/agent-primer.md"
 
 # Python 3.8+ is ubiquitous on macOS/Linux; Vaner itself requires 3.11+. Using
 # python3 avoids taking a jq dependency just to build a small JSON document.
+if command -v vaner >/dev/null 2>&1; then
+  # vaner on PATH — inject the canonical primer so the model uses Vaner well.
+  if [[ ! -f "${PRIMER_FILE}" ]]; then
+    # Primer missing (should never happen in a properly shipped plugin).
+    # Exit silently rather than disrupting the session.
+    exit 0
+  fi
+  PRIMER_FILE="${PRIMER_FILE}" python3 - <<'PY'
+import json
+import os
+import sys
+
+primer = open(os.environ["PRIMER_FILE"], encoding="utf-8").read().strip()
+
+payload = {
+    "continue": True,
+    "suppressOutput": True,
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": primer,
+    },
+}
+
+json.dump(payload, sys.stdout)
+sys.stdout.write("\n")
+PY
+  exit 0
+fi
+
+# vaner NOT on PATH — point the user at the installer.
 python3 - <<'PY'
 import json
 import sys

--- a/plugins/vaner/skills/next/SKILL.md
+++ b/plugins/vaner/skills/next/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: next
+description: Show the top candidate next moves Vaner has prepared context for. Use when the user asks "what's next?", "what should I look at?", or wants a list of good next tasks backed by Vaner's predictive context. Renders as numbered cards with label, why-now reasoning, and a confidence/readiness hint.
+---
+
+When the user invokes `/vaner:next`, surface the most-ready next candidates Vaner has prepared:
+
+1. Call `mcp__vaner__suggest` with a small `limit` (default: 3, cap at 5) to fetch the top intent suggestions. If the user passed arguments to `/vaner:next`, use them as a focus hint (e.g., `/vaner:next auth` → pass `focus: "auth"`).
+2. If a top suggestion looks actionable, also call `mcp__vaner__resolve` for it to pull the prepared context package (capture the `resolution_id` for later `mcp__vaner__feedback`).
+3. Render the results as **numbered candidate cards**, one per suggestion, with three pieces:
+
+   - **Label** — short, imperative phrasing of the candidate (e.g., "Trace the auth middleware chain", "Review the cockpit scenario cluster").
+   - **Why now** — one line on what makes this candidate relevant in the current state (recent edits, open scenarios, unresolved decisions, signals Vaner is tracking).
+   - **Readiness / confidence** — one line on how prepared Vaner is for it: confidence score, cache tier, or evidence count if `mcp__vaner__resolve` was called; otherwise the `vaner.suggest` score alone.
+
+   Example format:
+
+   ```
+   1. **Trace the auth middleware chain**
+      Why now: edits in src/auth/ today; Vaner has a prepared scenario covering session-token flow.
+      Readiness: confidence 0.82, 7 evidence items, cache tier: warm.
+      Pick: `/vaner:next 1` or ask "help me with #1".
+   ```
+
+4. After rendering, ask the user to pick a number (or describe a different task). If they pick, use the captured `resolution_id` to continue — do not re-call `vaner.resolve` for the same candidate.
+
+Do not render raw prediction dumps or invent readiness information Vaner didn't supply. If `mcp__vaner__suggest` returns no candidates, say so plainly and suggest running `vaner up` or checking `mcp__vaner__status` for daemon readiness rather than fabricating suggestions.
+
+This skill is a structured presenter for predictions; it is not a planner. Skip it entirely if the user is already mid-task or has given a concrete instruction.

--- a/scripts/sync-plugin-primer.sh
+++ b/scripts/sync-plugin-primer.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Keep plugins/vaner/prompts/agent-primer.md byte-identical to the canonical
+# copy under src/vaner/defaults/prompts/. The plugin is cached to
+# ~/.claude/plugins/cache/ by Claude Code, so it must vendor its own copy
+# rather than symlink across the tree. CI enforces parity.
+set -euo pipefail
+
+SRC="src/vaner/defaults/prompts/agent-primer.md"
+DST="plugins/vaner/prompts/agent-primer.md"
+
+usage() {
+  echo "usage: $0 --check | --write" >&2
+  exit 2
+}
+
+[[ $# -eq 1 ]] || usage
+
+case "$1" in
+  --check)
+    if [[ ! -f "$DST" ]]; then
+      echo "missing: $DST (run: $0 --write)" >&2
+      exit 1
+    fi
+    if ! diff -q "$SRC" "$DST" >/dev/null; then
+      echo "out of sync: $SRC vs $DST" >&2
+      echo "run: $0 --write" >&2
+      exit 1
+    fi
+    ;;
+  --write)
+    mkdir -p "$(dirname "$DST")"
+    cp "$SRC" "$DST"
+    ;;
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
## Summary

Completes the primer integration from #131 on the Claude Code plugin side.

- SessionStart hook now injects the canonical primer from `src/vaner/defaults/prompts/agent-primer.md` (vendored into `plugins/vaner/prompts/`) as `hookSpecificOutput.additionalContext` on every new or resumed session when `vaner` is on PATH. Previously silent on that branch. Missing-binary branch unchanged.
- Adds `/vaner:next` skill: structured numbered cards (label / why-now / readiness hint) over `mcp__vaner__suggest` + `mcp__vaner__resolve`, explicitly not a raw prediction dump.
- Adds `scripts/sync-plugin-primer.sh` for canonical ↔ vendored parity, gated by pre-commit + CI. Same pattern as `sync-plugin-skill.sh`; symlinks would break after Claude Code copies the plugin to `~/.claude/plugins/cache/`.

After this lands, the canonical primer has two consumers:

1. `vaner init` per-client rules files (Claude Code's `.claude/CLAUDE.md`, Cursor's `.cursor/rules/vaner.mdc`, Copilot's `.github/copilot-instructions.md`, Codex CLI's `AGENTS.md`, Cline's `.clinerules`, Continue's `.continue/rules/vaner.md`) — from #131.
2. The plugin's SessionStart hook — this PR.

One source of truth; both surfaces teach the model from it.

## Dependencies

This PR stacks on:

- #130 (\`claude-plugin-packaging\`): the plugin scaffolding (MCP wiring, manifest, hook, vaner-feedback/install skills, marketplace catalog, validate-claude-plugin workflow).
- #131 (\`primer-init-integration\`): the canonical \`agent-primer.md\` and \`vaner init\`'s per-client primer writes.

Both parents are merged into this branch so the working tree is complete. When #130 and #131 both land on main, this branch will rebase cleanly down to the two final commits added here (merge + feature commit). **Draft** until both parents merge.

## Test plan

Added to \`.github/workflows/validate-claude-plugin.yml\`:

- Primer parity check (\`scripts/sync-plugin-primer.sh --check\`).
- New **vaner-present** hook smoke: fakes a \`vaner\` binary on PATH, sets \`CLAUDE_PLUGIN_ROOT\`, runs the hook, and asserts the emitted \`additionalContext\` contains the canonical primer signatures (\`Using Vaner\`, \`vaner.resolve\`, \`vaner.feedback\`).
- Strengthens the existing **vaner-missing** hook smoke to assert it mentions \`install.sh\`.

Pre-commit: new local \`vaner-plugin-primer-parity\` hook; passes clean, fails correctly when the canonical or vendored primer is perturbed.

Verified locally:

\`\`\`
claude plugin validate ./plugins/vaner                           # clean
pre-commit run vaner-plugin-primer-parity --all-files            # Passed
pytest tests -m "not slow and not integration" --no-cov          # 347 pass, 13 skipped, 0 regressions
\`\`\`

End-to-end: launched a real session with \`claude --plugin-dir ./plugins/vaner --print\` and asked the model what guidance it received. It quoted the principle verbatim:

> "Use Vaner when it can reduce uncertainty, prepare likely context, or continue an existing path. Do not call it mechanically when the task is trivial or self-contained."

That confirms the primer lands in the model's context on session open, without the model needing any prompt engineering to use it.

## Why the \`/vaner:next\` skill shape

Terminal plugins can't draw clickable cards — that UX belongs in the VSCode cockpit webview, and is deliberately out of scope here. The skill is the terminal-native equivalent: structured numbered output with three actionable pieces per candidate (label, why-now, readiness/confidence), scoped to top-N ≤ 5 to stay scannable. When a candidate is actionable the skill captures the \`resolution_id\` from \`mcp__vaner__resolve\` so downstream \`mcp__vaner__feedback\` closes the loop.

The skill is explicit about what NOT to do: no raw prediction dumps, no fabricated readiness hints, no auto-invocation mid-task. It's a presenter, not a planner.

## Not in this PR

- Clickable prediction cards — staying in the VSCode cockpit where a real UI surface exists.
- Primer surfaces for Claude Desktop, Windsurf, Zed, Roo — no well-defined injection surface today; deferred (see #131's rationale).
- Plugin monitors for the daemon decision stream — watching how \`/vaner:next\` usage lands before adding more notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)