### PR TITLE
fix(plugin): follow-up from live-test findings

### DIFF
--- a/.cursor/skills/vaner/vaner-feedback/SKILL.md
+++ b/.cursor/skills/vaner/vaner-feedback/SKILL.md
@@ -10,6 +10,6 @@ x-vaner-managed: true
 
 Use this skill when finishing a task that used Vaner MCP scenarios.
 
-1. Keep scenario ids returned by list/get/expand calls.
-2. Call report_outcome with id, result (useful|partial|irrelevant), optional note.
-3. Set skill to vaner-feedback for attribution.
+1. Keep the `resolution_id` returned by `vaner.resolve`, and note any item ids you want to praise or reject from `vaner.expand` / `vaner.search`.
+2. Call `vaner.feedback` with `rating` (`useful` | `partial` | `wrong` | `irrelevant`) and include `resolution_id` plus any optional `correction`, `preferred_items`, or `rejected_items`.
+3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and improve future scenario ranking.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,16 @@ The Claude Code plugin lives under `plugins/vaner/` and is catalogued by `.claud
 
 Claude Code uses `plugin.json::version` to decide whether to propagate updates to installed users, so a missed bump strands everyone on the previous version. CI fails the PR if either parity check fails.
 
+### Version parity with the installed CLI
+
+The plugin's primer and `/vaner:next` skill target the v1.0 MCP tool surface introduced in Vaner **0.6.0** (`vaner.status`, `vaner.resolve`, `vaner.search`, `vaner.suggest`, `vaner.expand`, `vaner.feedback`, …). Users on v0.5.x or older expose the legacy 5-tool surface (`list_scenarios`, `expand_scenario`, `compare_scenarios`, `get_scenario`, `report_outcome`) and the primer's tool references will not resolve.
+
+Before announcing the plugin to the Anthropic marketplace or cutting a new release tag, confirm:
+
+1. PyPI has a `vaner` build at or above the tool-surface floor (currently 0.6.0).
+2. The installer (`scripts/install.sh`) default pin resolves to that build.
+3. `claude --plugin-dir ./plugins/vaner mcp list` succeeds against a fresh install.
+
 ## Dependency and Supply-Chain Hygiene
 
 Direct dependencies are declared in `pyproject.toml`.

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -56,6 +56,42 @@ rm -rf ~/.claude/skills/vaner
 
 For Cursor, Codex CLI, and other clients that don't support Claude Code plugins, continue using `vaner init` / the per-client instructions at [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp).
 
+## Running in scripted / non-interactive mode
+
+`claude --print` mode defaults to denying MCP tool calls that would require a permission prompt. Plugin MCP tools fall into that category. When scripting — benchmarks, CI checks, shell automations — grant the tools explicitly:
+
+```bash
+# Fastest, trust-everything approach (local shell scripts):
+claude --plugin-dir ./plugins/vaner --permission-mode bypassPermissions --print "…"
+
+# Surgical — only allow Vaner's MCP tools (recommended for CI):
+claude --plugin-dir ./plugins/vaner \
+  --allowedTools "mcp__plugin_vaner_vaner__*" \
+  --print "/vaner:next"
+```
+
+### MCP tool naming
+
+The canonical primer (`src/vaner/defaults/prompts/agent-primer.md`) and the `/vaner:next` skill refer to tools by their conceptual names: `vaner.status`, `vaner.resolve`, `vaner.search`, `vaner.suggest`, `vaner.expand`, `vaner.feedback`, `vaner.explain`, `vaner.warm`, `vaner.inspect`, `vaner.debug.trace`.
+
+Claude Code exposes plugin MCP tools with a namespaced prefix: `mcp__plugin_<plugin-name>_<server-name>__<tool>`. For the Vaner plugin that resolves to `mcp__plugin_vaner_vaner__vaner.status`, `mcp__plugin_vaner_vaner__vaner.resolve`, and so on. Confirm the exact names in a session with:
+
+```bash
+claude --plugin-dir ./plugins/vaner mcp list
+```
+
+(Expect `plugin:vaner:vaner: vaner mcp - ✓ Connected`.)
+
+The model generally maps the conceptual names to the prefixed names without help, but if you're writing automation that invokes tools by name, use the prefixed form directly.
+
+### Required CLI version
+
+The plugin targets the v1.0 MCP tool surface introduced in Vaner **0.6.0**. Older installs (0.5.x and below) expose a legacy 5-tool surface (`list_scenarios`, `get_scenario`, `expand_scenario`, `compare_scenarios`, `report_outcome`) — the primer's tool references will not match and the `/vaner:next` skill will not find the tools it expects. Check with `vaner --help` (look for `suggest`, `resolve`, and `feedback` subcommands) and upgrade via the canonical installer if needed:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash -s -- --yes
+```
+
 ## Troubleshooting
 
 - **`/mcp` does not show a `vaner` server.** Confirm `command -v vaner` works in the same shell you launched Claude Code from. The plugin's `.mcp.json` calls `vaner` directly; if it isn't on PATH, the server cannot start and the SessionStart hook will have told you so at session start.

--- a/plugins/vaner/prompts/agent-primer.md
+++ b/plugins/vaner/prompts/agent-primer.md
@@ -6,7 +6,7 @@ Use Vaner when it can reduce uncertainty, prepare likely context, or continue an
 
 Operational patterns:
 
