### PR TITLE
feat(exploration): deep-drill on high-priority next-prompt predictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+#### Deep-drill on high-priority predictions
+
+- Added a high-priority deep-drill pathway to the exploration frontier. Scenarios whose *effective* priority clears `exploration.deep_drill_priority_threshold` (default `0.60`) are now treated as high-confidence next-prompt predictions and get more compute invested:
+  - `_explore_scenario_with_llm()` receives a `high_priority` flag and widens the LLM prompt to accept up to `exploration.deep_drill_max_followons` follow-on branches (default `5` vs. the original hard-coded `3`). The prompt is also tagged `[HIGH-PRIORITY]` so the model knows to invest effort in surfacing second-order context (callers, callees, tests, configuration) rather than stopping at breadth.
+  - Children of high-priority parents inherit a decrementing `depth_bonus` budget (default `2`). The frontier's admission gate now allows `depth > max_exploration_depth` by up to `depth_bonus` hops, so a promising lineage can drill past the base depth cap without raising the cap for the whole frontier. The bonus shrinks by 1 per LLM hop so the drill-down is bounded.
+  - High-priority branches use a softer `deep_drill_branch_decay` (default `0.88`) instead of the general `branch_priority_decay` (default `0.70`), so the deep line keeps ranking near the top of the heap instead of getting crowded out by fresh shallow seeds.
+- Fixed a latent bug in `_explore_scenario_with_llm`: the `if not callable(self.llm)` guard previously returned a 2-tuple where the declared return type expected a 4-tuple, which would have raised at the call site. Now returns `([], [], "", 0.0)`.
+
 ## [0.7.0] - 2026-04-22
 
 ### Added

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -808,6 +808,11 @@ class VanerEngine:
                     return
 
                 use_llm = self._should_use_llm(scenario, ecfg)
+                # High-priority scenarios (and anything already carrying a
+                # depth bonus from a high-priority ancestor) get wider LLM
+                # fan-out and softer per-hop decay so Vaner can invest more
+                # cycles on predictions it already scored as likely.
+                is_high_priority = scenario.priority >= ecfg.deep_drill_priority_threshold or scenario.depth_bonus > 0
                 llm_semantic_intent = ""
                 follow_on: list[dict[str, object]] = []
                 llm_confidence = 0.0
@@ -821,6 +826,7 @@ class VanerEngine:
                             recent_queries=recent_query_text,
                             covered_paths=covered_paths,
                             artefacts_by_key=artefacts_by_key,
+                            high_priority=is_high_priority,
                         )
                     except asyncio.CancelledError:
                         raise
@@ -850,6 +856,20 @@ class VanerEngine:
 
                 async with state_lock:
                     # Push follow-on branches (LLM confidence gates priority).
+                    # High-priority lineages use a softer decay and carry a
+                    # decrementing depth bonus so the deep line keeps ranking
+                    # near the top of the frontier instead of being crowded
+                    # out by fresh shallow seeds.
+                    if is_high_priority:
+                        branch_decay = ecfg.deep_drill_branch_decay
+                    else:
+                        branch_decay = self._scoring_policy.branch_priority_decay
+                    if scenario.priority >= ecfg.deep_drill_priority_threshold:
+                        # Fresh high-priority lineage: grant full bonus budget.
+                        child_depth_bonus = max(scenario.depth_bonus, ecfg.deep_drill_depth_bonus)
+                    else:
+                        # Inherited lineage: decrement the bonus each hop.
+                        child_depth_bonus = max(0, scenario.depth_bonus - 1)
                     for branch in follow_on:
                         branch_files_raw = branch.get("files", [])
                         if not isinstance(branch_files_raw, list):
@@ -859,7 +879,7 @@ class VanerEngine:
                             continue
                         branch_conf = float(branch.get("confidence", llm_confidence or 0.5))
                         branch_conf = max(0.1, min(1.0, branch_conf))
-                        branch_priority = scenario.priority * self._scoring_policy.branch_priority_decay * branch_conf
+                        branch_priority = scenario.priority * branch_decay * branch_conf
                         branch_scenario = ExplorationScenario(
                             id=file_set_fingerprint(branch_files),
                             file_paths=branch_files,
@@ -870,6 +890,7 @@ class VanerEngine:
                             parent_id=scenario.id,
                             reason=str(branch.get("reason", "")),
                             layer="operational",
+                            depth_bonus=child_depth_bonus,
                         )
                         frontier.push(branch_scenario)
 
@@ -1014,6 +1035,7 @@ class VanerEngine:
         recent_queries: list[str],
         covered_paths: set[str],
         artefacts_by_key: dict[str, object],
