### PR TITLE
feat(init): install per-client usage primers alongside MCP wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-- Added a supported Claude Code plugin (`plugins/vaner/`) distributed via a same-repo marketplace at `.claude-plugin/marketplace.json`. Claude Code users can now install Vaner with `/plugin marketplace add Borgels/Vaner` followed by `/plugin install vaner@vaner`. The plugin bundles the Vaner MCP server, the `vaner-feedback` skill (now namespaced as `/vaner:vaner-feedback`), a `/vaner:install` skill that wraps the canonical installer behind a Bash-tool permission prompt, and a SessionStart hook that reports when the `vaner` CLI is missing from PATH.
+- Added per-client usage primers to `vaner init`. MCP wiring alone does not teach a model when and how to use Vaner; `init` now also installs a short guidance block into each detected client's native rules surface: `.claude/CLAUDE.md` (Claude Code), `.cursor/rules/vaner.mdc` (Cursor), `.github/copilot-instructions.md` (VS Code Copilot), `AGENTS.md` (Codex CLI), `.clinerules` (Cline), and `.continue/rules/vaner.md` (Continue). The primer is sourced from a single canonical file at `src/vaner/defaults/prompts/agent-primer.md` and wrapped client-specifically. Non-destructive: existing files get the primer appended in a delimited `<!-- vaner-primer:start … -->…<!-- vaner-primer:end -->` block that re-runs replace in place without touching surrounding content. Opt-out via `--no-primer`; `--user-primer` additionally writes the Claude Code primer at `~/.claude/CLAUDE.md` for always-on global guidance. Clients without a well-defined primer surface (Claude Desktop, Windsurf, Zed, Roo) are left as-is for this release.
 
 ## [0.6.2] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ What `vaner init` does by default:
 - writes repo-local config to `.vaner/config.toml`
 - writes repo-local Cursor MCP wiring to `.cursor/mcp.json`
 - writes managed feedback skills to `.cursor/skills/vaner/vaner-feedback/SKILL.md` and `~/.claude/skills/vaner/vaner-feedback/SKILL.md`
+- installs per-client usage primers (short guidance about when and how to use Vaner) into each detected client's rules surface: `.claude/CLAUDE.md` (Claude Code), `.cursor/rules/vaner.mdc` (Cursor), `.github/copilot-instructions.md` (Copilot), `AGENTS.md` (Codex CLI), `.clinerules` (Cline), `.continue/rules/vaner.md` (Continue). Primers are non-destructive: existing files get a delimited `<!-- vaner-primer:start v=… -->…<!-- vaner-primer:end -->` block that re-runs replace in place without touching content outside it.
 
 Use `vaner init --no-mcp --path .` if you want config only and do not want Vaner to wire MCP clients or managed
-skills. If Cursor is already open, reload the window after `vaner init` so the new MCP server is picked up.
+skills. Use `--no-primer` to skip the client-level guidance. Use `--user-primer` to also install the Claude Code
+primer at `~/.claude/CLAUDE.md` (always-on across every session) in addition to the repo-level `.claude/CLAUDE.md`.
+If Cursor is already open, reload the window after `vaner init` so the new MCP server is picked up.
 
 Start / verify runtime:
 