-1. **Prepared context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
+1. **Prepare context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
 2. **Fallback and branches.** Use `vaner.search` when `vaner.resolve` confidence is weak or the task requires a retrieval style it did not cover. Use `vaner.expand` to explore adjacent scenarios without recomputing everything.
 3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
 

--- a/plugins/vaner/scripts/check-vaner.sh
+++ b/plugins/vaner/scripts/check-vaner.sh
@@ -56,9 +56,11 @@ import sys
 
 message = (
     "The Vaner plugin is enabled, but the `vaner` CLI is not on PATH, so the "
-    "bundled MCP server cannot start. Vaner provides predictive context tools "
-    "(`mcp__vaner__search`, `mcp__vaner__resolve`, `mcp__vaner__expand`, "
-    "`mcp__vaner__feedback`, and more).\n\n"
+    "bundled MCP server cannot start. Once installed, Vaner will expose "
+    "predictive context tools through Claude Code's MCP plugin namespace "
+    "(`mcp__plugin_vaner_vaner__vaner.resolve`, "
+    "`mcp__plugin_vaner_vaner__vaner.search`, "
+    "`mcp__plugin_vaner_vaner__vaner.feedback`, and more).\n\n"
     "To install Vaner, the user can run:\n\n"
     "    curl -fsSL https://vaner.ai/install.sh | bash -s -- --yes\n\n"
     "Or, with explicit consent, invoke `/vaner:install` which wraps the same "

--- a/src/vaner/defaults/prompts/agent-primer.md
+++ b/src/vaner/defaults/prompts/agent-primer.md
@@ -6,7 +6,7 @@ Use Vaner when it can reduce uncertainty, prepare likely context, or continue an
 
 Operational patterns:
 
-1. **Prepared context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
+1. **Prepare context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
 2. **Fallback and branches.** Use `vaner.search` when `vaner.resolve` confidence is weak or the task requires a retrieval style it did not cover. Use `vaner.expand` to explore adjacent scenarios without recomputing everything.
 3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
 


### PR DESCRIPTION
## Summary

Five small fixes discovered during the live end-to-end test from the #132 thread. Each came from real test evidence, not speculation.

| # | Fix | Why |
|---|-----|-----|
| F1 | Primer grammar: "Prepared context early" → "Prepare context early" | `/vaner:next` card-pick flow flagged the past-participle/imperative mix |
| F2 | Docs: "Running in scripted / non-interactive mode" section | `--print` mode denies plugin MCP tools by default; undocumented footgun |
| F3 | Version-parity note in CONTRIBUTING + docs | Primer targets v0.6.0+ tool surface; older installs have legacy names |
| F4 | Hook missing-binary message previews `mcp__plugin_vaner_vaner__*` (correct) instead of `mcp__vaner__*` (wrong) | Actual Claude Code namespacing format |
| F5 | Dogfood skill (`.cursor/skills/vaner/vaner-feedback/SKILL.md`) updated to match canonical | Committed repo copy was stuck on v0.2.0 `list/get/expand` + `report_outcome` |

## Stack

Stacks on #132 → #131 → #130 (all three still open). Rebases cleanly onto main when they land; no conflicts expected.

## Test plan

Verified locally on branch `live-test-fixes`:

- \`ruff check .\` / \`ruff format --check .\` — clean
- \`bash scripts/sync-plugin-primer.sh --check\` — OK (parity preserved after fix)
- \`bash scripts/sync-plugin-skill.sh --check\` — OK
- \`bash scripts/bump-plugin-version.sh --check\` — OK
- \`claude plugin validate ./plugins/vaner\` — clean
- \`pytest tests/test_cli/test_primer.py tests/test_cli/test_init.py --no-cov\` — 26/26 pass

Hook smoke tests (two branches):

- **Missing binary**: \`PATH=/tmp:/usr/bin:/bin bash plugins/vaner/scripts/check-vaner.sh\` → emits JSON whose \`additionalContext\` contains \`mcp__plugin_vaner_vaner__\` (namespaced correctly) and \`install.sh\`.
- **Vaner present**: \`CLAUDE_PLUGIN_ROOT="\$PWD/plugins/vaner" bash plugins/vaner/scripts/check-vaner.sh\` → emits the canonical primer containing "Prepare context early" (reflects the F1 fix).

## Files

- \`src/vaner/defaults/prompts/agent-primer.md\` — F1
- \`plugins/vaner/prompts/agent-primer.md\` — F1 (parity re-sync)
- \`docs/claude-plugin.md\` — F2 + F3
- \`CONTRIBUTING.md\` — F3
- \`plugins/vaner/scripts/check-vaner.sh\` — F4
- \`.cursor/skills/vaner/vaner-feedback/SKILL.md\` — F5

## What's next

Two follow-up PRs drafted to stack on this one:

- **#134** — plugin monitor tailing \`.vaner/memory/log.md\` + dynamic cockpit-link injection when daemon reachable + tool-name prefixing note in primer.
- **#135** — wire \`exploration_concurrency\` (P1) + idle-aware concurrency ramp (P3) + multi-endpoint round-robin (P5) for ponder parallelism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)