+        high_priority: bool = False,
     ) -> tuple[list[str], list[dict[str, object]], str, float]:
         """Send a scenario to the LLM for enrichment and branch proposals.
 
@@ -1034,7 +1056,7 @@ class VanerEngine:
         from vaner.intent.reasoner import _as_str_list
 
         if not callable(self.llm):
-            return [], []
+            return [], [], "", 0.0
 
         # Build brief artefact summaries for the scenario's files
         file_summaries: list[str] = []
@@ -1055,8 +1077,28 @@ class VanerEngine:
         uncovered = [p for p in available_paths if p not in covered_paths]
         available_hint = "\n".join(uncovered[:50]) or "none"
 
+        ecfg = self.config.exploration
+        if high_priority:
+            max_follow_on = max(3, int(ecfg.deep_drill_max_followons))
+            follow_on_guidance = (
+                f"2. THIS IS A HIGH-CONFIDENCE NEXT-PROMPT PREDICTION. Invest effort and\n"
+                f"   suggest 0-{max_follow_on} ADJACENT scenarios worth exploring. Cover the\n"
+                "   second-order context the developer will likely need if this prediction\n"
+                "   lands (direct callers, callees, tests, configuration, cross-cutting\n"
+                "   concerns). Prefer higher-confidence branches over breadth-for-its-own-sake.\n"
+            )
+            priority_tag = " [HIGH-PRIORITY]"
+        else:
+            max_follow_on = 3
+            follow_on_guidance = (
+                "2. Suggest 0-3 ADJACENT scenarios worth exploring: file sets NOT in this\n"
+                "   scenario that the developer might need as a consequence. Only suggest\n"
+                "   scenarios you are confident have high value.\n"
+            )
+            priority_tag = ""
+
         prompt = (
-            "You are a code-context exploration engine. Evaluate this scenario and decide "
+            f"You are a code-context exploration engine.{priority_tag} Evaluate this scenario and decide "
             "which files are most relevant and what adjacent scenarios are worth exploring next.\n\n"
             f"Developer context:\n"
             f"- Recent queries:\n{recent_hint}\n"
@@ -1070,9 +1112,7 @@ class VanerEngine:
             "Tasks:\n"
             "1. Rank these files by likely relevance to the developer's next interaction.\n"
             "   Drop any that seem irrelevant given the developer's trajectory.\n"
-            "2. Suggest 0-3 ADJACENT scenarios worth exploring: file sets NOT in this\n"
-            "   scenario that the developer might need as a consequence. Only suggest\n"
-            "   scenarios you are confident have high value.\n"
+            f"{follow_on_guidance}"
             "3. Write a short semantic_intent (1-2 sentences) describing what developer\n"
             "   need this scenario addresses (e.g. 'authentication middleware, JWT validation').\n"
             "   This is used for matching future queries to this cached context.\n"
@@ -1132,7 +1172,7 @@ class VanerEngine:
         raw_follow_on = obj.get("follow_on", [])
         if not isinstance(raw_follow_on, list):
             raw_follow_on = []
-        for item in raw_follow_on[:3]:
+        for item in raw_follow_on[:max_follow_on]:
             if not isinstance(item, dict):
                 continue
             files = [p for p in _as_str_list(item.get("files", [])) if p in available_set]

--- a/src/vaner/intent/frontier.py
+++ b/src/vaner/intent/frontier.py
@@ -106,6 +106,11 @@ class ExplorationScenario:
     parent_id: str | None = None  # which scenario spawned this one
     reason: str = ""  # why this scenario was proposed
     layer: str = "operational"  # strategic | tactical | operational
+    # Deep-drill support: extra depth budget inherited from a high-priority
+    # ancestor. When >0 the admission gate allows ``depth`` to exceed the
+    # frontier's configured ``max_depth`` by up to this many hops. Children
+    # decrement the bonus by 1 per LLM hop, so the drill-down is bounded.
+    depth_bonus: int = 0
 
     def is_trivial(self) -> bool:
         """True for cheap, structural graph-walk scenarios that skip the LLM."""
@@ -536,6 +541,7 @@ class ExplorationFrontier:
                     parent_id=scenario.parent_id,
                     reason=scenario.reason,
                     layer=scenario.layer,
+                    depth_bonus=max(existing.depth_bonus, scenario.depth_bonus),
                 )
                 self._pending[scenario.id] = upgraded
                 self._push_counter += 1
@@ -547,7 +553,11 @@ class ExplorationFrontier:
             return False  # was already pending
 
         effective_depth = getattr(self, "_effective_max_depth", self.max_depth)
-        if scenario.depth > effective_depth:
+        # High-priority lineages carry a bonus budget that raises the depth
+        # cap for that specific branch only. Admission still fails if the
+        # scenario depth exceeds cap + bonus, so the extension is bounded.
+        allowed_depth = effective_depth + max(0, scenario.depth_bonus)
+        if scenario.depth > allowed_depth:
             return False
 
         if effective_priority < self.min_priority:
@@ -573,6 +583,7 @@ class ExplorationFrontier:
             parent_id=scenario.parent_id,
             reason=scenario.reason,
             layer=scenario.layer,
+            depth_bonus=max(0, scenario.depth_bonus),
         )
         self._pending[scenario.id] = admitted_scenario
         self._pending_file_sets.append(file_set)

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -209,6 +209,43 @@ class ExplorationConfig(BaseModel):
     """
 
     # ------------------------------------------------------------------
