### PR TITLE
feat(plugin): live scenario monitor + cockpit-link injection + tool-name note

### DIFF
--- a/.cursor/skills/vaner/vaner-feedback/SKILL.md
+++ b/.cursor/skills/vaner/vaner-feedback/SKILL.md
@@ -10,6 +10,6 @@ x-vaner-managed: true
 
 Use this skill when finishing a task that used Vaner MCP scenarios.
 
-1. Keep scenario ids returned by list/get/expand calls.
-2. Call report_outcome with id, result (useful|partial|irrelevant), optional note.
-3. Set skill to vaner-feedback for attribution.
+1. Keep the `resolution_id` returned by `vaner.resolve`, and note any item ids you want to praise or reject from `vaner.expand` / `vaner.search`.
+2. Call `vaner.feedback` with `rating` (`useful` | `partial` | `wrong` | `irrelevant`) and include `resolution_id` plus any optional `correction`, `preferred_items`, or `rejected_items`.
+3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and improve future scenario ranking.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,16 @@ The Claude Code plugin lives under `plugins/vaner/` and is catalogued by `.claud
 
 Claude Code uses `plugin.json::version` to decide whether to propagate updates to installed users, so a missed bump strands everyone on the previous version. CI fails the PR if either parity check fails.
 
+### Version parity with the installed CLI
+
+The plugin's primer and `/vaner:next` skill target the v1.0 MCP tool surface introduced in Vaner **0.6.0** (`vaner.status`, `vaner.resolve`, `vaner.search`, `vaner.suggest`, `vaner.expand`, `vaner.feedback`, …). Users on v0.5.x or older expose the legacy 5-tool surface (`list_scenarios`, `expand_scenario`, `compare_scenarios`, `get_scenario`, `report_outcome`) and the primer's tool references will not resolve.
+
+Before announcing the plugin to the Anthropic marketplace or cutting a new release tag, confirm:
+
+1. PyPI has a `vaner` build at or above the tool-surface floor (currently 0.6.0).
+2. The installer (`scripts/install.sh`) default pin resolves to that build.
+3. `claude --plugin-dir ./plugins/vaner mcp list` succeeds against a fresh install.
+
 ## Dependency and Supply-Chain Hygiene
 
 Direct dependencies are declared in `pyproject.toml`.

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -56,6 +56,42 @@ rm -rf ~/.claude/skills/vaner
 
 For Cursor, Codex CLI, and other clients that don't support Claude Code plugins, continue using `vaner init` / the per-client instructions at [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp).
 
+## Running in scripted / non-interactive mode
+
+`claude --print` mode defaults to denying MCP tool calls that would require a permission prompt. Plugin MCP tools fall into that category. When scripting — benchmarks, CI checks, shell automations — grant the tools explicitly:
+
+```bash
+# Fastest, trust-everything approach (local shell scripts):
+claude --plugin-dir ./plugins/vaner --permission-mode bypassPermissions --print "…"
+
+# Surgical — only allow Vaner's MCP tools (recommended for CI):
+claude --plugin-dir ./plugins/vaner \
+  --allowedTools "mcp__plugin_vaner_vaner__*" \
+  --print "/vaner:next"
+```
+
+### MCP tool naming
+
+The canonical primer (`src/vaner/defaults/prompts/agent-primer.md`) and the `/vaner:next` skill refer to tools by their conceptual names: `vaner.status`, `vaner.resolve`, `vaner.search`, `vaner.suggest`, `vaner.expand`, `vaner.feedback`, `vaner.explain`, `vaner.warm`, `vaner.inspect`, `vaner.debug.trace`.
+
+Claude Code exposes plugin MCP tools with a namespaced prefix: `mcp__plugin_<plugin-name>_<server-name>__<tool>`. For the Vaner plugin that resolves to `mcp__plugin_vaner_vaner__vaner.status`, `mcp__plugin_vaner_vaner__vaner.resolve`, and so on. Confirm the exact names in a session with:
+
+```bash
+claude --plugin-dir ./plugins/vaner mcp list
+```
+
+(Expect `plugin:vaner:vaner: vaner mcp - ✓ Connected`.)
+
+The model generally maps the conceptual names to the prefixed names without help, but if you're writing automation that invokes tools by name, use the prefixed form directly.
+
+### Required CLI version
+
+The plugin targets the v1.0 MCP tool surface introduced in Vaner **0.6.0**. Older installs (0.5.x and below) expose a legacy 5-tool surface (`list_scenarios`, `get_scenario`, `expand_scenario`, `compare_scenarios`, `report_outcome`) — the primer's tool references will not match and the `/vaner:next` skill will not find the tools it expects. Check with `vaner --help` (look for `suggest`, `resolve`, and `feedback` subcommands) and upgrade via the canonical installer if needed:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash -s -- --yes
+```
+
 ## Troubleshooting
 
 - **`/mcp` does not show a `vaner` server.** Confirm `command -v vaner` works in the same shell you launched Claude Code from. The plugin's `.mcp.json` calls `vaner` directly; if it isn't on PATH, the server cannot start and the SessionStart hook will have told you so at session start.

