### PR TITLE
ci: pin unpinned actions and package installs (zizmor + Scorecard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,8 @@ jobs:
           python-version: "3.12"
       - name: Install build + pipx
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build pipx
+          python -m pip install "pip==26.0.1"
+          python -m pip install "build==1.4.3" "pipx==1.11.1"
           python -m pipx ensurepath
       - name: Build wheel
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
             cosign sign-blob --yes --bundle "${f}.sigstore.json" "$f"
           done
       - name: Attest SBOM
-        uses: actions/attest-sbom@v2
+        uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2
         with:
           subject-path: "dist/*"
           sbom-path: "sbom.json"

--- a/.github/workflows/validate-claude-plugin.yml
+++ b/.github/workflows/validate-claude-plugin.yml
@@ -44,7 +44,7 @@ jobs:
           node-version: "20"
 
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@latest
+        run: npm install -g @anthropic-ai/claude-code@2.1.117
 
       - name: Skill parity (defaults ↔ plugin)
         run: bash scripts/sync-plugin-skill.sh --check


### PR DESCRIPTION
## Summary

- Pins `actions/attest-sbom` to commit SHA `bd218ad0` (v2) — fixes zizmor `unpinned-uses` failure on every main push
- Pins `pip==26.0.1`, `build==1.4.3`, `pipx==1.11.1` in the `release-smoke` job — closes Scorecard alerts #208 and #209
- Pins `@anthropic-ai/claude-code@2.1.117` instead of `@latest` — closes Scorecard alert #212

## Test plan

- [ ] Actionlint / zizmor workflow passes on this PR
- [ ] CI passes
- [ ] After merge, `gh api repos/Borgels/vaner/code-scanning/alerts --jq '[.[] | select(.state=="open")]|length'` drops from 4 to 1 (alert #207 is a legitimate contents:write for release uploads, will be dismissed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)