### PR TITLE
chore(release): v0.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "vaner",
       "source": "./plugins/vaner",
       "description": "MCP server, feedback skill, and bootstrap hook for Vaner.",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "category": "developer-tools",
       "tags": [
         "mcp",
@@ -22,7 +22,6 @@
         "scenarios",
         "vaner"
       ],
-      "homepage": "https://vaner.ai",
       "repository": "https://github.com/Borgels/Vaner",
       "license": "Apache-2.0",
       "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-04-22
+
 ### Added
 
 #### Activity-timing aware cycle budget

--- a/plugins/vaner/.claude-plugin/plugin.json
+++ b/plugins/vaner/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaner",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Vaner: predictive context middleware for AI coding workflows. Bundles the Vaner MCP server (search, expand, resolve, feedback, and more), the vaner-feedback skill, and a SessionStart hook that checks for the `vaner` CLI.",
   "author": {
     "name": "Borgels Olsen Holding ApS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vaner"
-version = "0.7.0"
+version = "0.7.1"
 description = "Predictive context middleware layer for AI workflows."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps version to 0.7.1 and promotes the Unreleased changelog entries.

## What's in this release

- **Activity-timing aware cycle budget** — EMA-based inter-prompt cadence estimator; adaptive cycle deadline shrinks during active sessions, expands when idle
- **Unused-prediction decay** — schema v7: `access_count` + `last_accessed_at` tracking; purges predictions the developer never consumed
- **Predicted-response precompute** (opt-in) — pre-drafts responses for top macro patterns when cycle has budget to spare
- **Deep-drill on high-priority predictions** — high-confidence scenarios get wider LLM prompts, depth bonus, and softer branch decay

## Files changed
- `pyproject.toml` — `0.7.0` → `0.7.1`
- `CHANGELOG.md` — promote `[Unreleased]` → `[0.7.1]`
- `plugins/vaner/.claude-plugin/plugin.json` — synced by `bump-plugin-version.sh`
- `.claude-plugin/marketplace.json` — synced by `bump-plugin-version.sh`

## After merge
Tag `v0.7.1` on the merge commit to trigger the release workflow (build, sign, SBOM, SLSA provenance, PyPI publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)