### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,9 +13,15 @@
       "name": "vaner",
       "source": "./plugins/vaner",
       "description": "MCP server, feedback skill, and bootstrap hook for Vaner.",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "category": "developer-tools",
-      "tags": ["mcp", "context", "retrieval", "scenarios", "vaner"],
+      "tags": [
+        "mcp",
+        "context",
+        "retrieval",
+        "scenarios",
+        "vaner"
+      ],
       "homepage": "https://vaner.ai",
       "repository": "https://github.com/Borgels/Vaner",
       "license": "Apache-2.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,42 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-22
+
 ### Added
 
+#### Claude Code plugin surface (supersedes manual MCP wiring for Claude Code)
+
+- Added a supported Claude Code plugin (`plugins/vaner/`) distributed via a same-repo marketplace at `.claude-plugin/marketplace.json`. Claude Code users can now install with `/plugin marketplace add Borgels/Vaner` followed by `/plugin install vaner@vaner`. Bundles the Vaner MCP server, the `vaner-feedback` skill (now namespaced as `/vaner:vaner-feedback`), a `/vaner:install` skill that wraps the canonical installer behind a Bash-tool permission prompt, and a SessionStart hook that reports when the `vaner` CLI is missing from PATH — otherwise injects the canonical Vaner usage primer on every session.
+- Added a `/vaner:next` skill in the plugin that calls `mcp__vaner__suggest` and renders top-N candidate next moves as structured numbered cards (label, why-now, confidence/readiness hint) rather than raw predictions. When Vaner's daemon is live the SessionStart hook also surfaces the cockpit URL (`http://127.0.0.1:8473/`) so the model can point the user at the live pipeline view.
+- Added a plugin monitor that tails `.vaner/memory/log.md` on first `/vaner:next` invocation, so the model stays aware of scenario events (resolve, feedback, promotion) mid-session.
+
+#### Canonical usage primer
+
 - Added per-client usage primers to `vaner init`. MCP wiring alone does not teach a model when and how to use Vaner; `init` now also installs a short guidance block into each detected client's native rules surface: `.claude/CLAUDE.md` (Claude Code), `.cursor/rules/vaner.mdc` (Cursor), `.github/copilot-instructions.md` (VS Code Copilot), `AGENTS.md` (Codex CLI), `.clinerules` (Cline), and `.continue/rules/vaner.md` (Continue). The primer is sourced from a single canonical file at `src/vaner/defaults/prompts/agent-primer.md` and wrapped client-specifically. Non-destructive: existing files get the primer appended in a delimited `<!-- vaner-primer:start … -->…<!-- vaner-primer:end -->` block that re-runs replace in place without touching surrounding content. Opt-out via `--no-primer`; `--user-primer` additionally writes the Claude Code primer at `~/.claude/CLAUDE.md` for always-on global guidance. Clients without a well-defined primer surface (Claude Desktop, Windsurf, Zed, Roo) are left as-is for this release.
+
+#### Ponder parallelism
+
 - Wired `compute.exploration_concurrency` (default 4) into the daemon's exploration loop. Previously a dead config — exposed by the cockpit UI and HTTP API but ignored by the engine. The scenario loop now runs up to `exploration_concurrency` LLM calls in parallel via an `asyncio.Semaphore`, with an `asyncio.Lock` guarding frontier mutations, follow-on branch pushes, and the covered-paths accumulator. Live benchmark on a single-GPU box with ollama 0.20.7 + `qwen2.5-coder:7b`: 9 scenarios in **140s at `exploration_concurrency=1` → 77s at `exploration_concurrency=4` (1.8× speedup)**. Server-side concurrency (vLLM natively, ollama with `OLLAMA_NUM_PARALLEL≥4`) determines the ceiling; a server that truly serializes requests will *degrade* below serial — a direct curl test against a single-slot backend measured 8 parallel calls as ~3× slower than 8 serial calls. The daemon emits a one-time `WARNING` log line whenever `exploration_concurrency > 1` reminding the operator to tune the server side. Individual scenario LLM failures no longer kill the whole cycle — they're logged and skipped. See `docs/performance.md` for the tuning ladder.
 - Added an idle-aware concurrency ramp. When `compute.idle_only = true`, the effective per-cycle concurrency now scales smoothly with current load (`max(1, int(exploration_concurrency × (1 − load)))`), so Vaner shares the machine gracefully under light foreground load instead of the previous binary "run at full speed or skip the cycle" behaviour. The hard idle-skip cutoff still applies above `idle_cpu_threshold` / `idle_gpu_threshold`.
 - Added multi-endpoint exploration routing. Set `exploration.endpoints = [...]` in `.vaner/config.toml` to dispatch exploration LLM calls across a pool of OpenAI-compatible endpoints (vLLM, remote ollama, LM Studio, etc.) via weighted round-robin. The pool tracks per-endpoint health (consecutive failures, total calls) and skips endpoints that have failed three or more times in a row for a 60-second cooldown before trying them half-open again. When `exploration.endpoints` is empty, behaviour is unchanged and Vaner uses the existing single-endpoint path.