+    # Deep-drill on high-priority predictions
+    # ------------------------------------------------------------------
+    # When a scenario's *effective* priority exceeds ``deep_drill_priority_threshold``
+    # Vaner treats it as a high-confidence next-prompt prediction and invests
+    # extra compute: more LLM follow-on branches, a depth-cap bonus that lets
+    # the lineage exceed ``max_exploration_depth``, and a softer per-hop decay
+    # so the deep line stays competitive in the frontier. Children inherit a
+    # decrementing bonus budget, so the drill-down is bounded.
+
+    deep_drill_priority_threshold: float = 0.60
+    """Effective-priority threshold (post source/layer multipliers) above
+    which a scenario is treated as a high-priority prediction worth deeper
+    exploration. ``1.01`` effectively disables deep-drill.
+    """
+
+    deep_drill_depth_bonus: int = 2
+    """Extra depth a high-priority lineage may explore beyond
+    ``max_exploration_depth``. The bonus decrements by 1 each LLM hop, so a
+    value of 2 lets one extra generation branch at full budget and one at
+    half budget before the frontier's regular depth cap reasserts.
+    """
+
+    deep_drill_max_followons: int = 5
+    """Max follow-on branches the LLM is allowed to propose for a
+    high-priority scenario (vs. the default 3 for normal scenarios). The LLM
+    prompt is widened accordingly; the frontier's admission gate still
+    dedups and filters.
+    """
+
+    deep_drill_branch_decay: float = 0.88
+    """Priority decay applied when pushing a follow-on branch from a
+    high-priority parent. The default (``0.88``) is gentler than the general
+    ``branch_priority_decay`` (``0.70``), so deep-drill lineages stay near
+    the top of the frontier instead of getting crowded out by fresh seeds.
+    """
+
+    # ------------------------------------------------------------------
     # Exploration LLM endpoint (separate from the user-facing backend)
     # ------------------------------------------------------------------
 