--- a/plugins/vaner/monitors/monitors.json
+++ b/plugins/vaner/monitors/monitors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "vaner-memory-log",
+    "command": "if [ -f .vaner/memory/log.md ]; then tail -n 0 -F .vaner/memory/log.md; else echo 'vaner-monitor: .vaner/memory/log.md not present yet; monitor will idle until daemon starts'; tail -f /dev/null; fi",
+    "description": "Vaner scenario events (resolve, expand, feedback, promotion/demotion) — one line per MCP call, surfaced as session notifications so the model stays aware of fresh scenario state.",
+    "when": "on-skill-invoke:next"
+  }
+]

--- a/plugins/vaner/prompts/agent-primer.md
+++ b/plugins/vaner/prompts/agent-primer.md
@@ -11,3 +11,5 @@ Operational patterns:
 3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
 
 Treat Vaner as a supplement, not a replacement for reading code. Skip it entirely for one-line changes, pure reformatting, or questions already answered in the open conversation.
+
+Your MCP client may prefix these tool names. For example, Claude Code exposes plugin MCP tools as `mcp__plugin_<plugin>_<server>__<tool>` — so `vaner.resolve` appears as `mcp__plugin_vaner_vaner__vaner.resolve`. The conceptual names in this document map directly to whatever prefix your client uses; no translation is needed when you reason about them, only when you call them.

--- a/plugins/vaner/prompts/agent-primer.md
+++ b/plugins/vaner/prompts/agent-primer.md
@@ -6,7 +6,7 @@ Use Vaner when it can reduce uncertainty, prepare likely context, or continue an
 
 Operational patterns:
 
-1. **Prepared context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
+1. **Prepare context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
 2. **Fallback and branches.** Use `vaner.search` when `vaner.resolve` confidence is weak or the task requires a retrieval style it did not cover. Use `vaner.expand` to explore adjacent scenarios without recomputing everything.
 3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
 