+
+### Fixed
+
+- Fixed primer grammar: step 1 of the canonical primer now reads "Prepare context early" (imperative, parallel with steps 2 and 3) instead of "Prepared context early" — caught by Vaner's own `/vaner:next` card-pick flow during live testing.
+- Fixed the plugin's SessionStart hook preview of missing-binary tool names: now advertises the real Claude Code namespacing (`mcp__plugin_vaner_vaner__vaner.resolve`, etc.) instead of the pre-namespace form.
+- Fixed dogfood skill drift: `.cursor/skills/vaner/vaner-feedback/SKILL.md` in this repo was stuck on the v0.2.0 tool names (`list_scenarios`, `report_outcome`); now matches the canonical v0.6.x template.
+
+### Docs
+
+- Added `docs/performance.md` with the full ponder-throughput tuning ladder (`exploration_concurrency` → `OLLAMA_NUM_PARALLEL` → `CUDA_VISIBLE_DEVICES` multi-GPU → multi-endpoint pool) and an emphatic warning about raising concurrency without a concurrent backend.
+- Added a scripted / non-interactive mode section to `docs/claude-plugin.md` covering `--permission-mode bypassPermissions`, `--allowedTools`, the MCP tool naming convention, and the minimum CLI version (v0.6.0) required for the primer's tool references to resolve.
+- Added a CLI-version parity note to `CONTRIBUTING.md` for the plugin distribution.
+
+### CI
+
+- Added `.github/workflows/validate-claude-plugin.yml`: parity scripts (skill, primer, version), JSON well-formedness, hook smoke tests (both missing-binary and vaner-present branches), and `claude plugin validate`.
+- Added `.github/workflows/creds-tripwire.yml`: narrow `git grep` for known test-only credentials and private-infrastructure hostnames on every PR and push.
 
 ## [0.6.2] - 2026-04-21
 

--- a/plugins/vaner/.claude-plugin/plugin.json
+++ b/plugins/vaner/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaner",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Vaner: predictive context middleware for AI coding workflows. Bundles the Vaner MCP server (search, expand, resolve, feedback, and more), the vaner-feedback skill, and a SessionStart hook that checks for the `vaner` CLI.",
   "author": {
     "name": "Borgels Olsen Holding ApS",
@@ -10,5 +10,11 @@
   "homepage": "https://vaner.ai",
   "repository": "https://github.com/Borgels/Vaner",
   "license": "Apache-2.0",
-  "keywords": ["mcp", "context", "retrieval", "scenarios", "vaner"]
+  "keywords": [
+    "mcp",
+    "context",
+    "retrieval",
+    "scenarios",
+    "vaner"
+  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vaner"
-version = "0.6.2"
+version = "0.7.0"
 description = "Predictive context middleware layer for AI workflows."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts **v0.7.0** aggregating the merged work from #130 → #135:

### Big-ticket changes

- **Claude Code plugin** (`/plugin install vaner@vaner`) with MCP server, `/vaner:vaner-feedback`, `/vaner:install`, `/vaner:next`, SessionStart hook injecting the canonical primer (or install instructions if CLI missing), and a memory-log monitor.
- **Canonical Vaner usage primer** shipped into Claude Code, Cursor, Copilot, Codex CLI, Cline, and Continue via `vaner init`, and into the plugin SessionStart hook — one source of truth at `src/vaner/defaults/prompts/agent-primer.md`, non-destructive delimited-block merge into existing rules files.
- **Ponder parallelism**: `compute.exploration_concurrency` is no longer dead config. Live benchmark on a single-GPU ollama 0.20.7 / qwen2.5-coder:7b box measured **9 scenarios in 140s → 77s** going from concurrency 1 → 4 (1.8× speedup). Idle-aware ramp scales smoothly with load. Multi-endpoint routing with weighted round-robin and health tracking.

### Version parity

- \`pyproject.toml\`: 0.6.2 → **0.7.0**
- \`plugins/vaner/.claude-plugin/plugin.json\`: 0.6.2 → 0.7.0
- \`.claude-plugin/marketplace.json\` (both top-level metadata and plugin entry): 0.6.2 → 0.7.0

Enforced by \`scripts/bump-plugin-version.sh --check\` in pre-commit and CI.

### Release mechanics

After this PR merges, tag \`v0.7.0\` on the resulting main commit to trigger \`.github/workflows/release.yml\` (PyPI trusted publishing, GHCR, sigstore attestations, SBOM). See \`CONTRIBUTING.md\` → \"PyPI Trusted Publishing Checklist\".

### CHANGELOG

Full per-change notes under \`[0.7.0]\` in \`CHANGELOG.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)