--- a/tests/test_engine/test_deep_drill.py
+++ b/tests/test_engine/test_deep_drill.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the high-priority deep-drill exploration behavior.
+
+Verifies that scenarios whose effective priority clears the configured
+``deep_drill_priority_threshold`` get:
+  1. A widened LLM follow-on prompt (up to ``deep_drill_max_followons`` branches).
+  2. A softer ``deep_drill_branch_decay`` applied to their children.
+  3. A decrementing depth-bonus budget that lets the lineage exceed
+     ``max_exploration_depth``.
+
+These rely on mocking the LLM so no external service is needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vaner.engine import VanerEngine
+from vaner.intent.adapter import CodeRepoAdapter
+from vaner.intent.frontier import ExplorationScenario, file_set_fingerprint
+
+
+@pytest.mark.asyncio
+async def test_deep_drill_widens_follow_on_cap(temp_repo: Path) -> None:
+    """A high-priority scenario should accept up to ``deep_drill_max_followons``."""
+
+    # Capture the prompt the LLM sees so we can assert on its shape.
+    captured: dict[str, str] = {}
+
+    async def _capturing_llm(prompt: str) -> str:
+        captured["prompt"] = prompt
+        # Return 5 follow-ons so we can verify the cap is enforced per scenario.
+        return (
+            '{"ranked_files": [], "semantic_intent": "", "confidence": 0.9, '
+            '"follow_on": ['
+            '{"files": ["a.py"], "reason": "r1", "confidence": 0.9},'
+            '{"files": ["b.py"], "reason": "r2", "confidence": 0.9},'
+            '{"files": ["c.py"], "reason": "r3", "confidence": 0.9},'
+            '{"files": ["d.py"], "reason": "r4", "confidence": 0.9},'
+            '{"files": ["e.py"], "reason": "r5", "confidence": 0.9}'
+            "]}"
+        )
+
+    adapter = CodeRepoAdapter(temp_repo)
+    engine = VanerEngine(adapter=adapter, llm=_capturing_llm)
+    engine.config.compute.idle_only = False
+    engine.config.exploration.llm_gate = "all"
+    engine.config.exploration.deep_drill_max_followons = 5
+
+    scenario = ExplorationScenario(
+        id=file_set_fingerprint(["sample.py"]),
+        file_paths=["sample.py"],
+        anchor="test",
+        source="graph",
+        priority=0.8,
+        depth=0,
+        reason="unit",
+    )
+
+    ranked, follow_on, _, _ = await engine._explore_scenario_with_llm(
+        scenario=scenario,
+        available_paths=["sample.py", "a.py", "b.py", "c.py", "d.py", "e.py"],
+        recent_queries=[],
+        covered_paths=set(),
+        artefacts_by_key={},
+        high_priority=True,
+    )
+
+    assert ranked == []
+    assert len(follow_on) == 5, f"expected 5 follow-ons, got {len(follow_on)}"
+    assert "HIGH-PRIORITY" in captured["prompt"]
+    assert "0-5" in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_normal_scenario_caps_follow_on_at_three(temp_repo: Path) -> None:
+    """Non-high-priority path keeps the original 0-3 follow-on cap."""
+
+    async def _llm(_prompt: str) -> str:
+        # 5 proposals; parser should drop to 3.
+        return (
+            '{"ranked_files": [], "semantic_intent": "", "confidence": 0.5, '
+            '"follow_on": ['
+            '{"files": ["a.py"], "reason": "r1", "confidence": 0.9},'
+            '{"files": ["b.py"], "reason": "r2", "confidence": 0.9},'
+            '{"files": ["c.py"], "reason": "r3", "confidence": 0.9},'
+            '{"files": ["d.py"], "reason": "r4", "confidence": 0.9},'
+            '{"files": ["e.py"], "reason": "r5", "confidence": 0.9}'
+            "]}"
+        )
+
+    adapter = CodeRepoAdapter(temp_repo)
+    engine = VanerEngine(adapter=adapter, llm=_llm)
+    engine.config.compute.idle_only = False
+    engine.config.exploration.llm_gate = "all"
+
+    scenario = ExplorationScenario(
+        id=file_set_fingerprint(["sample.py"]),
+        file_paths=["sample.py"],
+        anchor="test",
+        source="graph",
+        priority=0.3,
+        depth=0,
+        reason="unit",
+    )
+
+    _, follow_on, _, _ = await engine._explore_scenario_with_llm(
+        scenario=scenario,
+        available_paths=["sample.py", "a.py", "b.py", "c.py", "d.py", "e.py"],
+        recent_queries=[],
+        covered_paths=set(),
+        artefacts_by_key={},
+        high_priority=False,
+    )
+    assert len(follow_on) == 3
+
+
+def test_default_config_has_deep_drill_fields() -> None:
+    """Regression guard: the new config fields must be present + sane defaults."""
+    from vaner.models.config import ExplorationConfig
+
+    cfg = ExplorationConfig()
+    assert 0.0 <= cfg.deep_drill_priority_threshold <= 1.0
+    assert cfg.deep_drill_depth_bonus >= 0
+    assert cfg.deep_drill_max_followons >= 3
+    assert 0.0 < cfg.deep_drill_branch_decay <= 1.0

--- a/tests/test_intent/test_frontier.py
+++ b/tests/test_intent/test_frontier.py
@@ -165,6 +165,67 @@ def test_max_depth_rejection() -> None:
     assert not f.push(deep)
 
 