--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -59,6 +59,7 @@ from vaner.cli.commands.init import (
 from vaner.cli.commands.inspect import inspect_decision as inspect_decision_output
 from vaner.cli.commands.inspect import inspect_last as inspect_last_output
 from vaner.cli.commands.inspect import list_decisions as list_decisions_output
+from vaner.cli.commands.primer import PRIMER_SURFACES, write_primers
 from vaner.cli.commands.profile import export_pins, import_pins, pin_fact, profile_show, unpin_fact
 from vaner.cli.commands.runtime_snapshot import runtime_snapshot
 from vaner.cli.commands.supervisor import run_down, run_up
@@ -494,6 +495,18 @@ def init(
         help="Overwrite existing backend config even if already populated.",
     ),
     no_mcp: bool = typer.Option(False, "--no-mcp", help="Skip writing MCP client config files"),
+    no_primer: bool = typer.Option(
+        False,
+        "--no-primer",
+        help="Skip installing per-client usage primers (guidance markdown for each detected MCP client).",
+    ),
+    user_primer: bool = typer.Option(
+        False,
+        "--user-primer",
+        help=(
+            "Also install the Claude Code primer at the user scope (~/.claude/CLAUDE.md) in addition to the repo scope (.claude/CLAUDE.md)."
+        ),
+    ),
 ) -> None:
     """Initialize Vaner in the current repo and (optionally) pick a model backend.
 
@@ -519,6 +532,28 @@ def init(
             typer.echo(f"Scaffolded MCP client configs using `{launcher_command}`")
         except Exception as exc:
             typer.echo(f"Warning: could not write MCP client configs: {exc}")
+
+    if not no_primer:
+        try:
+            supported = sorted(PRIMER_SURFACES.keys())
+            primer_results = write_primers(
+                supported,
+                repo_root,
+                include_user_scope=user_primer,
+            )
+            installed = [r for r in primer_results if r.action in ("added", "updated")]
+            skipped = [r for r in primer_results if r.action == "skipped"]
+            failed = [r for r in primer_results if r.action == "failed"]
+            if installed:
+                typer.echo("Installed per-client usage primers:")
+                for r in installed:
+                    typer.echo(f"  - {r.path} ({r.action})")
+            if skipped:
+                typer.echo(f"Primer already up to date for {len(skipped)} client(s); no changes needed.")
+            for r in failed:
+                typer.echo(f"Warning: could not write primer for {r.client_id}: {r.error}")
+        except Exception as exc:  # pragma: no cover - defensive
+            typer.echo(f"Warning: could not install primers: {exc}")
 
     import sys as _sys
 

--- a/src/vaner/cli/commands/primer.py
+++ b/src/vaner/cli/commands/primer.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Primer injection: install Vaner usage guidance into each MCP client.
+
+MCP wiring alone is not enough. The model also needs explicit guidance about
+when and how to use Vaner, otherwise usage stays weak and inconsistent. This
+module owns the per-client primer surfaces and a non-destructive merge
+primitive so that `vaner init` can install guidance alongside the MCP config.
+
+A single canonical primer lives at
+``src/vaner/defaults/prompts/agent-primer.md``. Per-client surfaces wrap it
+with whatever the client expects (plain markdown, `.mdc` with frontmatter,
+and so on).
+
+Existing files are respected: the primer is written into a clearly delimited
+block (``<!-- vaner-primer:start v=VERSION -->…<!-- vaner-primer:end -->``)
+that can be replaced in place on re-init without touching content outside
+the markers. Files with no existing block get the block appended; users who
+want custom wording can simply edit outside the markers.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal
+
+PrimerAction = Literal["added", "updated", "skipped", "unsupported", "failed"]
+
+PRIMER_BLOCK_START_PREFIX = "<!-- vaner-primer:start"
+PRIMER_BLOCK_END = "<!-- vaner-primer:end -->"
+# Cursor rules use HTML-hostile frontmatter; use a different marker there.
+CURSOR_BLOCK_START_PREFIX = "{/* vaner-primer:start"
+CURSOR_BLOCK_END = "{/* vaner-primer:end */}"
+
+
+class PrimerScope(StrEnum):
+    """Where a primer file lives relative to the user."""
+
+    REPO = "repo"
+    USER = "user"
+
+
+@dataclass(slots=True)
+class PrimerResult:
+    """Outcome of a single per-client primer write."""
+
+    client_id: str
+    scope: PrimerScope
+    path: Path | None
+    action: PrimerAction
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PrimerSurface:
+    """Declarative description of where and how to write a client's primer."""
+
+    # Resolves the target file for a scope, or None if the scope is not supported.
+    path: Callable[[Path, PrimerScope], Path | None]
+    # Renders the canonical primer body into the file's native format.
+    render: Callable[[str, str], str]  # (body, version) -> full-file body
+    # "block" merges into a possibly-existing file; "replace" owns the file.
+    strategy: Literal["block", "replace"]
+    # Which delimiter pair the block strategy uses.
+    marker_style: Literal["html", "cursor"] = "html"
+
+
+def _home() -> Path:
+    return Path.home()
+
+
+# ---------------------------------------------------------------------------
+# Canonical primer source
+# ---------------------------------------------------------------------------
+
+
+def load_canonical_primer() -> str:
+    """Read the canonical primer text shipped with the package."""
+    package_root = Path(__file__).resolve().parents[2]
+    primer_path = package_root / "defaults" / "prompts" / "agent-primer.md"
+    return primer_path.read_text(encoding="utf-8").rstrip() + "\n"
+
+
+def primer_version() -> str:
+    """Version string baked into primer block markers.
+
+    Tracks ``vaner.__version__`` so re-runs after a Vaner upgrade refresh the
+    block in place without surprising users.
+    """
+    try:
+        from vaner import __version__
+
+        return str(__version__)
+    except Exception:  # pragma: no cover - defensive
+        return "0"
+
+
+# ---------------------------------------------------------------------------
+# Delimited block merge primitive
+# ---------------------------------------------------------------------------
+
+
+def apply_primer_block(
+    content: str,
+    body: str,
+    *,
+    version: str,
+    marker_style: Literal["html", "cursor"] = "html",
+) -> tuple[str, PrimerAction]:
+    """Insert or replace the Vaner primer block inside ``content``.
+
+    The block is delimited by ``<!-- vaner-primer:start v=VERSION -->`` and
+    ``<!-- vaner-primer:end -->`` (or the cursor-compatible equivalents).
+    Returns the new content and an action describing what changed.
+    """
+    body = body.rstrip()
+    if marker_style == "cursor":
+        start_prefix = CURSOR_BLOCK_START_PREFIX
+        end_marker = CURSOR_BLOCK_END
+        start_line = f"{start_prefix} v={version} */}}"
+    else:
+        start_prefix = PRIMER_BLOCK_START_PREFIX
+        end_marker = PRIMER_BLOCK_END
+        start_line = f"{start_prefix} v={version} -->"
+
+    new_block = f"{start_line}\n{body}\n{end_marker}"
+
+    pattern = re.compile(
+        re.escape(start_prefix) + r".*?" + re.escape(end_marker),
+        flags=re.DOTALL,
+    )
+    match = pattern.search(content)
+    if match is not None:
+        existing = match.group(0)
+        if existing == new_block:
+            return content, "skipped"
+        replaced = content[: match.start()] + new_block + content[match.end() :]
+        return replaced, "updated"
+
+    if content.strip():
+        merged = content.rstrip("\n") + "\n\n" + new_block + "\n"
+        return merged, "added"
+    return new_block + "\n", "added"
+
+
+# ---------------------------------------------------------------------------
+# Per-client render functions
+# ---------------------------------------------------------------------------
+
+
+def _render_plain_block(body: str, version: str) -> str:
+    """Render a markdown file wrapping the primer in an HTML-comment block."""
+    return apply_primer_block("", body, version=version, marker_style="html")[0]
+
+
+def _render_cursor_mdc(body: str, version: str) -> str:
+    """Render a Cursor ``.mdc`` rules file with the required frontmatter.
+
+    Cursor rules files use YAML frontmatter followed by Markdown. We own the
+    file entirely (``strategy='replace'``) so frontmatter is static.
+    """
+    frontmatter = f"---\ndescription: Vaner usage primer (v={version})\nalwaysApply: true\n---\n"
+    return frontmatter + "\n" + body.rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Per-client path resolvers
+# ---------------------------------------------------------------------------
+
+
+def _path_claude_code(repo_root: Path, scope: PrimerScope) -> Path | None:
+    if scope == PrimerScope.REPO:
+        return repo_root / ".claude" / "CLAUDE.md"
+    return _home() / ".claude" / "CLAUDE.md"
+
+
+def _path_cursor(repo_root: Path, scope: PrimerScope) -> Path | None:
+    if scope != PrimerScope.REPO:
+        return None
+    return repo_root / ".cursor" / "rules" / "vaner.mdc"
+
+
+def _path_vscode_copilot(repo_root: Path, scope: PrimerScope) -> Path | None:
+    if scope != PrimerScope.REPO:
+        return None
+    return repo_root / ".github" / "copilot-instructions.md"
+
+
+def _path_codex(repo_root: Path, scope: PrimerScope) -> Path | None:
+    if scope != PrimerScope.REPO:
+        return None
+    return repo_root / "AGENTS.md"
+
+
+def _path_cline(repo_root: Path, scope: PrimerScope) -> Path | None:
+    if scope != PrimerScope.REPO:
+        return None
+    return repo_root / ".clinerules"
+
+
+def _path_continue(repo_root: Path, scope: PrimerScope) -> Path | None:
+    if scope != PrimerScope.REPO:
+        return None
+    return repo_root / ".continue" / "rules" / "vaner.md"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+PRIMER_SURFACES: dict[str, PrimerSurface] = {
+    "claude-code": PrimerSurface(
+        path=_path_claude_code,
+        render=_render_plain_block,
+        strategy="block",
+        marker_style="html",
+    ),
+    "cursor": PrimerSurface(
+        path=_path_cursor,
+        render=_render_cursor_mdc,
+        strategy="replace",
+        marker_style="html",  # unused for replace-strategy surfaces
+    ),
+    "vscode-copilot": PrimerSurface(
+        path=_path_vscode_copilot,
+        render=_render_plain_block,
+        strategy="block",
+        marker_style="html",
+    ),
+    "codex-cli": PrimerSurface(
+        path=_path_codex,
+        render=_render_plain_block,
+        strategy="block",
+        marker_style="html",
+    ),
+    "cline": PrimerSurface(
+        path=_path_cline,
+        render=_render_plain_block,
+        strategy="block",
+        marker_style="html",
+    ),
+    "continue": PrimerSurface(
+        path=_path_continue,
+        render=_render_plain_block,
+        strategy="replace",
+        marker_style="html",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-client writer
+# ---------------------------------------------------------------------------
+
+
+def write_primer_for_client(
+    client_id: str,
+    repo_root: Path,
+    *,
+    scope: PrimerScope = PrimerScope.REPO,
+    body: str | None = None,
+    version: str | None = None,
+    dry_run: bool = False,
+) -> PrimerResult:
+    """Write the Vaner primer into ``client_id``'s primer surface.
+
+    Non-destructive: existing files outside the primer block are preserved,
+    and identical-content writes are reported as ``skipped`` so repeated
+    ``vaner init`` invocations are idempotent.
+    """
+    surface = PRIMER_SURFACES.get(client_id)
+    if surface is None:
+        return PrimerResult(
+            client_id=client_id,
+            scope=scope,
+            path=None,
+            action="unsupported",
+        )
+
+    target = surface.path(repo_root, scope)
+    if target is None:
+        return PrimerResult(
+            client_id=client_id,
+            scope=scope,
+            path=None,
+            action="unsupported",
+        )
+
+    resolved_body = body if body is not None else load_canonical_primer()
+    resolved_version = version or primer_version()
+    rendered = surface.render(resolved_body, resolved_version)
+
+    try:
+        existing = target.read_text(encoding="utf-8") if target.exists() else ""
+    except OSError as exc:
+        return PrimerResult(
+            client_id=client_id,
+            scope=scope,
+            path=target,
+            action="failed",
+            error=str(exc),
+        )
+
+    if surface.strategy == "replace":
+        if existing == rendered:
+            return PrimerResult(client_id=client_id, scope=scope, path=target, action="skipped")
+        action: PrimerAction = "updated" if existing else "added"
+        new_content = rendered
+    else:
+        new_content, action = apply_primer_block(existing, resolved_body, version=resolved_version, marker_style=surface.marker_style)
+        if new_content == existing:
+            action = "skipped"
+
+    if action == "skipped" or dry_run:
+        return PrimerResult(client_id=client_id, scope=scope, path=target, action=action)
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(new_content, encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - defensive I/O guard
+        return PrimerResult(
+            client_id=client_id,
+            scope=scope,
+            path=target,
+            action="failed",
+            error=str(exc),
+        )
+    return PrimerResult(client_id=client_id, scope=scope, path=target, action=action)
+
+
+def write_primers(
+    client_ids: list[str],
+    repo_root: Path,
+    *,
+    include_user_scope: bool = False,
+    dry_run: bool = False,
+) -> list[PrimerResult]:
+    """Write the primer for each client in ``client_ids``.
+
+    Repo-scoped surfaces are written unconditionally. User-scoped surfaces
+    (currently only ``~/.claude/CLAUDE.md``) are written when
+    ``include_user_scope=True``.
+    """
+    body = load_canonical_primer()
+    version = primer_version()
+    results: list[PrimerResult] = []
+    for client_id in client_ids:
+        results.append(
+            write_primer_for_client(
+                client_id,
+                repo_root,
+                scope=PrimerScope.REPO,
+                body=body,
+                version=version,
+                dry_run=dry_run,
+            )
+        )
+        if include_user_scope and client_id == "claude-code":
+            results.append(
+                write_primer_for_client(
+                    client_id,
+                    repo_root,
+                    scope=PrimerScope.USER,
+                    body=body,
+                    version=version,
+                    dry_run=dry_run,
+                )
+            )
+    return results

--- a/src/vaner/defaults/prompts/agent-primer.md
+++ b/src/vaner/defaults/prompts/agent-primer.md
@@ -1,0 +1,13 @@
+# Using Vaner
+
+Vaner is a local-first predictive context engine available to you as an MCP server. It prepares evidence-backed context packages in the background and exposes them through the `vaner.*` tool family (`vaner.resolve`, `vaner.search`, `vaner.expand`, `vaner.suggest`, `vaner.feedback`, `vaner.status`, `vaner.explain`, `vaner.warm`, `vaner.inspect`, `vaner.debug.trace`).
+
+Use Vaner when it can reduce uncertainty, prepare likely context, or continue an existing path. Do not call it mechanically when the task is trivial or self-contained.
+
+Operational patterns:
+
+1. **Prepared context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
+2. **Fallback and branches.** Use `vaner.search` when `vaner.resolve` confidence is weak or the task requires a retrieval style it did not cover. Use `vaner.expand` to explore adjacent scenarios without recomputing everything.
+3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
+
+Treat Vaner as a supplement, not a replacement for reading code. Skip it entirely for one-line changes, pure reformatting, or questions already answered in the open conversation.

--- a/tests/test_cli/test_primer.py
+++ b/tests/test_cli/test_primer.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+from vaner.cli.commands.primer import (
+    PRIMER_BLOCK_END,
+    PRIMER_SURFACES,
+    PrimerScope,
+    apply_primer_block,
+    load_canonical_primer,
+    primer_version,
+    write_primer_for_client,
+    write_primers,
+)
+
+# ---------------------------------------------------------------------------
+# Merge primitive
+# ---------------------------------------------------------------------------
+
+
+def test_apply_primer_block_inserts_into_empty_content():
+    result, action = apply_primer_block("", "primer body", version="1.0")
+    assert action == "added"
+    assert result.startswith("<!-- vaner-primer:start v=1.0 -->")
+    assert result.rstrip().endswith(PRIMER_BLOCK_END)
+    assert "primer body" in result
+
+
+def test_apply_primer_block_appends_to_existing_content():
+    existing = "# Project Notes\n\nexisting text\n"
+    result, action = apply_primer_block(existing, "primer body", version="1.0")
+    assert action == "added"
+    # Existing content preserved verbatim at the top.
+    assert result.startswith("# Project Notes\n\nexisting text\n")
+    assert "<!-- vaner-primer:start" in result
+    assert "primer body" in result
+
+
+def test_apply_primer_block_replaces_existing_block():
+    first, _ = apply_primer_block("# Notes\n", "first body", version="1.0")
+    second, action = apply_primer_block(first, "second body", version="2.0")
+    assert action == "updated"
+    # Only one block present.
+    assert second.count("vaner-primer:start") == 1
+    assert "second body" in second
+    assert "first body" not in second
+    assert "v=2.0" in second
+    # Surrounding content still intact.
+    assert second.startswith("# Notes\n")
+
+
+def test_apply_primer_block_idempotent_on_identical_rewrite():
+    first, _ = apply_primer_block("# Notes\n", "same body", version="1.0")
+    second, action = apply_primer_block(first, "same body", version="1.0")
+    assert action == "skipped"
+    assert second == first
+
+
+def test_apply_primer_block_preserves_content_outside_block():
+    before = "top\n"
+    after_tail = "bottom\n"
+    seeded, _ = apply_primer_block(before, "BODY_V1", version="1.0")
+    user_edit = seeded + after_tail
+    rewritten, action = apply_primer_block(user_edit, "BODY_V2", version="2.0")
+    assert action == "updated"
+    # Both the top and the bottom user content survive the rewrite.
+    assert rewritten.startswith("top\n")
+    assert rewritten.rstrip().endswith("bottom")
+    # Exactly one block, with new body and new version marker.
+    assert rewritten.count("vaner-primer:start") == 1
+    assert "BODY_V2" in rewritten
+    assert "BODY_V1" not in rewritten
+    assert "v=2.0" in rewritten
+
+
+# ---------------------------------------------------------------------------
+# Per-client writer
+# ---------------------------------------------------------------------------
+
+
+def test_write_primer_for_client_claude_code_repo_scope(temp_repo):
+    result = write_primer_for_client("claude-code", temp_repo, scope=PrimerScope.REPO)
+    assert result.action == "added"
+    assert result.path == temp_repo / ".claude" / "CLAUDE.md"
+    content = result.path.read_text(encoding="utf-8")
+    assert "vaner-primer:start" in content
+    assert "Using Vaner" in content
+
+
+def test_write_primer_for_client_claude_code_user_scope(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_primer_for_client("claude-code", repo, scope=PrimerScope.USER)
+    assert result.action == "added"
+    assert result.path == fake_home / ".claude" / "CLAUDE.md"
+
+
+def test_write_primer_for_client_cursor_uses_mdc_with_frontmatter(temp_repo):
+    result = write_primer_for_client("cursor", temp_repo)
+    assert result.action == "added"
+    assert result.path == temp_repo / ".cursor" / "rules" / "vaner.mdc"
+    content = result.path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "alwaysApply: true" in content
+    assert "Using Vaner" in content
+
+
+def test_write_primer_for_client_is_idempotent(temp_repo):
+    first = write_primer_for_client("codex-cli", temp_repo)
+    second = write_primer_for_client("codex-cli", temp_repo)
+    assert first.action == "added"
+    assert second.action == "skipped"
+    assert first.path == second.path == temp_repo / "AGENTS.md"
+
+
+def test_write_primer_preserves_existing_file_content(temp_repo):
+    copilot = temp_repo / ".github" / "copilot-instructions.md"
+    copilot.parent.mkdir(parents=True)
+    copilot.write_text("# Repo rules\n\nCustom instruction 1.\n", encoding="utf-8")
+    result = write_primer_for_client("vscode-copilot", temp_repo)
+    assert result.action == "added"
+    final = copilot.read_text(encoding="utf-8")
+    # Existing content intact at the top.
+    assert final.startswith("# Repo rules\n\nCustom instruction 1.\n")
+    # Primer appended after.
+    assert "vaner-primer:start" in final
+
+
+def test_write_primer_rewrites_existing_block_without_duplicating(temp_repo):
+    first = write_primer_for_client("cline", temp_repo)
+    assert first.action == "added"
+    # Re-run with a different version — should replace in place.
+    second = write_primer_for_client(
+        "cline",
+        temp_repo,
+        body="CUSTOM PRIMER",
+        version="bumped",
+    )
+    assert second.action == "updated"
+    content = (temp_repo / ".clinerules").read_text(encoding="utf-8")
+    assert content.count("vaner-primer:start") == 1
+    assert "v=bumped" in content
+    assert "CUSTOM PRIMER" in content
+    assert "Using Vaner" not in content  # canonical body replaced
+
+
+def test_write_primer_user_content_above_and_below_block_survives_rewrite(temp_repo):
+    agents = temp_repo / "AGENTS.md"
+    agents.write_text("# Project Agents\n\nabove-rule\n", encoding="utf-8")
+    first = write_primer_for_client("codex-cli", temp_repo, body="v1", version="1")
+    assert first.action == "added"
+    # Simulate user adding content after the block.
+    content = agents.read_text(encoding="utf-8") + "\nbelow-rule\n"
+    agents.write_text(content, encoding="utf-8")
+    # Rewrite with new body + version.
+    second = write_primer_for_client("codex-cli", temp_repo, body="v2", version="2")
+    assert second.action == "updated"
+    rewritten = agents.read_text(encoding="utf-8")
+    assert rewritten.startswith("# Project Agents\n\nabove-rule\n")
+    assert "below-rule" in rewritten
+    assert "v2" in rewritten
+    assert rewritten.count("vaner-primer:start") == 1
+
+
+def test_write_primer_unsupported_client_returns_unsupported(temp_repo):
+    result = write_primer_for_client("claude-desktop", temp_repo)
+    assert result.action == "unsupported"
+    assert result.path is None
+
+
+def test_write_primer_user_scope_unsupported_for_non_claude_code(temp_repo):
+    # Cursor only has a repo-scope surface.
+    result = write_primer_for_client("cursor", temp_repo, scope=PrimerScope.USER)
+    assert result.action == "unsupported"
+
+
+# ---------------------------------------------------------------------------
+# Batch write_primers + init integration
+# ---------------------------------------------------------------------------
+
+
+def test_write_primers_writes_all_supported_clients(temp_repo):
+    results = write_primers(sorted(PRIMER_SURFACES.keys()), temp_repo)
+    written = {r.client_id: r for r in results}
+    assert written["claude-code"].action == "added"
+    assert written["cursor"].action == "added"
+    assert written["vscode-copilot"].action == "added"
+    assert written["codex-cli"].action == "added"
+    assert written["cline"].action == "added"
+    assert written["continue"].action == "added"
+
+
+def test_write_primers_user_scope_only_touches_claude_code(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    results = write_primers(sorted(PRIMER_SURFACES.keys()), repo, include_user_scope=True)
+    user_results = [r for r in results if r.scope == PrimerScope.USER]
+    # Only claude-code has a user-scope surface.
+    assert len(user_results) == 1
+    assert user_results[0].client_id == "claude-code"
+    assert user_results[0].path == fake_home / ".claude" / "CLAUDE.md"
+    assert user_results[0].action == "added"
+
+
+def test_init_writes_primers_by_default(temp_repo, monkeypatch):
+    fake_home = temp_repo / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["init", "--path", str(temp_repo), "--no-interactive", "--no-mcp"],
+    )
+    assert result.exit_code == 0, result.output
+    assert (temp_repo / ".claude" / "CLAUDE.md").exists()
+    assert (temp_repo / "AGENTS.md").exists()
+    assert (temp_repo / ".cursor" / "rules" / "vaner.mdc").exists()
+    # User-scope Claude file should NOT be created by default.
+    assert not (fake_home / ".claude" / "CLAUDE.md").exists()
+
+
+def test_init_no_primer_flag_skips_primer_writes(temp_repo):
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["init", "--path", str(temp_repo), "--no-interactive", "--no-mcp", "--no-primer"],
+    )
+    assert result.exit_code == 0, result.output
+    assert not (temp_repo / ".claude" / "CLAUDE.md").exists()
+    assert not (temp_repo / "AGENTS.md").exists()
+    assert not (temp_repo / ".cursor" / "rules" / "vaner.mdc").exists()
+
+
+def test_init_user_primer_flag_also_writes_user_scope_claude_code(temp_repo, monkeypatch):
+    fake_home = temp_repo / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--path",
+            str(temp_repo),
+            "--no-interactive",
+            "--no-mcp",
+            "--user-primer",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (temp_repo / ".claude" / "CLAUDE.md").exists()
+    assert (fake_home / ".claude" / "CLAUDE.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Canonical loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_canonical_primer_reads_shipped_file():
+    body = load_canonical_primer()
+    assert body.strip().startswith("# Using Vaner")
+    # Anchored on the user-provided principle.
+    assert "reduce uncertainty" in body
+    assert "do not call it mechanically" in body.lower()
+
+
+def test_primer_version_tracks_package_version():
+    assert primer_version() == __import__("vaner").__version__


### PR DESCRIPTION
Triage draft: branch recovered from local-only state for review.

**1 unique commit** ahead of main:
- `feat(init): install per-client usage primers alongside MCP wiring`

## Notes
Installs per-client usage primers during `vaner init` / MCP wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)