--- a/plugins/vaner/scripts/check-vaner.sh
+++ b/plugins/vaner/scripts/check-vaner.sh
@@ -56,9 +56,11 @@ import sys
 
 message = (
     "The Vaner plugin is enabled, but the `vaner` CLI is not on PATH, so the "
-    "bundled MCP server cannot start. Vaner provides predictive context tools "
-    "(`mcp__vaner__search`, `mcp__vaner__resolve`, `mcp__vaner__expand`, "
-    "`mcp__vaner__feedback`, and more).\n\n"
+    "bundled MCP server cannot start. Once installed, Vaner will expose "
+    "predictive context tools through Claude Code's MCP plugin namespace "
+    "(`mcp__plugin_vaner_vaner__vaner.resolve`, "
+    "`mcp__plugin_vaner_vaner__vaner.search`, "
+    "`mcp__plugin_vaner_vaner__vaner.feedback`, and more).\n\n"
     "To install Vaner, the user can run:\n\n"
     "    curl -fsSL https://vaner.ai/install.sh | bash -s -- --yes\n\n"
     "Or, with explicit consent, invoke `/vaner:install` which wraps the same "

--- a/plugins/vaner/scripts/check-vaner.sh
+++ b/plugins/vaner/scripts/check-vaner.sh
@@ -27,19 +27,30 @@ if command -v vaner >/dev/null 2>&1; then
     # Exit silently rather than disrupting the session.
     exit 0
   fi
-  PRIMER_FILE="${PRIMER_FILE}" python3 - <<'PY'
+
+  # Probe the cockpit. If the daemon is up, the model can point the user at the
+  # live pipeline view and reference scenario counts without extra tool calls.
+  # 1s timeout keeps SessionStart snappy even when the daemon is down.
+  cockpit_hint=""
+  if command -v curl >/dev/null 2>&1 && curl -sf -m 1 -o /dev/null http://127.0.0.1:8473/status 2>/dev/null; then
+    cockpit_hint=$'\n\nLive Vaner state is available at http://127.0.0.1:8473/ (cockpit is up). Mention this to the user if they ask about prediction state, scenario queue depth, or want to see the live pipeline view.'
+  fi
+
+  PRIMER_FILE="${PRIMER_FILE}" COCKPIT_HINT="${cockpit_hint}" python3 - <<'PY'
 import json
 import os
 import sys
 
 primer = open(os.environ["PRIMER_FILE"], encoding="utf-8").read().strip()
+cockpit_hint = os.environ.get("COCKPIT_HINT", "")
+additional_context = primer + cockpit_hint
 
 payload = {
     "continue": True,
     "suppressOutput": True,
     "hookSpecificOutput": {
         "hookEventName": "SessionStart",
-        "additionalContext": primer,
+        "additionalContext": additional_context,
     },
 }
 

--- a/src/vaner/defaults/prompts/agent-primer.md
+++ b/src/vaner/defaults/prompts/agent-primer.md
@@ -11,3 +11,5 @@ Operational patterns:
 3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
 
 Treat Vaner as a supplement, not a replacement for reading code. Skip it entirely for one-line changes, pure reformatting, or questions already answered in the open conversation.
+
+Your MCP client may prefix these tool names. For example, Claude Code exposes plugin MCP tools as `mcp__plugin_<plugin>_<server>__<tool>` — so `vaner.resolve` appears as `mcp__plugin_vaner_vaner__vaner.resolve`. The conceptual names in this document map directly to whatever prefix your client uses; no translation is needed when you reason about them, only when you call them.

--- a/src/vaner/defaults/prompts/agent-primer.md
+++ b/src/vaner/defaults/prompts/agent-primer.md
@@ -6,7 +6,7 @@ Use Vaner when it can reduce uncertainty, prepare likely context, or continue an
 
 Operational patterns:
 
-1. **Prepared context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
+1. **Prepare context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
 2. **Fallback and branches.** Use `vaner.search` when `vaner.resolve` confidence is weak or the task requires a retrieval style it did not cover. Use `vaner.expand` to explore adjacent scenarios without recomputing everything.
 3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
 


### PR DESCRIPTION
## Summary

Three quality improvements that extend the plugin beyond the core primer-plus-MCP surface.

### Q1. Plugin monitor (\`plugins/vaner/monitors/monitors.json\`)

When \`/vaner:next\` is first invoked in a session, the plugin monitor starts tailing \`.vaner/memory/log.md\`. Every subsequent MCP call (resolve/expand/feedback/promotion/demotion) appends a line there; \`tail -F\` pipes each new line to Claude Code as a session notification. The model stays aware of evolving scenario state mid-session.

Design choices:
- **\`when: "on-skill-invoke:next"\`** — the tail doesn't start at session-start, avoiding noise for sessions that never use Vaner.
- **Graceful idle** when the log file doesn't exist (daemon never started in this repo) — falls back to \`tail -f /dev/null\` so the plugin doesn't error out.
- **One line per MCP call** — already the shape \`.vaner/memory/log.md\` uses; monitor passes it through unchanged.

### Q2. Dynamic cockpit-link injection (\`plugins/vaner/scripts/check-vaner.sh\`)

The SessionStart hook now probes \`http://127.0.0.1:8473/status\` with a 1-second timeout. If the daemon's cockpit is reachable, one line is appended to the primer's \`additionalContext\`:

> Live Vaner state is available at http://127.0.0.1:8473/ (cockpit is up). Mention this to the user if they ask about prediction state, scenario queue depth, or want to see the live pipeline view.

When the daemon is down the probe fails silently and no hint is added. The canonical primer stays static; the environment-specific hint is injected dynamically. Hook still exits 0 unconditionally; session startup is never blocked on the probe.

### Q3. Tool-name prefixing note in the primer

One paragraph appended to the canonical primer explaining that Claude Code exposes plugin MCP tools as \`mcp__plugin_<plugin>_<server>__<tool>\`, so \`vaner.resolve\` appears as \`mcp__plugin_vaner_vaner__vaner.resolve\`. The live test found the model occasionally guessed at tool names under namespacing; this makes the mapping explicit in-context from turn zero. Parity-synced to the vendored copy.

## Stack

Stacks on #133 → #132 → #131 → #130. Opened as **draft** until the underlying PRs land.

## Test plan

Smoke tests (scripted, both in CI candidate form):

\`\`\`bash
# Daemon-down branch: no cockpit hint
CLAUDE_PLUGIN_ROOT="\$PWD/plugins/vaner" bash plugins/vaner/scripts/check-vaner.sh | \
  python3 -c 'import json,sys; d=json.load(sys.stdin); assert "http://127.0.0.1:8473" not in d["hookSpecificOutput"]["additionalContext"]'

# Daemon-up branch: cockpit hint lands after the primer
python3 -c "<fake HTTP on :8473/status>" &
CLAUDE_PLUGIN_ROOT="\$PWD/plugins/vaner" bash plugins/vaner/scripts/check-vaner.sh | \
  python3 -c 'import json,sys; d=json.load(sys.stdin); ctx=d["hookSpecificOutput"]["additionalContext"]; assert "http://127.0.0.1:8473" in ctx; assert ctx.rindex("8473") > ctx.rindex("questions already answered")'
\`\`\`

Both pass locally.

Other verification:
- \`claude plugin validate ./plugins/vaner\` — clean
- Primer parity, skill parity, version parity — all OK
- \`pytest tests/test_cli/test_primer.py --no-cov\` — 21/21 pass
- \`monitors.json\`: valid JSON, single entry, \`on-skill-invoke:next\` trigger

## Follow-up

- **#135** — ponder parallelism (P1 + P3 + P5): wire \`exploration_concurrency\` to an asyncio.Semaphore, idle-aware concurrency ramp, multi-endpoint round-robin with health tracking. Stacks on #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)