+def test_depth_bonus_allows_exceeding_base_depth_cap() -> None:
+    """High-priority lineages can exceed max_depth by their depth_bonus."""
+    f = ExplorationFrontier(max_depth=2, min_priority=0.01)
+    # depth=3 exceeds max_depth=2, but depth_bonus=2 raises the admission
+    # cap to 4, so this one is admitted.
+    deep = ExplorationScenario(
+        id=file_set_fingerprint(["deep.py"]),
+        file_paths=["deep.py"],
+        anchor="anc",
+        source="llm_branch",
+        priority=0.8,
+        depth=3,
+        reason="drill",
+        depth_bonus=2,
+    )
+    assert f.push(deep)
+    # depth=5 with bonus=2 (cap=4) should still be rejected — bonus is bounded.
+    too_deep = ExplorationScenario(
+        id=file_set_fingerprint(["toodeep.py"]),
+        file_paths=["toodeep.py"],
+        anchor="anc",
+        source="llm_branch",
+        priority=0.8,
+        depth=5,
+        reason="drill",
+        depth_bonus=2,
+    )
+    assert not f.push(too_deep)
+
+
+def test_depth_bonus_preserved_on_priority_upgrade() -> None:
+    """Pushing a higher-priority variant must not erase an existing bonus."""
+    f = ExplorationFrontier(max_depth=2, min_priority=0.01)
+    original = ExplorationScenario(
+        id=file_set_fingerprint(["same.py"]),
+        file_paths=["same.py"],
+        anchor="anc",
+        source="llm_branch",
+        priority=0.4,
+        depth=1,
+        reason="first",
+        depth_bonus=2,
+    )
+    assert f.push(original)
+    upgrade = ExplorationScenario(
+        id=file_set_fingerprint(["same.py"]),
+        file_paths=["same.py"],
+        anchor="anc",
+        source="llm_branch",
+        priority=0.9,
+        depth=1,
+        reason="second",
+        depth_bonus=0,  # deliberately lower
+    )
+    f.push(upgrade)
+    popped = f.pop()
+    assert popped is not None
+    # Pending entry should have retained the larger bonus.
+    assert popped.depth_bonus == 2
+
+
 def test_min_priority_rejection() -> None:
     f = ExplorationFrontier(min_priority=0.5)
     low = _scenario(["a.py"], priority=0.1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a bounded **deep-drill** pathway to the scenario exploration loop so Vaner invests more compute on predictions it already scores as likely next prompts — rather than treating the top of the frontier the same as the middle and moving on to the next seed.

When a scenario's *effective* priority clears `exploration.deep_drill_priority_threshold` (default `0.60`), the daemon now:

1. **Widens the LLM fan-out** to `exploration.deep_drill_max_followons` (default `5` vs. the old hard-coded `3`), and tags the prompt `[HIGH-PRIORITY]` so the model invests in surfacing second-order context (callers, callees, tests, configuration) instead of stopping at breadth.
2. **Grants a bounded depth-bonus budget** (default `2`). The frontier admission gate allows `depth > max_exploration_depth` by up to `depth_bonus` hops, so a promising lineage can drill past the base depth cap without raising the cap globally. Children decrement the budget by 1 per LLM hop so the drill-down is bounded.
3. **Softens the per-hop decay** to `deep_drill_branch_decay` (default `0.88`) instead of the general `branch_priority_decay` (default `0.70`), so the deep line keeps ranking near the top of the heap instead of getting crowded out by fresh shallow seeds.

## Why

The user flagged that Vaner could be better at working longer and more thoroughly on scenarios it already scored highly as likely next prompts. Before this change every scenario got the same treatment — same depth cap, same flat branch decay, same hard-coded cap of 3 LLM follow-on branches — so the engine would move on to the next seed rather than pressing further on a confident line.

The new knobs are all opt-in via config defaults that only activate above the priority threshold, so behavior under low-confidence seeds is unchanged.

## Implementation summary

- `src/vaner/models/config.py`: added `deep_drill_priority_threshold`, `deep_drill_depth_bonus`, `deep_drill_max_followons`, `deep_drill_branch_decay` to `ExplorationConfig` with documented defaults.
- `src/vaner/intent/frontier.py`: added `ExplorationScenario.depth_bonus`; `push()` now allows admission up to `effective_max_depth + depth_bonus` and preserves the bonus when upgrading an existing pending entry.
- `src/vaner/engine.py`:
  - `_explore_scenario_with_llm()` takes a `high_priority` flag that widens the follow-on cap and tags the prompt.
  - `_process_scenario()` detects high-priority scenarios (by effective priority or inherited bonus), applies `deep_drill_branch_decay` when pushing follow-ons, and propagates `depth_bonus` to children.
  - Also fixes a latent bug where the `not callable(self.llm)` guard returned a 2-tuple while the signature declared a 4-tuple.

## Test Plan

- [x] `ruff check .` on changed files (all pass)
- [x] `pytest tests/test_intent tests/test_engine tests/test_ponder_cap.py` — 107 passed, 1 pre-existing skip
- [x] `pytest` full suite — 370 passed, 14 pre-existing skips
- [x] New frontier tests: `depth_bonus` admission above cap + preservation on priority upgrade
- [x] New engine tests: high-priority LLM prompt includes `[HIGH-PRIORITY]` tag and widened follow-on cap; normal path still caps at three; config defaults are sane
- [ ] `mypy src` (not run — not exercised by base CI surface on this branch)
- [ ] DCO sign-off present (`Signed-off-by`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d58d182-5d7c-4a05-ac9a-e12adac14d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d58d182-5d7c-4a05-ac9a-e12adac14d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

