### PR TITLE
feat(intent): 0.8.3 — Overnight / Deep-Run Mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "vaner",
       "source": "./plugins/vaner",
       "description": "MCP server, feedback skill, and bootstrap hook for Vaner.",
-      "version": "0.8.0",
+      "version": "0.8.3",
       "category": "developer-tools",
       "tags": [
         "mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-04-24
+
+### Added
+
+#### Overnight / Deep-Run Mode (WS1–WS3)
+- **Policy layer** distinguishing intent ("user is away for the night") from incidental idleness. Introduces a persisted `DeepRunSession` record (`src/vaner/intent/deep_run.py`, `src/vaner/store/deep_run.py`) with single-active-session enforced by a UNIQUE partial index on `status='active'` plus a defensive store-layer check. Sessions resume on daemon restart; expired sessions auto-close with `cancelled_reason="expired_on_restart"`.
+- **Three presets** (Conservative / Balanced / Aggressive) compose the existing engine knobs (exploit/invest/no-regret ratio biases, drafter thresholds, frontier weights, `idle_curve_multiplier`, per-cycle utilisation). `src/vaner/intent/deep_run_policy.py` ships the immutable preset table + four horizon biases (`likely_next` / `long_horizon` / `finish_partials` / `balanced`) + the focus admission gate (`active_goals` / `current_workspace` / `all_recent`).
+- **`PredictionGovernor.Mode.DEEP_RUN`** added alongside BACKGROUND / DEDICATED / BUDGET. Continues unless explicitly stopped; pause/resume gating is delegated to the engine via gate probes.
+- **Resource / cost / locality gates** (`src/vaner/intent/deep_run_gates.py`):
+  - `ResourceGateProbe` Protocol + `NoOpResourceGateProbe` default for tests; `evaluate_resource_gates()` returns the active pause-reason set (battery / thermal / user-input / engine-error-rate).
+  - `try_consume_cost()` — thread-safe in-memory cumulative spend counter, gates remote calls when `cost_cap_usd > 0`. `cost_cap_usd = 0` (the default) means *no remote spend permitted* — a hard router-layer block, not a budget warning.
+  - `is_remote_call_allowed()` — `local_only` blocks remote URLs.
+  - Routing-state singleton (`set_active_session_for_routing()` / `get_active_session_for_routing()`) lets the router consult the active session without parameter-passing through every LLM call.
+- **Router-layer enforcement** (`src/vaner/router/backends.py`): new `_enforce_deep_run_gates_for_remote()` helper plus `DeepRunRemoteCallBlockedError` raised when locality or cost gates fire. Wired into the four remote-call paths (sync + streaming, primary + fallback). Zero behaviour change when no Deep-Run session is active.
+- **Maturation revisiting** (`src/vaner/intent/deep_run_maturation.py`) — the central new mechanism. A maturation pass re-enters the drafter on already-`READY` predictions to deepen evidence, refine drafts, and resolve contradictions. Critical defenses against the well-known same-model self-judging anti-pattern (per Anthropic Engineering's *Harness design for long-running apps*):
+  - **Generator/judge role separation.** Drafter and judge are distinct callables with distinct prompts. Default `JudgeCallable` is a programmatic, skeptical, rubric-based judge — `kept=False` unless concrete contract clauses are satisfied.
+  - **Per-pass `MaturationContract`** built from the prediction's current weakness signal *before* the drafter runs. Universal forbidden clauses (no length-only growth, no silent evidence-ref removal, anchor preserved) plus weakness-specific must-clauses (e.g. "≥2 new evidence_refs not in the prior set").
+  - **Probationary persistence + diminishing-returns thresholds.** Kept maturations are probationary for N cycles; subsequent reconciliation contradictions roll them back via `rollback_kept_maturation()`. Persistence threshold tightens with each `revision`.
+  - `select_maturation_candidates()` ranks READY predictions by goal-confidence × evidence-room × revision decay × state factor, respecting per-prediction failure caps and probation windows.
+- **Honest 4-counter discipline** (spec §9.2 / §14.1): `DeepRunSession` and `DeepRunSummary` carry `matured_kept`, `matured_discarded`, `matured_rolled_back`, `matured_failed` as four separate values. Every surface (CLI, MCP, HTTP, cockpit) renders all four; never collapses into a single inflated "matured" total.
+- **`PredictionRun` extension** with `revision`, `last_matured_cycle`, `probationary_until_cycle`, `failed_revisits`, `maturation_eligible`.
+
+#### Surfaces (WS4)
+- **CLI** — `vaner deep-run start | stop | status | list | show` (`src/vaner/cli/commands/deep_run.py`). `--until` accepts duration (`8h`, `45m`), time-of-day (`07:00`), or ISO-8601. Dual output: human Rich rendering + `--json` for machine consumers.
+- **MCP** — five new tools (`vaner.deep_run.start`, `.stop`, `.status`, `.list`, `.show`); `vaner.status` extended with a `deep_run` field carrying the active session record.
+- **Daemon HTTP** — `POST /deep-run/start`, `POST /deep-run/stop`, `GET /deep-run/status`, `GET /deep-run/sessions`, `GET /deep-run/sessions/{id}` (`src/vaner/daemon/http.py`).
+- **Cockpit (React)** — `ui/cockpit/src/types/deepRun.ts` (TS schema mirrors), `ui/cockpit/src/api/deepRun.ts` (fetch helpers), `ui/cockpit/src/components/DeepRunPanel.tsx` (status pill + start card + history table). All four maturation counters surfaced separately.
+- **Desktop hand-off** — `docs/0.8.3/desktop-hand-off.md` documents the wire format, SwiftUI scope, and integration points for the separate `vaner-desktop` repo (popover quick action, menu-bar indicator, preferences card).
+- **Single canonical record across surfaces.** `DeepRunSession` row is the one source of truth; CLI / MCP / HTTP / cockpit all read it. Stable-schema serializers (`_session_to_dict` / `_summary_to_dict`) shared between CLI and MCP and HTTP.
+
+#### Bench primitives + ship gates (WS5)
+- `Vaner-train/eval/deep_run_bench.py` — `MaturationBenchOutcome`, `MaturationBenchMetrics`, `compute_maturation_metrics()`, `evaluate_ship_gates()`. Five binding ship gates encoded in `SHIP_GATES`:
+  - `maturation_effectiveness` — external-judged mean improvement Δ ≥ +0.30 per kept pass.
+  - `judge_external_agreement` — Cohen's κ ≥ 0.70 between in-engine and external judges. The anti-self-judging gate.
+  - `persistence_rate_in_band` — kept fraction in [0.25, 0.55].
+  - `probationary_rollback_rate` — ≤ 0.15.
+  - `stale_by_morning_rate` — ≤ 0.15.
+- Per-archetype floor: no archetype's mean Δ may be below +0.15; all four of writer/researcher/developer/planner must have ≥1 session in the fixture.
+- Validation report at `docs/benchmarks/0.8.3-deep-run-validation.md` documents the gates + lists the remaining follow-up work (labelled fixture corpus, external judge wiring, bench run).
+
+### Internal
+- Tests: +211 across WS1–WS5. Full Vaner suite: 1020 passing, 14 skipped (zero new skips).
+- Pre-existing tool-list assertions in `tests/test_mcp/test_protocol_roundtrip.py`, `test_scenario_tools.py`, `test_server_boot.py` updated to include the five new `vaner.deep_run.*` tools (26 tools total, up from 21).
+- Hard safety gates verified in code + tests: cost-cap compliance (no overshoot under 100-thread concurrency), local-only fidelity (zero remote calls when `local_only`), single-active session enforcement, four-counter integrity, resume-on-restart, reconciliation rollback inside probation.
+
+### Why this is different from idle mode
+Idle mode answers a *resource* question ("is the machine free right now?") and must hedge against the user returning at any moment. Deep-Run answers a *policy* question ("is the user telling me they will be away for a long, predictable window and want me to use it well?") and adopts a different stance: longer per-cycle utilisation, broader frontier, deeper drafting bars, **maturation passes on already-ready predictions**, accumulated provenance, post-session summary. Deep-Run never *infers* itself from idleness alone — it requires explicit user opt-in via CLI / MCP / cockpit / desktop.
+
+### Why this does not turn Vaner into an autonomous agent harness
+Deep-Run only ever does *more* prepare and *more* promote work. The **prepare ≠ promote ≠ adopt ≠ execute** boundary is preserved: adoption requires an explicit MCP/HTTP/CLI call from a user or authorised agent; execution endpoints with `side_effects ∈ {"read", "mutate"}` are out of scope. Deep-Run lets Vaner *think* harder while you sleep; it does not let Vaner *do* anything you did not already authorise it to do during the day.
+
 ## [0.8.0] - 2026-04-23
 
 ### Added

--- a/docs/0.8.3/desktop-hand-off.md
+++ b/docs/0.8.3/desktop-hand-off.md
@@ -1,0 +1,75 @@
+# 0.8.3 WS4 — vaner-desktop hand-off
+
+The macOS desktop app lives in a separate repo (`vaner-desktop/`) with
+its own SwiftUI/AppKit codebase, build pipeline, and review cycle. The
+Vaner repo's WS4 ships everything the desktop needs to integrate
+without further engine changes; this note is the contract.
+
+## Wire format
+
+The desktop app talks to the daemon over loopback HTTP at
+`127.0.0.1:8473` (the same `HTTPEngineClient` it already uses). All
+five Deep-Run endpoints accept and return JSON in the canonical schema
+defined by [src/vaner/cli/commands/deep_run.py](../../src/vaner/cli/commands/deep_run.py)
+(`_session_to_dict` + `_summary_to_dict`):
+
+| Method | Path                                  | Body / Query                                                                                                        | Response                                       |
+|--------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+| POST   | `/deep-run/start`                     | `{ ends_at, preset?, focus?, horizon_bias?, locality?, cost_cap_usd?, metadata? }`                                  | `DeepRunSession` row                           |
+| POST   | `/deep-run/stop`                      | `{ kill?: bool, reason?: string }`                                                                                  | `{ summary: DeepRunSummary \| null }`          |
+| GET    | `/deep-run/status`                    | —                                                                                                                   | `{ session: DeepRunSession \| null }`          |
+| GET    | `/deep-run/sessions?limit=N`          | —                                                                                                                   | `{ sessions: DeepRunSession[] }`               |
+| GET    | `/deep-run/sessions/{id}`             | —                                                                                                                   | `DeepRunSession` (404 if not found)            |
+
+The `vaner status` daemon endpoint (`GET /status`) already gains a
+`deep_run` field of shape `{ active: bool, session: DeepRunSession | null }`
+so the menu-bar indicator can render from one round-trip.
+
+## SwiftUI scope (stretch — defer to a follow-up PR in vaner-desktop)
+
+Three additions, all read/write the canonical record:
+
+1. **Menu-bar quick action** in `Popover/PopoverRoot.swift` — a "Deep-Run
+   tonight" button that opens a compact sheet (`DeepRunSheet.swift`) with:
+   - Until-time picker (defaults to 07:00 next morning)
+   - Preset segmented control (Conservative / Balanced / Aggressive)
+   - Local-only toggle
+   - Optional cost-cap field (defaults to $0)
+2. **Active-session indicator** — menu-bar icon adopts a moon-glyph
+   badge while a session is active; clicking reveals
+   `DeepRunStatusPanel.swift` (preset, time remaining, cycles, the
+   four maturation counters as separate values, "Stop" button).
+3. **Preferences pane** addition in `Companion/PreferencesPane.swift`
+   — defaults card (preset, cost cap, locality, "pause on user input").
+
+The schema mirror lives in `vaner-desktop/State/DeepRunModels.swift`
+(to be added). Suggested types are exact mirrors of
+[ui/cockpit/src/types/deepRun.ts](../../ui/cockpit/src/types/deepRun.ts).
+
+## Honest 4-counter discipline
+
+Per spec §9.2 / §14.1, every surface that displays maturation activity
+must show all four counters as separate values, never collapsed into a
+single "matured" total:
+
+- `matured_kept` — judge approved + persisted
+- `matured_discarded` — judge rejected the new draft
+- `matured_rolled_back` — kept then contradicted in probation
+- `matured_failed` — exhausted per-prediction failure cap
+
+The CLI / MCP / cockpit already enforce this. Desktop UI must follow.
+
+## Notifications
+
+When a session ends, the daemon emits a `deep_run_ended` event. Desktop
+posts a macOS user notification: "Deep-Run finished. {kept} matured
+kept, {cycles_run} cycles, ${spend_usd} spent." If
+`cost_cap_exceeded` ever appears in the session's pause reasons, the
+notification copy switches to surface that explicitly.
+
+## Out of scope for 0.8.3
+
+- Recurring schedule ("every weeknight 11pm–7am") — defer to 0.8.4 with
+  a `vaner.schedules.*` MCP surface.
+- Per-archetype preset auto-tuning — depends on archetype becoming
+  first-class post-0.8.3.

--- a/docs/benchmarks/0.8.3-deep-run-validation.md
+++ b/docs/benchmarks/0.8.3-deep-run-validation.md
@@ -1,0 +1,86 @@
+# 0.8.3 Deep-Run Mode — Validation status
+
+## What this document is
+
+This is the placeholder for the 0.8.3 ship-validation report. The bench
+harness, metric schema, and ship-gate evaluation are all implemented and
+tested in this PR (WS5). The actual bench *run* — which produces the
+numbers that decide ship/no-ship — depends on inputs that cannot be
+fabricated and have to land in a follow-up:
+
+- A labelled morning-briefing fixture corpus across writer / researcher
+  / developer / planner archetypes (≥10 sessions per archetype, per
+  spec §14.1's cross-archetype gate).
+- An external judge model — strictly stronger than the in-engine
+  judge — invoked only at bench time to compute the
+  `judge_external_agreement` (Cohen's κ ≥ 0.70) anti-self-judging gate.
+- Multi-hour bench compute against the labelled fixture under each of
+  the three presets (Conservative / Balanced / Aggressive).
+
+Until those land, this document records the **gate definitions** and
+the **schema** the run will use. The numbers are intentionally absent.
+
+## Ship gates (binding)
+
+The gate table is locked in [Vaner-train/eval/deep_run_bench.py](../../../Vaner-train/eval/deep_run_bench.py)
+(`SHIP_GATES`). A regression test in
+[Vaner-train/tests/test_deep_run_bench.py](../../../Vaner-train/tests/test_deep_run_bench.py)
+asserts the table covers the five spec-named gates exactly.
+
+| Gate | Threshold | Condition | Why |
+|---|---|---|---|
+| `maturation_effectiveness` | ≥ +0.30 | external-judged mean Δ per kept pass | Validates Deep-Run actually improves drafts. |
+| `judge_external_agreement` | κ ≥ 0.70 | in-engine vs. external judge `kept` agreement | Anti-self-judging gate (spec §9.2 / §14.1). |
+| `persistence_rate_in_band` | 0.25 ≤ rate ≤ 0.55 | kept fraction of total attempts | Below 0.25 = contracts too strict; above 0.55 = judge too lenient. |
+| `probationary_rollback_rate` | ≤ 0.15 | rollbacks of kept maturations during probation | Higher = the judge is being fooled by drafts that don't survive contact with reconciliation. |
+| `stale_by_morning_rate` | ≤ 0.15 | READY-at-end predictions stale before next session | Validates the work isn't wasted overnight. |
+
+Plus the **per-archetype floor** (spec §14.1 cross-archetype gate): no
+archetype's mean Δ may be below +0.15, and all four of writer /
+researcher / developer / planner must have ≥1 session in the fixture.
+
+## Hard safety gates (binding; not subject to bench numbers)
+
+These are not metrics — they are properties enforced in code and
+verified by the WS1–WS4 unit / integration tests, not by the bench.
+
+| Property | Where enforced | Test |
+|---|---|---|
+| Cost-cap compliance — no remote spend over the cap | [src/vaner/intent/deep_run_gates.py](../../src/vaner/intent/deep_run_gates.py) `try_consume_cost` | [tests/test_intent/test_deep_run_gates.py](../../tests/test_intent/test_deep_run_gates.py) |
+| Local-only fidelity — zero remote calls when locality=local_only | [src/vaner/router/backends.py](../../src/vaner/router/backends.py) `_enforce_deep_run_gates_for_remote` | [tests/test_router/test_deep_run_gate_integration.py](../../tests/test_router/test_deep_run_gate_integration.py) |
+| Single active session — second start raises | [src/vaner/store/deep_run.py](../../src/vaner/store/deep_run.py) `create_session` + UNIQUE partial index | [tests/test_store/test_deep_run_store.py](../../tests/test_store/test_deep_run_store.py), [tests/test_engine/test_deep_run_lifecycle.py](../../tests/test_engine/test_deep_run_lifecycle.py) |
+| Honest 4-counter integrity — every surface shows kept/discarded/rolled_back/failed separately | CLI / MCP / HTTP / cockpit components | [tests/test_cli/test_deep_run.py](../../tests/test_cli/test_deep_run.py), [tests/test_mcp/test_deep_run_tools.py](../../tests/test_mcp/test_deep_run_tools.py), [tests/test_daemon/test_deep_run_http.py](../../tests/test_daemon/test_deep_run_http.py) |
+| Auto-adopt count = 0 — Deep-Run never invokes adoption | [src/vaner/engine.py](../../src/vaner/engine.py) (no call sites) | covered by absence; lint check is a follow-up |
+| Resume-on-restart — in-flight session survives daemon restart | [src/vaner/engine.py](../../src/vaner/engine.py) `_resume_deep_run_on_restart` | [tests/test_engine/test_deep_run_lifecycle.py](../../tests/test_engine/test_deep_run_lifecycle.py) |
+| Reconciliation persistence — kept maturation rolls back on contradicting signal in probation | [src/vaner/intent/deep_run_maturation.py](../../src/vaner/intent/deep_run_maturation.py) `rollback_kept_maturation` | [tests/test_intent/test_deep_run_maturation.py](../../tests/test_intent/test_deep_run_maturation.py) |
+
+All hard safety gates **pass as of this PR**. The remaining open
+question is the bench-number question.
+
+## What still needs to land
+
+1. **Fixture corpus.** ≥10 labelled morning-briefing sessions per
+   archetype under `Vaner-train/tests/fixtures/deep_run/`. Format:
+   one JSON per session matching the existing
+   `session_replay_bench` shape, plus a labelled "next-morning prompt"
+   set so the adopt-rate metric can be computed.
+2. **External judge wiring.** Choose an external model (a stronger
+   model than the in-engine judge — see spec §9.2: cheap callable for
+   in-engine judge, separate prompt frame). Wire it as a
+   `JudgeCallable` in a new `eval/deep_run_external_judge.py`.
+3. **Bench script.** A `eval/run_deep_run_bench.py` that loads the
+   fixture, runs each preset, calls
+   `compute_maturation_metrics()` + `evaluate_ship_gates()`, and writes
+   the numbers back into this document.
+4. **Run + write up.** Produce the actual numbers and replace the gate
+   table above with the validation result.
+
+## Sequencing
+
+This PR is the *engine + surfaces + harness primitives* PR. The labelled
+corpus + bench run is its own follow-up — it depends on human labelling
+work and can land independently of the engine, since the engine code
+shipped here passes all hard safety gates and is feature-complete.
+
+When the follow-up bench run lands, this document gets the numbers
+inlined and the "still needs to land" section is removed.

--- a/plugins/vaner/.claude-plugin/plugin.json
+++ b/plugins/vaner/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaner",
-  "version": "0.8.0",
+  "version": "0.8.3",
   "description": "Vaner: predictive context middleware for AI coding workflows. Bundles the Vaner MCP server (search, expand, resolve, feedback, and more), the vaner-feedback skill, and a SessionStart hook that checks for the `vaner` CLI.",
   "author": {
     "name": "Borgels Olsen Holding ApS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vaner"
-version = "0.8.0"
+version = "0.8.3"
 description = "Predictive context middleware layer for AI workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -45,6 +45,7 @@ from vaner.cli.commands.daemon import (
     stop_daemon,
     write_pid,
 )
+from vaner.cli.commands.deep_run import deep_run_app
 from vaner.cli.commands.distill import distill_skill_file
 from vaner.cli.commands.explain import render_human, render_json
 from vaner.cli.commands.init import (
@@ -2139,6 +2140,7 @@ app.add_typer(daemon_app, name="daemon", rich_help_panel="Background and local")
 app.add_typer(config_app, name="config", rich_help_panel="Configure")
 app.add_typer(profile_app, name="profile", rich_help_panel="Background and local")
 app.add_typer(scenarios_app, name="scenarios", rich_help_panel="Use with an agent")
+app.add_typer(deep_run_app, name="deep-run", rich_help_panel="Background and local")
 
 
 def run() -> None:

--- a/src/vaner/cli/commands/deep_run.py
+++ b/src/vaner/cli/commands/deep_run.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS4 — `vaner deep-run` CLI commands (0.8.3).
+
+Five verbs: ``start``, ``stop``, ``status``, ``list``, ``show``.
+Each is a thin shell over :mod:`vaner.server` async helpers — the
+server module owns the engine construction + persistence; the CLI
+owns argument parsing + rendering.
+
+The output format is dual: human-friendly Rich rendering by default,
+``--json`` for machine consumers (cockpit, desktop, agents, scripts).
+The same JSON contract is used by :mod:`vaner.mcp.server` for the
+``vaner.deep_run.*`` MCP tools so every surface speaks the same schema.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from vaner.intent.deep_run import DeepRunSession, DeepRunSummary
+from vaner.server import (
+    alist_deep_run_sessions,
+    aresolve_deep_run_session,
+    astart_deep_run,
+    astatus_deep_run,
+    astop_deep_run,
+)
+
+deep_run_app = typer.Typer(
+    help=(
+        "Overnight / Deep-Run mode: declare a long uninterrupted preparation window so Vaner can mature predictions and broaden coverage."
+    )
+)
+_console = Console()
+
+
+# ---------------------------------------------------------------------------
+# `--until` parsing — accepts duration ("8h", "30m"), HH:MM, or ISO-8601
+# ---------------------------------------------------------------------------
+
+
+_DURATION_RE = re.compile(r"^\s*(\d+)\s*([smhd])\s*$", re.IGNORECASE)
+_TIMEOFDAY_RE = re.compile(r"^\s*(\d{1,2}):(\d{2})\s*$")
+
+
+def _parse_until(spec: str, *, now: float | None = None) -> float:
+    """Parse ``--until`` into an absolute epoch timestamp.
+
+    Accepted forms:
+    - duration: ``30s`` / ``45m`` / ``8h`` / ``2d``
+    - time of day: ``07:00`` (next occurrence; tomorrow if already past today)
+    - ISO-8601: ``2026-04-25T07:00:00``
+
+    Raises ``typer.BadParameter`` on parse error so the CLI shows a clean
+    message rather than a stack trace.
+    """
+
+    base_ts = now if now is not None else time.time()
+    text = spec.strip()
+    if not text:
+        raise typer.BadParameter("--until cannot be empty")
+
+    m = _DURATION_RE.match(text)
+    if m:
+        amount = int(m.group(1))
+        unit = m.group(2).lower()
+        seconds = {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit] * amount
+        if seconds <= 0:
+            raise typer.BadParameter(f"--until {spec!r} is non-positive")
+        return base_ts + float(seconds)
+
+    m = _TIMEOFDAY_RE.match(text)
+    if m:
+        hour = int(m.group(1))
+        minute = int(m.group(2))
+        if not (0 <= hour < 24 and 0 <= minute < 60):
+            raise typer.BadParameter(f"--until {spec!r} is not a valid time")
+        now_dt = datetime.fromtimestamp(base_ts).astimezone()
+        target = now_dt.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if target.timestamp() <= base_ts:
+            target = target.replace(day=target.day + 1)
+        return target.timestamp()
+
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise typer.BadParameter(f"--until {spec!r} is not a recognised duration / time / ISO-8601") from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC).astimezone()
+    return dt.timestamp()
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def _session_to_dict(session: DeepRunSession) -> dict[str, object]:
+    return {
+        "id": session.id,
+        "status": session.status,
+        "preset": session.preset,
+        "focus": session.focus,
+        "horizon_bias": session.horizon_bias,
+        "locality": session.locality,
+        "cost_cap_usd": session.cost_cap_usd,
+        "spend_usd": session.spend_usd,
+        "workspace_root": session.workspace_root,
+        "started_at": session.started_at,
+        "ends_at": session.ends_at,
+        "ended_at": session.ended_at,
+        "cycles_run": session.cycles_run,
+        "matured_kept": session.matured_kept,
+        "matured_discarded": session.matured_discarded,
+        "matured_rolled_back": session.matured_rolled_back,
+        "matured_failed": session.matured_failed,
+        "promoted_count": session.promoted_count,
+        "pause_reasons": list(session.pause_reasons),
+        "cancelled_reason": session.cancelled_reason,
+        "metadata": dict(session.metadata),
+    }
+
+
+def _summary_to_dict(summary: DeepRunSummary) -> dict[str, object]:
+    return {
+        "session_id": summary.session_id,
+        "started_at": summary.started_at,
+        "ended_at": summary.ended_at,
+        "preset": summary.preset,
+        "cycles_run": summary.cycles_run,
+        "matured_kept": summary.matured_kept,
+        "matured_discarded": summary.matured_discarded,
+        "matured_rolled_back": summary.matured_rolled_back,
+        "matured_failed": summary.matured_failed,
+        "promoted_count": summary.promoted_count,
+        "spend_usd": summary.spend_usd,
+        "pause_reasons": list(summary.pause_reasons),
+        "cancelled_reason": summary.cancelled_reason,
+        "final_status": summary.final_status,
+    }
+
+
+def _human_session_panel(session: DeepRunSession) -> Table:
+    """Single-session status table for `status` / `start` output."""
+
+    table = Table.grid(padding=(0, 1))
+    table.add_column(style="bold")
+    table.add_column()
+    table.add_row("session", session.id)
+    table.add_row("status", session.status)
+    table.add_row("preset", session.preset)
+    table.add_row("focus / horizon", f"{session.focus} / {session.horizon_bias}")
+    table.add_row("locality", session.locality)
+    cap = f"${session.cost_cap_usd:.2f}" if session.cost_cap_usd > 0 else "0 (no remote spend permitted)"
+    spend_pct = f" ({session.spend_usd / session.cost_cap_usd * 100:.0f}% of cap)" if session.cost_cap_usd > 0 else ""
+    table.add_row("cost cap / spend", f"{cap}; spent ${session.spend_usd:.4f}{spend_pct}")
+    started = datetime.fromtimestamp(session.started_at).astimezone().strftime("%H:%M:%S")
+    ends = datetime.fromtimestamp(session.ends_at).astimezone().strftime("%H:%M:%S")
+    table.add_row("started / ends", f"{started} → {ends}")
+    table.add_row("cycles", str(session.cycles_run))
+    table.add_row(
+        "matured (4-count)",
+        (
+            f"kept={session.matured_kept} discarded={session.matured_discarded} "
+            f"rolled_back={session.matured_rolled_back} failed={session.matured_failed}"
+        ),
+    )
+    if session.pause_reasons:
+        table.add_row("pause reasons", ", ".join(session.pause_reasons))
+    if session.cancelled_reason:
+        table.add_row("cancelled", session.cancelled_reason)
+    return table
+
+
+def _human_session_list(sessions: list[DeepRunSession]) -> Table:
+    table = Table(show_lines=False)
+    table.add_column("id", style="dim", overflow="crop", max_width=12)
+    table.add_column("status")
+    table.add_column("preset")
+    table.add_column("started")
+    table.add_column("cycles", justify="right")
+    table.add_column("matured", justify="right")
+    table.add_column("spend", justify="right")
+    for s in sessions:
+        started = datetime.fromtimestamp(s.started_at).astimezone().strftime("%m-%d %H:%M")
+        matured = f"{s.matured_kept}/{s.matured_kept + s.matured_discarded + s.matured_rolled_back + s.matured_failed}"
+        spend = f"${s.spend_usd:.2f}" if s.spend_usd > 0 else "—"
+        table.add_row(s.id, s.status, s.preset, started, str(s.cycles_run), matured, spend)
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+@deep_run_app.command("start", help="Start a Deep-Run session for a declared away window.")
+def start(
+    until: str = typer.Option(..., "--until", help="Window end. Forms: 8h, 07:00, 2026-04-25T07:00:00."),
+    preset: str = typer.Option("balanced", "--preset", help="conservative | balanced | aggressive"),
+    focus: str = typer.Option(
+        "active_goals",
+        "--focus",
+        help="active_goals | current_workspace | all_recent",
+    ),
+    horizon: str = typer.Option(
+        "balanced",
+        "--horizon",
+        help="likely_next | long_horizon | finish_partials | balanced",
+    ),
+    locality: str = typer.Option(
+        "local_preferred",
+        "--locality",
+        help="local_only | local_preferred | allow_cloud",
+    ),
+    cost_cap_usd: float = typer.Option(
+        0.0,
+        "--cost-cap",
+        help="USD cap for remote backend spend. 0 = no remote spend permitted.",
+        min=0.0,
+    ),
+    workspace: str | None = typer.Option(None, "--workspace", help="Workspace root (defaults to cwd)"),
+    tag: str | None = typer.Option(None, "--tag", help="Optional metadata tag"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    path: str | None = typer.Option(None, "--path", help="Repository root override"),
+) -> None:
+    repo_root = _repo_root(path)
+    ends_at = _parse_until(until)
+    metadata = {"caller": "cli"}
+    if tag is not None:
+        metadata["tag"] = tag
+    session = asyncio.run(
+        astart_deep_run(
+            repo_root,
+            ends_at=ends_at,
+            preset=preset,
+            focus=focus,
+            horizon_bias=horizon,
+            locality=locality,
+            cost_cap_usd=cost_cap_usd,
+            workspace_root=workspace,
+            metadata=metadata,
+        )
+    )
+    if as_json:
+        typer.echo(json.dumps(_session_to_dict(session), indent=2))
+        return
+    _console.print("[bold green]Deep-Run started[/]")
+    _console.print(_human_session_panel(session))
+
+
+@deep_run_app.command("stop", help="Stop the currently active Deep-Run session.")
+def stop(
+    kill: bool = typer.Option(False, "--kill", help="Mark the session 'killed' (immediate stop)"),
+    reason: str | None = typer.Option(None, "--reason", help="Optional cancellation reason"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    path: str | None = typer.Option(None, "--path", help="Repository root override"),
+) -> None:
+    repo_root = _repo_root(path)
+    summary = asyncio.run(astop_deep_run(repo_root, kill=kill, reason=reason))
+    if summary is None:
+        if as_json:
+            typer.echo(json.dumps(None))
+        else:
+            _console.print("[yellow]No active Deep-Run session to stop.[/]")
+        raise typer.Exit(code=0 if not kill else 1)
+    if as_json:
+        typer.echo(json.dumps(_summary_to_dict(summary), indent=2))
+        return
+    _console.print(
+        f"[bold]Deep-Run {summary.final_status}.[/] "
+        f"{summary.cycles_run} cycle(s); matured kept={summary.matured_kept} "
+        f"discarded={summary.matured_discarded} rolled_back={summary.matured_rolled_back} "
+        f"failed={summary.matured_failed}; spent ${summary.spend_usd:.4f}."
+    )
+
+
+@deep_run_app.command("status", help="Show the current Deep-Run session state.")
+def status(
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    path: str | None = typer.Option(None, "--path", help="Repository root override"),
+) -> None:
+    repo_root = _repo_root(path)
+    session = asyncio.run(astatus_deep_run(repo_root))
+    if session is None:
+        if as_json:
+            typer.echo(json.dumps(None))
+        else:
+            _console.print("[dim]No active Deep-Run session.[/]")
+        return
+    if as_json:
+        typer.echo(json.dumps(_session_to_dict(session), indent=2))
+        return
+    _console.print(_human_session_panel(session))
+
+
+@deep_run_app.command("list", help="List recent Deep-Run sessions.")
+def list_(
+    limit: int = typer.Option(10, "--limit", min=1, max=200, help="Max sessions to list"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    path: str | None = typer.Option(None, "--path", help="Repository root override"),
+) -> None:
+    repo_root = _repo_root(path)
+    sessions = asyncio.run(alist_deep_run_sessions(repo_root, limit=limit))
+    if as_json:
+        typer.echo(json.dumps([_session_to_dict(s) for s in sessions], indent=2))
+        return
+    if not sessions:
+        _console.print("[dim]No Deep-Run sessions recorded yet.[/]")
+        return
+    _console.print(_human_session_list(sessions))
+
+
+@deep_run_app.command("show", help="Show a specific Deep-Run session by id.")
+def show(
+    session_id: str = typer.Argument(..., help="Session id (uuid hex)"),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    path: str | None = typer.Option(None, "--path", help="Repository root override"),
+) -> None:
+    repo_root = _repo_root(path)
+    session = asyncio.run(aresolve_deep_run_session(repo_root, session_id))
+    if session is None:
+        _console.print(f"[red]Session {session_id} not found.[/]")
+        raise typer.Exit(code=1)
+    if as_json:
+        typer.echo(json.dumps(_session_to_dict(session), indent=2))
+        return
+    _console.print(_human_session_panel(session))
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (mirror app.py's repo-root convention)
+# ---------------------------------------------------------------------------
+
+
+def _repo_root(path: str | None) -> Path:
+    import os
+
+    if path:
+        return Path(path).resolve()
+    env_path = os.environ.get("VANER_PATH", "").strip()
+    return Path(env_path).resolve() if env_path else Path.cwd()
+
+
+__all__ = ["deep_run_app"]

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -124,6 +124,119 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
             }
         )
 
+    # ------------------------------------------------------------------
+    # 0.8.3 WS4 — Deep-Run lifecycle HTTP endpoints. Cockpit + desktop
+    # consume these. When the daemon is wired to a live engine, calls
+    # route through engine methods so the routing singleton + cost gate
+    # update in-process. When the engine is None (serve-http only),
+    # calls fall back to vaner.server helpers that build a default
+    # engine per call — durable but does not arm in-process gates.
+    # ------------------------------------------------------------------
+
+    async def _deep_run_call(handler: Any, *args: Any, **kwargs: Any) -> Any:
+        if engine is not None:
+            return await handler(engine, *args, **kwargs)
+        from vaner.server import (
+            alist_deep_run_sessions,
+            aresolve_deep_run_session,
+            astart_deep_run,
+            astatus_deep_run,
+            astop_deep_run,
+        )
+
+        fallback_map = {
+            "start": astart_deep_run,
+            "stop": astop_deep_run,
+            "status": astatus_deep_run,
+            "list": alist_deep_run_sessions,
+            "show": aresolve_deep_run_session,
+        }
+        op = handler  # str key when engine is None
+        return await fallback_map[op](config.repo_root, *args, **kwargs)
+
+    def _serialize_session(session: Any) -> dict[str, Any] | None:
+        from vaner.cli.commands.deep_run import _session_to_dict
+
+        return _session_to_dict(session) if session is not None else None
+
+    def _serialize_summary(summary: Any) -> dict[str, Any] | None:
+        from vaner.cli.commands.deep_run import _summary_to_dict
+
+        return _summary_to_dict(summary) if summary is not None else None
+
+    @app.post("/deep-run/start")
+    async def deep_run_start(request: Request) -> JSONResponse:
+        body = await request.json() if request.headers.get("content-length") else {}
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="JSON object body required")
+        ends_at = body.get("ends_at")
+        if not isinstance(ends_at, (int, float)):
+            raise HTTPException(status_code=400, detail="ends_at (epoch number) is required")
+        kwargs: dict[str, Any] = {
+            "ends_at": float(ends_at),
+            "preset": str(body.get("preset", "balanced")),
+            "focus": str(body.get("focus", "active_goals")),
+            "horizon_bias": str(body.get("horizon_bias", "balanced")),
+            "locality": str(body.get("locality", "local_preferred")),
+            "cost_cap_usd": float(body.get("cost_cap_usd", 0.0)),
+            "metadata": dict(body.get("metadata") or {}) | {"caller": "http"},
+        }
+        try:
+            if engine is not None:
+                session = await engine.start_deep_run(**kwargs)
+            else:
+                from vaner.server import astart_deep_run
+
+                session = await astart_deep_run(config.repo_root, **kwargs)
+        except Exception as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return JSONResponse(_serialize_session(session))
+
+    @app.post("/deep-run/stop")
+    async def deep_run_stop(request: Request) -> JSONResponse:
+        body = await request.json() if request.headers.get("content-length") else {}
+        if not isinstance(body, dict):
+            body = {}
+        kill = bool(body.get("kill", False))
+        reason = body.get("reason") if isinstance(body.get("reason"), str) else None
+        if engine is not None:
+            summary = await engine.stop_deep_run(kill=kill, reason=reason)
+        else:
+            from vaner.server import astop_deep_run
+
+            summary = await astop_deep_run(config.repo_root, kill=kill, reason=reason)
+        return JSONResponse({"summary": _serialize_summary(summary)})
+
+    @app.get("/deep-run/status")
+    async def deep_run_status_endpoint() -> JSONResponse:
+        if engine is not None:
+            session = await engine.current_deep_run()
+        else:
+            from vaner.server import astatus_deep_run
+
+            session = await astatus_deep_run(config.repo_root)
+        return JSONResponse({"session": _serialize_session(session)})
+
+    @app.get("/deep-run/sessions")
+    async def deep_run_list_sessions(limit: int = 20) -> JSONResponse:
+        limit = max(1, min(200, int(limit)))
+        if engine is not None:
+            sessions = await engine.list_deep_run_sessions(limit=limit)
+        else:
+            from vaner.server import alist_deep_run_sessions
+
+            sessions = await alist_deep_run_sessions(config.repo_root, limit=limit)
+        return JSONResponse({"sessions": [_serialize_session(s) for s in sessions]})
+
+    @app.get("/deep-run/sessions/{session_id}")
+    async def deep_run_show(session_id: str) -> JSONResponse:
+        from vaner.server import aresolve_deep_run_session
+
+        session = await aresolve_deep_run_session(config.repo_root, session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail=f"session {session_id!r} not found")
+        return JSONResponse(_serialize_session(session))
+
     @app.get("/compute/devices")
     async def compute_devices() -> JSONResponse:
         devices: list[dict[str, Any]] = [{"id": "cpu", "label": "CPU", "kind": "cpu"}]

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -133,27 +133,6 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
     # engine per call — durable but does not arm in-process gates.
     # ------------------------------------------------------------------
 
-    async def _deep_run_call(handler: Any, *args: Any, **kwargs: Any) -> Any:
-        if engine is not None:
-            return await handler(engine, *args, **kwargs)
-        from vaner.server import (
-            alist_deep_run_sessions,
-            aresolve_deep_run_session,
-            astart_deep_run,
-            astatus_deep_run,
-            astop_deep_run,
-        )
-
-        fallback_map = {
-            "start": astart_deep_run,
-            "stop": astop_deep_run,
-            "status": astatus_deep_run,
-            "list": alist_deep_run_sessions,
-            "show": aresolve_deep_run_session,
-        }
-        op = handler  # str key when engine is None
-        return await fallback_map[op](config.repo_root, *args, **kwargs)
-
     def _serialize_session(session: Any) -> dict[str, Any] | None:
         from vaner.cli.commands.deep_run import _session_to_dict
 

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -29,6 +29,24 @@ from vaner.intent.allocator import PortfolioAllocator
 from vaner.intent.arcs import ArcObservation, ConversationArcModel, classify_query_category, derive_prompt_macro
 from vaner.intent.briefing import BriefingAssembler
 from vaner.intent.cache import TieredPredictionCache
+from vaner.intent.deep_run import (
+    DeepRunFocus,
+    DeepRunHorizonBias,
+    DeepRunLocality,
+    DeepRunPauseReason,
+    DeepRunPreset,
+    DeepRunSession,
+    DeepRunSummary,
+)
+from vaner.intent.deep_run_gates import (
+    NoOpResourceGateProbe,
+    ResourceGateConfig,
+    ResourceGateProbe,
+    cost_gate_spent_usd,
+    evaluate_resource_gates,
+    reset_cost_gate,
+    set_active_session_for_routing,
+)
 from vaner.intent.drafter import Drafter
 from vaner.intent.ev import jaccard_reuse
 from vaner.intent.features import extract_hybrid_features
@@ -65,6 +83,7 @@ from vaner.models.config import ComputeConfig, ExplorationConfig, VanerConfig
 from vaner.models.context import ContextPackage
 from vaner.models.decision import DecisionRecord, PredictionLink, ScoreFactor
 from vaner.models.signal import SignalEvent
+from vaner.store import deep_run as deep_run_store
 from vaner.store.artefacts import ArtefactStore
 from vaner.store.profile_store import UserProfileStore
 from vaner.store.scenarios import ScenarioStore
@@ -196,6 +215,18 @@ class VanerEngine:
         # string / list means "no prior observation", which yields no signals.
         self._last_observed_head_sha: str = ""
         self._last_observed_categories: list[str] = []
+        # 0.8.3 WS1: cached active Deep-Run session. Loaded from the store
+        # by ``initialize()`` (resume-on-restart), updated by
+        # ``start_deep_run`` / ``stop_deep_run``. ``None`` means no
+        # session is in flight.
+        self._active_deep_run_session: DeepRunSession | None = None
+        self._deep_run_loaded: bool = False
+        # 0.8.3 WS2: resource gate probe + threshold config. The default
+        # NoOpResourceGateProbe reports "no constraint" everywhere so
+        # tests do not need to mock platform info; production wiring
+        # plugs in a psutil-backed probe via ``set_resource_gate_probe``.
+        self._resource_gate_probe: ResourceGateProbe = NoOpResourceGateProbe()
+        self._resource_gate_config = ResourceGateConfig()
         # WS9: single canonical briefing assembler. Engine holds it so the
         # approximation-warning latch is shared across call sites (draft path
         # + evidence-threshold synthesis). A real tokenizer can be injected
@@ -314,6 +345,7 @@ class VanerEngine:
             self._arc_loaded = True
         await self._sync_extra_context_sources()
         await self._sync_pinned_facts()
+        await self._resume_deep_run_on_restart()
 
     def invalidate_extra_sources(self) -> None:
         """Mark external context sources dirty so they are re-synced."""
@@ -2969,6 +3001,226 @@ class VanerEngine:
         await self.initialize()
         graph = await self._load_graph()
         return graph.propagate(source_key, depth=depth)
+
+    async def _resume_deep_run_on_restart(self) -> None:
+        """Resume / expire / clear the cached Deep-Run session on startup.
+
+        Called from ``initialize()``. Idempotent — flips
+        ``_deep_run_loaded`` after the first successful run so subsequent
+        ``initialize()`` calls (which happen on every ``observe`` and
+        ``prepare``) are no-ops.
+
+        Two cases:
+
+        1. The DB has a session whose ``ends_at`` is in the past — the
+           daemon was likely killed during a window. Mark it ``ended``
+           with ``cancelled_reason="expired_on_restart"`` and clear the
+           cache.
+        2. The DB has a session whose ``ends_at`` is still in the
+           future — restore it to the in-memory cache. Counters and
+           ``status`` are taken from the persisted row verbatim; any
+           in-flight policy state (preset bias, locality, etc.) is
+           re-applied by the next cycle.
+        """
+
+        if self._deep_run_loaded:
+            return
+        await deep_run_store.close_expired_sessions(self.store.db_path, now=time.time())
+        self._active_deep_run_session = await deep_run_store.get_active_session(self.store.db_path)
+        # WS2: publish the restored session to the routing singleton +
+        # cost-gate state so the router enforces locality / cost from
+        # the moment the engine comes up. ``None`` clears both.
+        set_active_session_for_routing(self._active_deep_run_session)
+        reset_cost_gate(self._active_deep_run_session)
+        self._deep_run_loaded = True
+
+    async def start_deep_run(
+        self,
+        *,
+        ends_at: float,
+        preset: DeepRunPreset = "balanced",
+        focus: DeepRunFocus = "active_goals",
+        horizon_bias: DeepRunHorizonBias = "balanced",
+        locality: DeepRunLocality = "local_preferred",
+        cost_cap_usd: float = 0.0,
+        workspace_root: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> DeepRunSession:
+        """Start a new Deep-Run session.
+
+        Single-active-session is enforced at the store layer — a second
+        concurrent ``start_deep_run`` raises
+        :class:`DeepRunActiveSessionExistsError`. Surfaces (CLI / MCP /
+        cockpit / desktop) translate that into a stable user-facing
+        message.
+
+        ``cost_cap_usd`` defaults to ``0.0``, which means *no remote
+        spend permitted* for the session — the safe default. Callers
+        wanting cloud spend opt in explicitly per session.
+        """
+
+        await self.initialize()
+        session = DeepRunSession.new(
+            ends_at=ends_at,
+            preset=preset,
+            focus=focus,
+            horizon_bias=horizon_bias,
+            locality=locality,
+            cost_cap_usd=cost_cap_usd,
+            workspace_root=workspace_root or str(self.config.repo_root),
+            metadata=metadata,
+        )
+        await deep_run_store.create_session(self.store.db_path, session)
+        self._active_deep_run_session = session
+        # WS2: publish to the router + reset the in-memory cost gate
+        # so the very next remote-call decision sees the new policy.
+        set_active_session_for_routing(session)
+        reset_cost_gate(session)
+        return session
+
+    async def stop_deep_run(self, *, kill: bool = False, reason: str | None = None) -> DeepRunSummary | None:
+        """Stop the currently active Deep-Run session.
+
+        Returns the final :class:`DeepRunSummary`, or ``None`` if no
+        session was active. ``kill=True`` records ``status="killed"``
+        for the audit trail; the caller is responsible for halting
+        in-flight cycles. ``kill=False`` (default) records
+        ``status="ended"`` for a clean stop.
+        """
+
+        await self.initialize()
+        session = self._active_deep_run_session
+        if session is None:
+            return None
+        now = time.time()
+        new_status = "killed" if kill else "ended"
+        await deep_run_store.update_session_status(
+            self.store.db_path,
+            session.id,
+            status=new_status,
+            ended_at=now,
+            cancelled_reason=reason if reason is not None else session.cancelled_reason,
+        )
+        # Refresh from disk so the summary reflects any concurrent
+        # counter increments the cycle loop wrote in parallel.
+        refreshed = await deep_run_store.get_session(self.store.db_path, session.id)
+        self._active_deep_run_session = None
+        # WS2: clear the routing singleton + cost gate so subsequent
+        # remote calls fall back to the router's normal behaviour.
+        set_active_session_for_routing(None)
+        reset_cost_gate(None)
+        if refreshed is None:
+            return None
+        return DeepRunSummary.from_session(refreshed)
+
+    async def current_deep_run(self) -> DeepRunSession | None:
+        """Return the active Deep-Run session, or ``None``.
+
+        Reads from the in-memory cache. The cache is populated by
+        ``initialize()`` / ``start_deep_run`` and cleared by
+        ``stop_deep_run``; it is the canonical record every Vaner
+        surface should render.
+        """
+
+        await self.initialize()
+        return self._active_deep_run_session
+
+    async def list_deep_run_sessions(self, *, limit: int = 20) -> list[DeepRunSession]:
+        """Recent Deep-Run sessions, newest first. Includes terminated
+        sessions for the history surface."""
+
+        await self.initialize()
+        return await deep_run_store.list_sessions(self.store.db_path, limit=limit)
+
+    def set_resource_gate_probe(
+        self,
+        probe: ResourceGateProbe,
+        *,
+        config: ResourceGateConfig | None = None,
+    ) -> None:
+        """Inject a platform-specific :class:`ResourceGateProbe`.
+
+        Production daemon wires a psutil-backed probe at startup; tests
+        compose with the mutable :class:`NoOpResourceGateProbe`. Safe to
+        call at any time — the next gate evaluation uses the new probe.
+        """
+
+        self._resource_gate_probe = probe
+        if config is not None:
+            self._resource_gate_config = config
+
+    async def evaluate_deep_run_gates(self) -> list[DeepRunPauseReason]:
+        """Evaluate the resource gates against the current probe.
+
+        If a session is active and the gates report constraints that
+        differ from the session's recorded ``pause_reasons``, persist
+        the new set and flip the session's status accordingly:
+
+        - non-empty constraints + ``status == 'active'`` ⇒ ``paused``
+        - empty constraints + ``status == 'paused'`` ⇒ ``active``
+        - same constraints ⇒ no-op (avoids spurious DB writes)
+
+        Returns the current set of pause reasons (empty when the
+        session may run, or when no session is active).
+        """
+
+        session = self._active_deep_run_session
+        if session is None:
+            return []
+        reasons = evaluate_resource_gates(
+            probe=self._resource_gate_probe,
+            config=self._resource_gate_config,
+        )
+        same = sorted(reasons) == sorted(session.pause_reasons)
+        if same and ((reasons and session.status == "paused") or (not reasons and session.status == "active")):
+            return reasons
+        new_status = "paused" if reasons else "active"
+        await deep_run_store.update_session_status(
+            self.store.db_path,
+            session.id,
+            status=new_status,
+            pause_reasons=reasons,
+        )
+        session.pause_reasons = list(reasons)
+        session.status = new_status
+        return reasons
+
+    async def flush_deep_run_cost_to_store(self) -> float | None:
+        """Push the in-memory cost-gate spend into the persisted session row.
+
+        Returns the persisted ``spend_usd`` after the flush, or ``None``
+        if no session / no cost gate. Engine calls this at end of cycle
+        so the cockpit / CLI / desktop see up-to-date durable spend.
+        """
+
+        session = self._active_deep_run_session
+        if session is None:
+            return None
+        in_memory = cost_gate_spent_usd()
+        if in_memory is None:
+            return None
+        delta = max(0.0, in_memory - session.spend_usd)
+        if delta > 0:
+            await deep_run_store.increment_session_counters(self.store.db_path, session.id, spend_usd=delta)
+            session.spend_usd = in_memory
+        return session.spend_usd
+
+    async def increment_deep_run_cycle_counter(self, *, promoted_count: int = 0) -> None:
+        """Advance the active session's ``cycles_run`` (+optional promoted
+        count) by one cycle. Called by the engine at the end of every
+        cycle that ran while a Deep-Run session was active."""
+
+        session = self._active_deep_run_session
+        if session is None:
+            return
+        await deep_run_store.increment_session_counters(
+            self.store.db_path,
+            session.id,
+            cycles_run=1,
+            promoted_count=promoted_count,
+        )
+        session.cycles_run += 1
+        session.promoted_count += promoted_count
 
     async def run_background(self, interval_seconds: int = 15, governor: PredictionGovernor | None = None) -> None:
         self._running = True

--- a/src/vaner/intent/deep_run.py
+++ b/src/vaner/intent/deep_run.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Overnight / Deep-Run Mode data model (0.8.3).
+
+Deep-Run Mode is a *policy layer* on top of the engine. It distinguishes
+"the user is incidentally idle" (a resource condition the engine already
+tracks) from "the user has declared a long, predictable away window and
+wants preparedness over immediacy" (an intent signal). When the user opts
+in via CLI / MCP / cockpit / desktop, the engine adopts a different
+stance for the duration of the window: longer per-cycle utilisation,
+broader exploration frontier, deeper drafting bars, **maturation passes
+on already-ready predictions**, and a persisted summary at the end.
+
+This module owns the core types:
+
+- :class:`DeepRunSession` — the persisted policy record. One row per
+  declared window. The engine's governor consults the active session
+  every cycle; the cockpit / desktop / CLI / MCP all read this single
+  canonical record. Single-active-session is enforced at the store
+  layer (see :mod:`vaner.store.deep_run`).
+- :class:`DeepRunSummary` — post-session aggregate. Reports four
+  honest counts (kept / discarded / rolled back / failed-3x) rather
+  than a single inflated "matured" number, per the spec's anti-self-
+  judging discipline (§9.2).
+- :class:`DeepRunPassLogEntry` — one row in the per-pass audit log.
+  Used by ``vaner.explain`` and the cockpit history panel; required
+  for the maturation-effectiveness bench (§14).
+
+The dataclass shape mirrors :mod:`vaner.intent.artefacts` so callers can
+treat identity, mutable state, and audit records independently. There is
+no dependency on ``goals.py``, ``prediction.py``, or ``governor.py`` —
+status strings that cross module boundaries are typed as plain
+``Literal`` here.
+
+Cycle-safety note: the maturation-pass machinery (``MaturationContract``,
+``MaturationPassRef``) lives in WS3 and is not declared here. WS1 ships
+the session lifecycle + audit-log skeleton only.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+DeepRunPreset = Literal["conservative", "balanced", "aggressive"]
+DeepRunFocus = Literal["active_goals", "current_workspace", "all_recent"]
+DeepRunHorizonBias = Literal[
+    "likely_next",
+    "long_horizon",
+    "finish_partials",
+    "balanced",
+]
+DeepRunLocality = Literal["local_only", "local_preferred", "allow_cloud"]
+DeepRunStatus = Literal["active", "paused", "ended", "killed"]
+
+DeepRunPassAction = Literal[
+    # Maturation lifecycle (WS3): kept = judge approved + persisted;
+    # discarded = judge rejected; rolled_back = subsequent reconciliation
+    # contradicted a kept maturation during its probation window;
+    # failed = repeated revisits exhausted the per-prediction cap.
+    "matured_kept",
+    "matured_discarded",
+    "matured_rolled_back",
+    "matured_failed",
+    # Non-maturation actions for completeness (the same audit log records
+    # frontier exploration during a Deep-Run window so cycle composition
+    # is reconstructable post-hoc).
+    "promoted",
+    "explored",
+]
+
+# Reasons a Deep-Run session may pause without ending. Surfaced in
+# ``DeepRunSession.pause_reasons`` and in the user-facing status displays.
+DeepRunPauseReason = Literal[
+    "battery",
+    "thermal",
+    "user_input_observed",
+    "engine_error_rate",
+    "cost_cap_exceeded",
+    "user_requested",
+]
+
+
+def new_deep_run_session_id() -> str:
+    """Fresh uuid4-based id for a new :class:`DeepRunSession`."""
+    return uuid.uuid4().hex
+
+
+def new_deep_run_pass_id() -> str:
+    """Fresh uuid4-based id for a :class:`DeepRunPassLogEntry`."""
+    return uuid.uuid4().hex
+
+
+@dataclass(slots=True)
+class DeepRunSession:
+    """The persisted policy record for one declared away window.
+
+    Identity is the ``id`` (uuid). Lifecycle is captured by ``status``:
+    a session moves from ``active`` to ``paused`` (and back) as resource
+    or cost gates fire, and terminates at ``ended`` (clock-determined or
+    user stop) or ``killed`` (immediate stop, in-flight cycle abandoned).
+
+    Counters (``cycles_run``, ``matured_kept`` …) are updated by the
+    engine at the end of each cycle. The four maturation-outcome
+    counters together with ``cycles_run`` give a complete, honest
+    accounting of what the session did — see spec §14.1 (the
+    judge–external agreement gate would be impossible to interpret if
+    the session reported only ``matured_kept``).
+
+    ``spend_usd`` accumulates remote-backend cost (per
+    ``ExplorationEndpoint.cost_per_1k_tokens``) and is the gate
+    consulted by the router when ``cost_cap_usd > 0``.
+    ``cost_cap_usd == 0`` is the safe default and means *no remote
+    spend permitted* for the session — a hard router-layer block, not
+    a budget warning.
+    """
+
+    id: str
+    started_at: float
+    ends_at: float
+    preset: DeepRunPreset
+    focus: DeepRunFocus
+    horizon_bias: DeepRunHorizonBias
+    locality: DeepRunLocality
+    cost_cap_usd: float
+    workspace_root: str
+    status: DeepRunStatus
+    pause_reasons: list[DeepRunPauseReason] = field(default_factory=list)
+    spend_usd: float = 0.0
+    cycles_run: int = 0
+    matured_kept: int = 0
+    matured_discarded: int = 0
+    matured_rolled_back: int = 0
+    matured_failed: int = 0
+    promoted_count: int = 0
+    ended_at: float | None = None
+    cancelled_reason: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def new(
+        cls,
+        *,
+        ends_at: float,
+        preset: DeepRunPreset,
+        focus: DeepRunFocus,
+        horizon_bias: DeepRunHorizonBias,
+        locality: DeepRunLocality,
+        cost_cap_usd: float,
+        workspace_root: str,
+        metadata: dict[str, str] | None = None,
+        started_at: float | None = None,
+    ) -> DeepRunSession:
+        """Build a fresh active session with a new id and ``status="active"``."""
+
+        return cls(
+            id=new_deep_run_session_id(),
+            started_at=started_at if started_at is not None else time.time(),
+            ends_at=ends_at,
+            preset=preset,
+            focus=focus,
+            horizon_bias=horizon_bias,
+            locality=locality,
+            cost_cap_usd=cost_cap_usd,
+            workspace_root=workspace_root,
+            status="active",
+            metadata=dict(metadata or {}),
+        )
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in ("ended", "killed")
+
+    @property
+    def matured_total(self) -> int:
+        """Total maturation attempts across all four outcomes.
+
+        Per the §9.2 honesty discipline, surfaces should always show all
+        four sub-counters rather than this sum on its own. Provided here
+        for arithmetic convenience (e.g. computing kept-rate in tests).
+        """
+
+        return self.matured_kept + self.matured_discarded + self.matured_rolled_back + self.matured_failed
+
+
+@dataclass(slots=True)
+class DeepRunPassLogEntry:
+    """One row in the per-pass audit log.
+
+    Records what happened to one prediction during one Deep-Run cycle.
+    The engine writes one entry per maturation attempt (kept, discarded,
+    rolled back, or failed) and also records ``promoted`` / ``explored``
+    actions so cycle composition is fully reconstructable.
+
+    ``contract_json`` and ``judge_verdict_json`` are populated by WS3
+    (the maturation pass that constructs a ``MaturationContract`` and
+    invokes the judge). For WS1, both default to ``None`` — only the
+    skeleton schema lands now.
+    """
+
+    id: str
+    session_id: str
+    prediction_id: str
+    pass_at: float
+    action: DeepRunPassAction
+    cycle_index: int
+    before_evidence_score: float | None = None
+    after_evidence_score: float | None = None
+    before_draft_hash: str | None = None
+    after_draft_hash: str | None = None
+    contract_json: str | None = None
+    judge_verdict_json: str | None = None
+
+    @classmethod
+    def new(
+        cls,
+        *,
+        session_id: str,
+        prediction_id: str,
+        action: DeepRunPassAction,
+        cycle_index: int,
+        pass_at: float | None = None,
+        before_evidence_score: float | None = None,
+        after_evidence_score: float | None = None,
+        before_draft_hash: str | None = None,
+        after_draft_hash: str | None = None,
+        contract_json: str | None = None,
+        judge_verdict_json: str | None = None,
+    ) -> DeepRunPassLogEntry:
+        return cls(
+            id=new_deep_run_pass_id(),
+            session_id=session_id,
+            prediction_id=prediction_id,
+            pass_at=pass_at if pass_at is not None else time.time(),
+            action=action,
+            cycle_index=cycle_index,
+            before_evidence_score=before_evidence_score,
+            after_evidence_score=after_evidence_score,
+            before_draft_hash=before_draft_hash,
+            after_draft_hash=after_draft_hash,
+            contract_json=contract_json,
+            judge_verdict_json=judge_verdict_json,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DeepRunSummary:
+    """Post-session aggregate.
+
+    Built from a closed :class:`DeepRunSession` row plus the matching
+    pass-log rows. Surfaced by ``vaner deep-run show <id>``,
+    ``vaner.deep_run.show`` (MCP), the cockpit history detail drawer,
+    and the desktop end-of-session notification.
+
+    The four ``matured_*`` counts are reported separately, never
+    collapsed into a single "matured" number — see spec §9.2 / §14.1.
+    """
+
+    session_id: str
+    started_at: float
+    ended_at: float
+    preset: DeepRunPreset
+    cycles_run: int
+    matured_kept: int
+    matured_discarded: int
+    matured_rolled_back: int
+    matured_failed: int
+    promoted_count: int
+    spend_usd: float
+    pause_reasons: tuple[DeepRunPauseReason, ...]
+    cancelled_reason: str | None
+    final_status: DeepRunStatus
+
+    @classmethod
+    def from_session(cls, session: DeepRunSession) -> DeepRunSummary:
+        if session.ended_at is None:
+            raise ValueError("DeepRunSummary requires an ended session (ended_at is None — session is still active or paused)")
+        return cls(
+            session_id=session.id,
+            started_at=session.started_at,
+            ended_at=session.ended_at,
+            preset=session.preset,
+            cycles_run=session.cycles_run,
+            matured_kept=session.matured_kept,
+            matured_discarded=session.matured_discarded,
+            matured_rolled_back=session.matured_rolled_back,
+            matured_failed=session.matured_failed,
+            promoted_count=session.promoted_count,
+            spend_usd=session.spend_usd,
+            pause_reasons=tuple(session.pause_reasons),
+            cancelled_reason=session.cancelled_reason,
+            final_status=session.status,
+        )

--- a/src/vaner/intent/deep_run_gates.py
+++ b/src/vaner/intent/deep_run_gates.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS2 — Deep-Run resource / cost / locality gates (0.8.3).
+
+Three gate families, each implemented as a pure function operating on
+an active :class:`DeepRunSession` plus a small probe / state object.
+The engine consults the gates each cycle (resource gates) or before
+each remote call (cost + locality). All gates are *signals*, not
+*actions*: they return what is true; the engine decides what to do.
+
+Resource gates
+--------------
+
+A :class:`ResourceGateProbe` Protocol abstracts platform-specific
+queries (battery, thermal, GPU temp, foreground input, engine error
+rate). The default :class:`NoOpResourceGateProbe` returns "no
+constraint" for every method so tests can compose freely; production
+code wires a platform-aware implementation (psutil + per-OS calls)
+that lives outside this module.
+
+Cost + locality gates
+---------------------
+
+Pure functions consult an optional active session. Cost gating uses a
+thread-safe in-memory cumulative spend counter (the persisted
+``DeepRunSession.spend_usd`` is updated separately by the engine; the
+in-memory counter is the per-process arbiter for concurrent calls).
+
+Routing-state singleton
+-----------------------
+
+The router (``vaner.router.backends``) needs to consult the active
+session to enforce locality and cost without a parameter-passing
+refactor through every LLM call. The :func:`set_active_session_for_routing`
+/ :func:`get_active_session_for_routing` pair maintains a thread-safe
+process-wide pointer the engine updates on session start / stop. When
+no session is active the pointer is ``None`` and the router falls
+back to its existing behaviour.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from vaner.intent.deep_run import DeepRunPauseReason, DeepRunSession
+
+# ---------------------------------------------------------------------------
+# Resource gate probe
+# ---------------------------------------------------------------------------
+
+
+class ResourceGateProbe(Protocol):
+    """Platform-agnostic resource probe.
+
+    Implementations wrap psutil / OS-specific calls. The default
+    :class:`NoOpResourceGateProbe` returns "no constraint" for every
+    method; a production probe wired by the daemon returns real
+    platform values. Each method is sync and cheap enough to call
+    once per cycle.
+    """
+
+    def battery_charge_percent(self) -> int | None:
+        """Battery charge as 0–100, or ``None`` if no battery present."""
+
+    def is_on_battery(self) -> bool:
+        """``True`` when the device is running on battery (not plugged in)."""
+
+    def is_thermal_throttled(self) -> bool:
+        """``True`` when the OS reports CPU thermal throttling active."""
+
+    def gpu_temp_celsius(self) -> int | None:
+        """Hottest GPU temperature in C, or ``None`` if not measurable."""
+
+    def seconds_since_user_input(self) -> float | None:
+        """Seconds since the last foreground user input event, or
+        ``None`` if not measurable. ``0.0`` means input is happening
+        right now."""
+
+    def cycle_failure_rate(self) -> float:
+        """Recent engine cycle failure rate, 0.0–1.0. Used to pause
+        Deep-Run when the engine is in trouble rather than silently
+        burning compute on broken cycles."""
+
+
+@dataclass(slots=True)
+class NoOpResourceGateProbe:
+    """Default probe: every method reports "no constraint."
+
+    Used in tests and on platforms where no probe has been wired yet.
+    Production wiring should replace this with a psutil-backed probe
+    in the daemon startup path. Mutable in tests via the public
+    fields below for easy preset of synthetic resource conditions.
+    """
+
+    battery_pct: int | None = None
+    on_battery: bool = False
+    thermal_throttled: bool = False
+    gpu_temp: int | None = None
+    seconds_idle: float | None = None
+    failure_rate: float = 0.0
+
+    def battery_charge_percent(self) -> int | None:
+        return self.battery_pct
+
+    def is_on_battery(self) -> bool:
+        return self.on_battery
+
+    def is_thermal_throttled(self) -> bool:
+        return self.thermal_throttled
+
+    def gpu_temp_celsius(self) -> int | None:
+        return self.gpu_temp
+
+    def seconds_since_user_input(self) -> float | None:
+        return self.seconds_idle
+
+    def cycle_failure_rate(self) -> float:
+        return self.failure_rate
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceGateConfig:
+    """Thresholds for the resource gates. Mirrors
+    :data:`vaner.toml [deep_run.guardrails]`. Defaults match spec §16.1."""
+
+    battery_pause_charge_threshold: int = 30
+    gpu_temp_pause_ceiling_c: int = 85
+    cpu_throttle_pause_enabled: bool = True
+    user_input_pause_grace_seconds: int = 60
+    engine_error_rate_pause_threshold: float = 0.10
+
+
+def evaluate_resource_gates(
+    *,
+    probe: ResourceGateProbe,
+    config: ResourceGateConfig | None = None,
+) -> list[DeepRunPauseReason]:
+    """Return the set of pause reasons currently asserted by the probe.
+
+    Empty list means "no constraints — the session may run." A
+    non-empty list means the engine should mark the session
+    ``status='paused'`` with these reasons until at least one clears.
+
+    The engine is responsible for the pause/resume *decision*; this
+    function only reports facts.
+    """
+
+    cfg = config if config is not None else ResourceGateConfig()
+    reasons: list[DeepRunPauseReason] = []
+
+    if probe.is_on_battery():
+        charge = probe.battery_charge_percent()
+        if charge is not None and charge < cfg.battery_pause_charge_threshold:
+            reasons.append("battery")
+
+    thermal_hit = False
+    if cfg.cpu_throttle_pause_enabled and probe.is_thermal_throttled():
+        thermal_hit = True
+    gpu_temp = probe.gpu_temp_celsius()
+    if gpu_temp is not None and gpu_temp >= cfg.gpu_temp_pause_ceiling_c:
+        thermal_hit = True
+    if thermal_hit:
+        reasons.append("thermal")
+
+    secs = probe.seconds_since_user_input()
+    if secs is not None and secs < cfg.user_input_pause_grace_seconds:
+        reasons.append("user_input_observed")
+
+    if probe.cycle_failure_rate() > cfg.engine_error_rate_pause_threshold:
+        reasons.append("engine_error_rate")
+
+    return reasons
+
+
+# ---------------------------------------------------------------------------
+# Cost gate (thread-safe in-memory cumulative spend)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _CostGateState:
+    """Per-session cumulative remote spend counter.
+
+    The persisted ``DeepRunSession.spend_usd`` is the durable record.
+    This in-memory counter is the per-process arbiter that prevents
+    concurrent calls from each individually thinking they fit under
+    the cap and collectively overshooting it.
+    """
+
+    session_id: str
+    cap_usd: float
+    spent_usd: float = 0.0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_cost_state: _CostGateState | None = None
+_cost_state_lock = threading.Lock()
+
+
+def reset_cost_gate(session: DeepRunSession | None) -> None:
+    """Initialise (or clear) the in-memory cost gate for a session.
+
+    Engine calls this on ``start_deep_run`` (with the session) and on
+    ``stop_deep_run`` (with ``None``). Calling repeatedly with the
+    same session id is idempotent. Calling with a different session
+    id swaps the gate to the new session and zeros the counter.
+    """
+
+    global _cost_state
+    with _cost_state_lock:
+        if session is None:
+            _cost_state = None
+            return
+        _cost_state = _CostGateState(
+            session_id=session.id,
+            cap_usd=float(session.cost_cap_usd),
+            spent_usd=float(session.spend_usd),
+        )
+
+
+def try_consume_cost(estimated_usd: float) -> bool:
+    """Reserve ``estimated_usd`` against the active cost cap.
+
+    Returns ``True`` if the spend fits and was reserved; ``False`` if
+    it would exceed the cap. A return of ``False`` is the engine's
+    cue to either skip the call, downgrade to a local backend, or
+    pause the session.
+
+    With ``cap_usd == 0.0`` (the safe default) any positive estimate
+    returns ``False`` — no remote spend permitted. A zero-cost call
+    (e.g. a cache hit) always returns ``True``.
+
+    Thread-safe; safe to call from concurrent backend tasks. Returns
+    ``True`` (no-op) when no Deep-Run session is active.
+    """
+
+    state = _cost_state
+    if state is None:
+        return True
+    with state.lock:
+        if estimated_usd <= 0.0:
+            return True
+        if state.cap_usd <= 0.0:
+            return False
+        if state.spent_usd + estimated_usd > state.cap_usd:
+            return False
+        state.spent_usd += float(estimated_usd)
+        return True
+
+
+def remaining_cost_budget() -> float | None:
+    """Return the remaining budget in USD, or ``None`` if no session."""
+
+    state = _cost_state
+    if state is None:
+        return None
+    with state.lock:
+        return max(0.0, state.cap_usd - state.spent_usd)
+
+
+def cost_gate_spent_usd() -> float | None:
+    """Return the cumulative in-memory spend, or ``None`` if no session.
+
+    Used by the engine to flush the in-memory counter into the
+    persisted ``DeepRunSession.spend_usd`` periodically (durable
+    record vs. fast-path arbiter). The two diverge briefly between
+    flushes; the persisted value lags the in-memory value.
+    """
+
+    state = _cost_state
+    if state is None:
+        return None
+    with state.lock:
+        return state.spent_usd
+
+
+# ---------------------------------------------------------------------------
+# Locality gate
+# ---------------------------------------------------------------------------
+
+
+def _is_local_url(base_url: str) -> bool:
+    """Mirror of ``vaner.router.backends._is_local_backend`` — kept as
+    a duplicate to avoid an intent → router import (router can import
+    intent freely; intent should not depend on router)."""
+
+    lowered = base_url.lower()
+    return "localhost" in lowered or "127.0.0.1" in lowered or "0.0.0.0" in lowered
+
+
+def is_remote_call_allowed(base_url: str) -> bool:
+    """Return ``True`` if the active session permits a call to ``base_url``.
+
+    - No active session ⇒ always ``True`` (unchanged router behaviour).
+    - Active session with ``locality='local_only'`` ⇒ only local URLs.
+    - Active session with ``locality in {'local_preferred', 'allow_cloud'}``
+      ⇒ always ``True`` (locality preference is enforced by the router's
+      pre-existing fallback logic, not by hard gating here).
+
+    Thread-safe; intended to be called by the router from any context.
+    """
+
+    session = get_active_session_for_routing()
+    if session is None:
+        return True
+    if session.locality == "local_only":
+        return _is_local_url(base_url)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Routing-state singleton
+# ---------------------------------------------------------------------------
+
+
+_routing_session: DeepRunSession | None = None
+_routing_session_lock = threading.Lock()
+
+
+def set_active_session_for_routing(session: DeepRunSession | None) -> None:
+    """Publish the active Deep-Run session so the router can consult it.
+
+    Engine calls this on ``start_deep_run`` (with the session) and on
+    ``stop_deep_run`` (with ``None``). Also called by
+    ``_resume_deep_run_on_restart`` when an in-flight session is
+    restored from the store.
+
+    The router reads the pointer via :func:`get_active_session_for_routing`
+    in the cost / locality gate paths.
+    """
+
+    global _routing_session
+    with _routing_session_lock:
+        _routing_session = session
+
+
+def get_active_session_for_routing() -> DeepRunSession | None:
+    """Return the active session pointer, or ``None`` if no session."""
+
+    with _routing_session_lock:
+        return _routing_session
+
+
+__all__ = [
+    "NoOpResourceGateProbe",
+    "ResourceGateConfig",
+    "ResourceGateProbe",
+    "cost_gate_spent_usd",
+    "evaluate_resource_gates",
+    "get_active_session_for_routing",
+    "is_remote_call_allowed",
+    "remaining_cost_budget",
+    "reset_cost_gate",
+    "set_active_session_for_routing",
+    "try_consume_cost",
+]

--- a/src/vaner/intent/deep_run_maturation.py
+++ b/src/vaner/intent/deep_run_maturation.py
@@ -186,7 +186,8 @@ class MaturationDrafterCallable(Protocol):
         self,
         prediction: PredictedPrompt,
         contract: MaturationContract,
-    ) -> tuple[str, list[str]]: ...
+    ) -> tuple[str, list[str]]:
+        """Protocol — no implementation."""
 
 
 class JudgeCallable(Protocol):
@@ -206,7 +207,8 @@ class JudgeCallable(Protocol):
         old_draft: str | None,
         new_draft: str,
         new_evidence_refs: list[str],
-    ) -> MaturationVerdict: ...
+    ) -> MaturationVerdict:
+        """Protocol — no implementation."""
 
 
 # ---------------------------------------------------------------------------

--- a/src/vaner/intent/deep_run_maturation.py
+++ b/src/vaner/intent/deep_run_maturation.py
@@ -1,0 +1,782 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS3 — Deep-Run maturation revisiting (0.8.3).
+
+The central new mechanism. A maturation pass takes an already-``READY``
+prediction and re-enters the drafter with a *contract* derived from
+the prediction's current weakness signal: low evidence, shallow draft,
+stale grounding, unresolved contradiction, or high evidence volatility.
+The drafter produces a candidate new draft. A separate **judge** —
+distinct callable, distinct prompt, skeptical default — measures the
+new draft against the contract clause-by-clause. Persistence requires
+all "must" clauses satisfied AND zero "forbidden" clauses violated.
+
+Why this shape (per spec §9.2): a same-model self-judging loop will
+systematically over-approve its own work. The defenses, all required:
+
+1. **Generator/judge role separation.** The drafter never sees the
+   judge's prompt; the judge never sees the drafter's prompt. The
+   judge defaults to ``kept=False`` and may only return ``kept=True``
+   when it can name concrete contract-specified evidence.
+2. **Contract before drafter.** The :class:`MaturationContract` is
+   built from the prediction's current weakness *before* the drafter
+   runs, so the judge measures against an explicit standard rather
+   than a feeling.
+3. **Probationary persistence + diminishing-returns thresholds.** A
+   kept maturation is probationary for N cycles; subsequent
+   reconciliation contradictions roll it back. The persistence
+   threshold tightens with each ``revision``.
+
+The default judge in this module is **rubric-based and programmatic**
+— it does not require an LLM. It compares old vs. new draft using
+explicit, gradable rules (evidence-ref deltas, paragraph diffs, length
+checks). An LLM-backed judge can be plugged in later via the
+:class:`JudgeCallable` Protocol; the programmatic default is the
+floor, not the ceiling.
+
+Engine integration is opt-in: the engine only calls
+:func:`mature_one` from a Deep-Run cycle hook. Outside Deep-Run,
+none of this code runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from vaner.intent.deep_run import (
+    DeepRunPassAction,
+    DeepRunSession,
+)
+from vaner.intent.deep_run_policy import preset_for
+from vaner.intent.prediction import PredictedPrompt
+
+TargetWeakness = Literal[
+    "low_evidence",
+    "high_volatility",
+    "shallow_draft",
+    "stale_grounding",
+    "unresolved_contradiction",
+]
+
+ClauseKind = Literal["must", "forbidden"]
+
+
+# ---------------------------------------------------------------------------
+# Contract types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ContractClause:
+    """A single, gradable rule the new draft must satisfy (or avoid).
+
+    ``key`` is a stable identifier (e.g. ``"new_evidence_refs_min_2"``)
+    used by the judge to look up the corresponding programmatic check.
+    ``description`` is human-readable; it appears in audit logs and in
+    judge verdicts so the user can understand why a draft was kept or
+    discarded.
+    """
+
+    key: str
+    description: str
+    kind: ClauseKind
+
+
+@dataclass(frozen=True, slots=True)
+class MaturationContract:
+    """The success criteria for one maturation pass (spec §9.2(b)).
+
+    Built from the prediction's current weakness *before* invoking
+    the drafter so the contract is not retrofitted to whatever the
+    drafter happens to produce. The judge measures the new draft
+    against this contract clause-by-clause.
+
+    A kept verdict requires *all* ``must`` clauses satisfied AND
+    *zero* ``forbidden`` clauses violated.
+    """
+
+    pass_id: str
+    target_weakness: TargetWeakness
+    must_clauses: tuple[ContractClause, ...]
+    forbidden_clauses: tuple[ContractClause, ...]
+    grading_rubric_version: str = "v1"
+
+    @property
+    def required_new_evidence_refs(self) -> int:
+        """Convenience: the minimum number of new evidence refs the
+        contract requires (0 if no clause demands it). Read by the
+        rubric judge to score the ``low_evidence`` target."""
+
+        for clause in self.must_clauses:
+            if clause.key.startswith("new_evidence_refs_min_"):
+                try:
+                    return int(clause.key.rsplit("_", 1)[-1])
+                except ValueError:
+                    continue
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Verdict + outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class MaturationVerdict:
+    """Output of a :class:`JudgeCallable` for one pass.
+
+    ``kept=True`` means the new draft satisfies the contract and
+    should be persisted. ``kept=False`` means discard the new draft
+    and increment ``failed_revisits``.
+
+    ``satisfied_clauses`` lists the ``must`` clause keys the judge
+    confirmed; ``failed_clause`` is set when the verdict is
+    ``kept=False`` and identifies the first clause that failed
+    (whether a ``must`` was unsatisfied or a ``forbidden`` was
+    violated). The pair forms the audit trail surfaced by
+    ``vaner.explain``.
+    """
+
+    kept: bool
+    satisfied_clauses: tuple[str, ...]
+    failed_clause: str | None
+    reason: str
+
+
+@dataclass(slots=True)
+class MaturationOutcome:
+    """Result of one :func:`mature_one` call."""
+
+    prediction_id: str
+    session_id: str
+    cycle_index: int
+    contract: MaturationContract
+    verdict: MaturationVerdict
+    action: DeepRunPassAction
+    before_evidence_score: float
+    after_evidence_score: float
+    before_draft_hash: str | None
+    after_draft_hash: str | None
+    new_draft: str | None  # populated when kept=True; None otherwise
+
+
+# ---------------------------------------------------------------------------
+# Drafter + judge protocols
+# ---------------------------------------------------------------------------
+
+
+class MaturationDrafterCallable(Protocol):
+    """Async callable: produce a candidate new draft for a maturation pass.
+
+    Receives the existing :class:`PredictedPrompt` plus the
+    :class:`MaturationContract`. Must return a tuple of
+    ``(new_draft_text, new_evidence_refs)`` where ``new_evidence_refs``
+    is the list of evidence ref strings the drafter included in the
+    new draft (used by the judge to verify ``new_evidence_refs_min_N``
+    clauses without requiring text-mining).
+
+    Real implementations wrap the existing :class:`Drafter` with a
+    maturation-specific prompt frame; tests pass a synthetic stub.
+    """
+
+    async def __call__(
+        self,
+        prediction: PredictedPrompt,
+        contract: MaturationContract,
+    ) -> tuple[str, list[str]]: ...
+
+
+class JudgeCallable(Protocol):
+    """Async callable: grade a candidate new draft against a contract.
+
+    Distinct from :class:`MaturationDrafterCallable` — different
+    signature, different prompt frame, different identity. Defaults
+    to a *not improved* verdict if any contract clause is unsatisfied
+    or violated.
+    """
+
+    async def __call__(
+        self,
+        *,
+        prediction: PredictedPrompt,
+        contract: MaturationContract,
+        old_draft: str | None,
+        new_draft: str,
+        new_evidence_refs: list[str],
+    ) -> MaturationVerdict: ...
+
+
+# ---------------------------------------------------------------------------
+# Contract builder
+# ---------------------------------------------------------------------------
+
+
+_UNIVERSAL_FORBIDDEN: tuple[ContractClause, ...] = (
+    ContractClause(
+        key="no_length_only_growth",
+        description="No length-only growth (≥30% longer with no new evidence_refs).",
+        kind="forbidden",
+    ),
+    ContractClause(
+        key="no_evidence_ref_removal",
+        description="Do not silently remove correct prior evidence_refs.",
+        kind="forbidden",
+    ),
+    ContractClause(
+        key="anchor_preserved",
+        description="The matured draft must still address the same anchor.",
+        kind="forbidden",
+    ),
+)
+
+
+def _detect_target_weakness(
+    prediction: PredictedPrompt,
+    *,
+    evidence_floor: float,
+) -> TargetWeakness:
+    """Pick the dominant weakness signal driving this maturation pass.
+
+    Order of precedence (tightest signal first): stale grounding wins
+    if file content drifted; otherwise low evidence; otherwise shallow
+    draft. Volatility / contradiction targets land in WS3.x with the
+    full reconciliation hook-up.
+    """
+
+    artifacts = prediction.artifacts
+    if artifacts.evidence_score < evidence_floor:
+        return "low_evidence"
+    draft = artifacts.draft_answer or ""
+    if len(draft.split()) < 80:
+        return "shallow_draft"
+    return "low_evidence"
+
+
+def build_contract(
+    prediction: PredictedPrompt,
+    *,
+    pass_id: str,
+    evidence_floor: float = 0.6,
+    grading_rubric_version: str = "v1",
+) -> MaturationContract:
+    """Construct the contract for one maturation pass on this prediction.
+
+    The chosen ``target_weakness`` selects the ``must`` clauses; the
+    ``forbidden`` clauses are universal (apply to every weakness).
+    ``evidence_floor`` defaults match the spec's Balanced preset; the
+    engine passes the active preset's threshold for tighter / looser
+    Conservative / Aggressive behaviour.
+    """
+
+    weakness = _detect_target_weakness(prediction, evidence_floor=evidence_floor)
+    must: tuple[ContractClause, ...]
+    if weakness == "low_evidence":
+        must = (
+            ContractClause(
+                key="new_evidence_refs_min_2",
+                description=("Cite ≥2 evidence sources not in the prior evidence_refs set."),
+                kind="must",
+            ),
+        )
+    elif weakness == "shallow_draft":
+        must = (
+            ContractClause(
+                key="add_substantive_paragraph_min_80_words",
+                description=(
+                    "Add ≥1 new substantive paragraph (≥80 words) addressing a sub-question not covered in the prior draft. No paraphrase."
+                ),
+                kind="must",
+            ),
+            ContractClause(
+                key="new_evidence_refs_min_1",
+                description="At least one new evidence_ref accompanying the new content.",
+                kind="must",
+            ),
+        )
+    elif weakness == "stale_grounding":
+        must = (
+            ContractClause(
+                key="refresh_file_hashes_min_1",
+                description="Replace ≥1 stale file_content_hash citation.",
+                kind="must",
+            ),
+        )
+    elif weakness == "high_volatility":
+        must = (
+            ContractClause(
+                key="resolve_named_contradiction",
+                description=(
+                    "Name the prior contradiction by referencing both conflicting "
+                    "evidence_ref ids and either retract one or state the "
+                    "reconciling reading explicitly."
+                ),
+                kind="must",
+            ),
+        )
+    else:  # unresolved_contradiction
+        must = (
+            ContractClause(
+                key="address_contradicting_item",
+                description=("Explicitly reference the conflicting IntentArtefactItem.id and state defer / contradict / synthesise."),
+                kind="must",
+            ),
+        )
+    return MaturationContract(
+        pass_id=pass_id,
+        target_weakness=weakness,
+        must_clauses=must,
+        forbidden_clauses=_UNIVERSAL_FORBIDDEN,
+        grading_rubric_version=grading_rubric_version,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default rubric judge (programmatic, skeptical)
+# ---------------------------------------------------------------------------
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"\b\w+\b", text))
+
+
+def _paragraph_set(text: str) -> set[str]:
+    """Normalised-paragraph set for paraphrase-vs-new detection.
+
+    Two paragraphs that differ only in whitespace / casing collapse
+    to the same key — used by the judge to detect "the new draft just
+    paraphrases the old paragraphs."
+    """
+
+    paragraphs = re.split(r"\n\s*\n", text.strip())
+    return {p.strip().lower() for p in paragraphs if p.strip()}
+
+
+async def default_rubric_judge(
+    *,
+    prediction: PredictedPrompt,
+    contract: MaturationContract,
+    old_draft: str | None,
+    new_draft: str,
+    new_evidence_refs: list[str],
+) -> MaturationVerdict:
+    """The skeptical, programmatic default judge.
+
+    Implements every contract clause as a rule on the
+    ``(old_draft, new_draft, new_evidence_refs)`` tuple. Defaults to
+    ``kept=False`` if any ``must`` is unsatisfied or any ``forbidden``
+    is violated. Provides a concrete, named reason — never a vague
+    "this looks better" verdict.
+
+    This judge is intentionally conservative. False negatives (rejecting
+    a good improvement) are recoverable — the next cycle can try
+    again. False positives (approving a marginal change) are not — the
+    matured draft becomes the new baseline and the user sees worse
+    output than they had before.
+    """
+
+    if not new_draft.strip():
+        return MaturationVerdict(
+            kept=False,
+            satisfied_clauses=(),
+            failed_clause="empty_new_draft",
+            reason="judge: new_draft is empty",
+        )
+
+    old = old_draft or ""
+    prior_refs = set(prediction.artifacts.scenario_ids) | set(_extract_evidence_ref_ids(old))
+    new_refs_set = set(new_evidence_refs)
+
+    # Forbidden: length-only growth.
+    old_len = _word_count(old)
+    new_len = _word_count(new_draft)
+    new_unique_refs = new_refs_set - prior_refs
+    if old_len > 0 and new_len > 1.30 * old_len and not new_unique_refs:
+        return MaturationVerdict(
+            kept=False,
+            satisfied_clauses=(),
+            failed_clause="no_length_only_growth",
+            reason=(f"judge: new draft is {new_len / max(1, old_len):.0%} of old length but introduces no new evidence_refs"),
+        )
+
+    # Forbidden: silent removal of prior evidence refs.
+    if prior_refs and prior_refs - new_refs_set - set(_extract_evidence_ref_ids(new_draft)):
+        # Only flag when the new draft both (a) drops a ref the old
+        # draft had and (b) provides no replacement set that includes it.
+        # Conservative: defer to LLM judge in WS3.x for nuanced reading;
+        # here we only block clear cases where the new draft has fewer
+        # total refs than the old.
+        if len(new_refs_set | set(_extract_evidence_ref_ids(new_draft))) < len(prior_refs):
+            return MaturationVerdict(
+                kept=False,
+                satisfied_clauses=(),
+                failed_clause="no_evidence_ref_removal",
+                reason="judge: new draft drops prior evidence_refs without retraction",
+            )
+
+    # Must clauses — evaluate one at a time.
+    satisfied: list[str] = []
+    for clause in contract.must_clauses:
+        ok, reason = _evaluate_must_clause(
+            clause=clause,
+            old_draft=old,
+            new_draft=new_draft,
+            new_evidence_refs=new_evidence_refs,
+            prior_refs=prior_refs,
+        )
+        if not ok:
+            return MaturationVerdict(
+                kept=False,
+                satisfied_clauses=tuple(satisfied),
+                failed_clause=clause.key,
+                reason=f"judge: clause {clause.key!r} failed — {reason}",
+            )
+        satisfied.append(clause.key)
+
+    return MaturationVerdict(
+        kept=True,
+        satisfied_clauses=tuple(satisfied),
+        failed_clause=None,
+        reason=f"judge: {len(satisfied)} must-clause(s) satisfied; no forbidden violations",
+    )
+
+
+_EVIDENCE_REF_PATTERN = re.compile(r"\[evidence:([a-zA-Z0-9_-]+)\]")
+
+
+def _extract_evidence_ref_ids(text: str) -> set[str]:
+    """Extract evidence-ref tokens of the form ``[evidence:<id>]``
+    from a draft body. Used to detect refs the drafter mentioned
+    inline without listing them in ``new_evidence_refs``."""
+
+    return set(_EVIDENCE_REF_PATTERN.findall(text))
+
+
+def _evaluate_must_clause(
+    *,
+    clause: ContractClause,
+    old_draft: str,
+    new_draft: str,
+    new_evidence_refs: list[str],
+    prior_refs: set[str],
+) -> tuple[bool, str]:
+    key = clause.key
+    if key.startswith("new_evidence_refs_min_"):
+        try:
+            n = int(key.rsplit("_", 1)[-1])
+        except ValueError:
+            return False, f"clause key {key!r} has invalid count suffix"
+        new_unique = set(new_evidence_refs) - prior_refs
+        if len(new_unique) >= n:
+            return True, f"{len(new_unique)} new ref(s) >= {n}"
+        return False, f"only {len(new_unique)} new ref(s) (need {n})"
+    if key == "add_substantive_paragraph_min_80_words":
+        old_paragraphs = _paragraph_set(old_draft)
+        new_paragraphs = _paragraph_set(new_draft) - old_paragraphs
+        substantial = [p for p in new_paragraphs if _word_count(p) >= 80]
+        if substantial:
+            return True, f"{len(substantial)} new paragraph(s) with ≥80 words"
+        return (
+            False,
+            f"no new paragraph >= 80 words (found {len(new_paragraphs)} new paragraphs)",
+        )
+    if key == "refresh_file_hashes_min_1":
+        # Simple heuristic: the new draft cites a file_content_hash that
+        # the old did not. Production version (post-WS3) compares against
+        # the persisted file_content_hashes map directly.
+        old_hashes = set(re.findall(r"\bsha[12]?:[a-f0-9]{8,}\b", old_draft))
+        new_hashes = set(re.findall(r"\bsha[12]?:[a-f0-9]{8,}\b", new_draft))
+        if new_hashes - old_hashes:
+            return True, "new file content hash cited"
+        return False, "no new file_content_hash citation"
+    if key == "resolve_named_contradiction":
+        # Substring match for "[contradiction:..." token. Coarse on
+        # purpose; LLM judge in WS3.x refines.
+        if "[contradiction:" in new_draft and "[contradiction:" not in old_draft:
+            return True, "new contradiction reference present"
+        return False, "no [contradiction:...] reference introduced"
+    if key == "address_contradicting_item":
+        if "[item:" in new_draft and "[item:" not in old_draft:
+            return True, "contradicting item referenced"
+        return False, "no [item:...] reference introduced"
+    return False, f"unknown clause key {key!r}"
+
+
+# ---------------------------------------------------------------------------
+# Candidate ranking + selection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class MaturationCandidate:
+    """One ranked candidate for the next maturation pass."""
+
+    prediction: PredictedPrompt
+    score: float
+    eligible: bool
+    skip_reason: str | None
+
+
+def score_maturation_value(
+    prediction: PredictedPrompt,
+    *,
+    goal_confidence: float = 0.5,
+    artefact_alignment_score: float = 1.0,
+    item_state: str = "pending",
+) -> float:
+    """Compute the ``maturation_value`` score from the spec §9.1 formula.
+
+    Higher = better candidate. Components:
+
+    - ``goal_confidence`` × ``artefact_alignment_score`` — how much
+      this prediction aligns with declared intent
+    - ``(1 - normalized_evidence_score)`` — how much room there is
+      to improve
+    - ``1 / (revision + 1)`` — diminishing returns across revisions
+    - state factor — pending/in_progress/stalled count fully; complete
+      counts at 0.5 (still maturable but lower priority)
+
+    Probationary or failure-capped predictions are excluded by
+    :func:`select_maturation_candidates`, not by this score.
+    """
+
+    evidence_norm = max(0.0, min(1.0, prediction.artifacts.evidence_score / 1.0))
+    evidence_room = 1.0 - evidence_norm
+    state_factor = 1.0 if item_state in ("pending", "in_progress", "stalled") else 0.5
+    revision_decay = 1.0 / (prediction.run.revision + 1)
+    return goal_confidence * artefact_alignment_score * evidence_room * revision_decay * state_factor
+
+
+def select_maturation_candidates(
+    predictions: list[PredictedPrompt],
+    *,
+    session: DeepRunSession,
+    cycle_index: int,
+    max_candidates: int,
+    goal_confidence_lookup: Callable[[PredictedPrompt], float] | None = None,
+    artefact_alignment_lookup: Callable[[PredictedPrompt], float] | None = None,
+    item_state_lookup: Callable[[PredictedPrompt], str] | None = None,
+) -> list[MaturationCandidate]:
+    """Rank READY predictions for the next maturation pass.
+
+    Eligibility filters (in order):
+    1. ``maturation_eligible`` must be True.
+    2. ``readiness == "ready"`` only — pre-ready predictions go through
+       the normal drafter, not maturation.
+    3. ``failed_revisits < preset.max_revisits_per_prediction`` (cap on
+       repeated failures so we stop attempting after exhaustion).
+    4. ``revision < preset.max_revisits_per_prediction`` (cap on kept
+       revisions per prediction).
+    5. ``probationary_until_cycle is None`` or ``< cycle_index`` —
+       predictions in their probation window are not re-matured.
+
+    Returns up to ``max_candidates`` eligible predictions ordered by
+    descending score. Ineligible predictions are returned at the tail
+    (``eligible=False`` + ``skip_reason``) for audit / debug surfaces;
+    callers should filter on ``eligible=True`` before invoking
+    :func:`mature_one`.
+    """
+
+    preset = preset_for(session)
+    cap = preset.max_revisits_per_prediction
+    eligible: list[MaturationCandidate] = []
+    skipped: list[MaturationCandidate] = []
+    for prediction in predictions:
+        skip_reason = _maturation_skip_reason(prediction, cap=cap, cycle_index=cycle_index)
+        if skip_reason is not None:
+            skipped.append(
+                MaturationCandidate(
+                    prediction=prediction,
+                    score=0.0,
+                    eligible=False,
+                    skip_reason=skip_reason,
+                )
+            )
+            continue
+        gc = goal_confidence_lookup(prediction) if goal_confidence_lookup else 0.5
+        aa = artefact_alignment_lookup(prediction) if artefact_alignment_lookup else 1.0
+        st = item_state_lookup(prediction) if item_state_lookup else "pending"
+        score = score_maturation_value(
+            prediction,
+            goal_confidence=gc,
+            artefact_alignment_score=aa,
+            item_state=st,
+        )
+        eligible.append(
+            MaturationCandidate(
+                prediction=prediction,
+                score=score,
+                eligible=True,
+                skip_reason=None,
+            )
+        )
+    eligible.sort(key=lambda c: c.score, reverse=True)
+    return eligible[:max_candidates] + skipped
+
+
+def _maturation_skip_reason(
+    prediction: PredictedPrompt,
+    *,
+    cap: int,
+    cycle_index: int,
+) -> str | None:
+    run = prediction.run
+    if not run.maturation_eligible:
+        return "maturation_eligible=False"
+    if run.readiness != "ready":
+        return f"readiness={run.readiness!r} (only 'ready' eligible)"
+    if run.failed_revisits >= cap:
+        return f"failed_revisits={run.failed_revisits} >= cap={cap}"
+    if run.revision >= cap:
+        return f"revision={run.revision} >= cap={cap}"
+    if run.probationary_until_cycle is not None and run.probationary_until_cycle >= cycle_index:
+        return f"probationary until cycle {run.probationary_until_cycle} (current={cycle_index})"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Maturation pass orchestrator
+# ---------------------------------------------------------------------------
+
+
+_PROBATION_CYCLES = 3
+
+
+def _hash_text(text: str | None) -> str | None:
+    if text is None:
+        return None
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()[:16]
+
+
+async def mature_one(
+    prediction: PredictedPrompt,
+    *,
+    session: DeepRunSession,
+    drafter: MaturationDrafterCallable,
+    judge: JudgeCallable | None = None,
+    cycle_index: int,
+    pass_id: str,
+    evidence_floor: float | None = None,
+    on_kept_evidence_increment: float = 0.10,
+) -> MaturationOutcome:
+    """Run one maturation pass against a single prediction.
+
+    Steps:
+    1. Build contract from current weakness.
+    2. Invoke ``drafter`` with the contract.
+    3. Invoke ``judge`` (default: :func:`default_rubric_judge`) with
+       the (old, new, contract) tuple.
+    4. If kept: persist new draft on the prediction, increment
+       ``revision``, set ``probationary_until_cycle``, bump
+       ``evidence_score``, reset ``failed_revisits`` to 0,
+       update ``last_matured_cycle``.
+    5. If discarded: leave the existing draft alone, increment
+       ``failed_revisits``.
+
+    Returns a :class:`MaturationOutcome` describing what happened. The
+    engine writes a ``deep_run_pass_log`` row from the outcome.
+
+    Note: this function does *not* itself write to the database. It
+    mutates the in-memory ``PredictionRun`` and returns an outcome
+    record; the engine is responsible for persisting both the
+    prediction registry update and the audit-log row. Keeping this
+    separation lets unit tests exercise the full pass logic without
+    a store fixture.
+    """
+
+    judge_callable: JudgeCallable = judge or default_rubric_judge
+    floor = evidence_floor if evidence_floor is not None else preset_for(session).draft_evidence_threshold
+    contract = build_contract(prediction, pass_id=pass_id, evidence_floor=floor)
+    old_draft = prediction.artifacts.draft_answer
+    before_evidence = prediction.artifacts.evidence_score
+    before_hash = _hash_text(old_draft)
+
+    new_draft, new_refs = await drafter(prediction, contract)
+    after_hash = _hash_text(new_draft)
+
+    verdict = await judge_callable(
+        prediction=prediction,
+        contract=contract,
+        old_draft=old_draft,
+        new_draft=new_draft,
+        new_evidence_refs=new_refs,
+    )
+
+    if verdict.kept:
+        prediction.artifacts.draft_answer = new_draft
+        prediction.artifacts.evidence_score = before_evidence + on_kept_evidence_increment
+        prediction.run.revision += 1
+        prediction.run.last_matured_cycle = cycle_index
+        prediction.run.probationary_until_cycle = cycle_index + _PROBATION_CYCLES
+        prediction.run.failed_revisits = 0
+        action: DeepRunPassAction = "matured_kept"
+    else:
+        prediction.run.failed_revisits += 1
+        action = "matured_discarded"
+
+    return MaturationOutcome(
+        prediction_id=prediction.spec.id,
+        session_id=session.id,
+        cycle_index=cycle_index,
+        contract=contract,
+        verdict=verdict,
+        action=action,
+        before_evidence_score=before_evidence,
+        after_evidence_score=prediction.artifacts.evidence_score,
+        before_draft_hash=before_hash,
+        after_draft_hash=after_hash,
+        new_draft=new_draft if verdict.kept else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Probation rollback hook
+# ---------------------------------------------------------------------------
+
+
+def rollback_kept_maturation(
+    prediction: PredictedPrompt,
+    *,
+    rollback_to_draft: str | None,
+    rollback_to_evidence_score: float,
+    cycle_index: int,
+) -> None:
+    """Roll back the most recent kept maturation on this prediction.
+
+    Called by reconciliation when a contradicting signal fires inside
+    the prediction's probation window. Restores the prior draft +
+    evidence_score, decrements ``revision`` (the kept maturation no
+    longer counts), and increments ``failed_revisits`` (so we stop
+    re-attempting if reconciliation keeps disagreeing).
+
+    Engine wires this into the reconciliation path; this module just
+    owns the in-memory mutation contract.
+    """
+
+    prediction.artifacts.draft_answer = rollback_to_draft
+    prediction.artifacts.evidence_score = rollback_to_evidence_score
+    prediction.run.revision = max(0, prediction.run.revision - 1)
+    prediction.run.failed_revisits += 1
+    prediction.run.probationary_until_cycle = None
+    prediction.run.last_matured_cycle = cycle_index
+
+
+__all__ = [
+    "ClauseKind",
+    "ContractClause",
+    "JudgeCallable",
+    "MaturationCandidate",
+    "MaturationContract",
+    "MaturationDrafterCallable",
+    "MaturationOutcome",
+    "MaturationVerdict",
+    "TargetWeakness",
+    "build_contract",
+    "default_rubric_judge",
+    "mature_one",
+    "rollback_kept_maturation",
+    "score_maturation_value",
+    "select_maturation_candidates",
+]

--- a/src/vaner/intent/deep_run_policy.py
+++ b/src/vaner/intent/deep_run_policy.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS2 — Deep-Run preset table + applicator (0.8.3).
+
+The preset table from spec §7.2 lives here as immutable data. Engine
+code calls :func:`preset_for` and :func:`horizon_bias_for` to obtain
+the override bundle for an active session, then weaves the values into
+its own scoring / drafting / scheduling decisions.
+
+Design notes:
+
+- Presets are *additive overrides*, not replacements. Engine code
+  reads the base config and applies the preset deltas on top. Outside
+  a Deep-Run session, no overrides apply.
+- The preset bundle is pure data — no side effects, no lazy loading,
+  no async. The engine consults it every cycle without cost.
+- Adding a new preset means adding one entry to :data:`PRESETS`. The
+  shape of :class:`DeepRunPresetSpec` is fixed by spec §16.2 (config
+  surface) — adding a field requires a config-schema migration.
+- Horizon biases are orthogonal to presets and compose multiplicatively
+  with the preset's own long-horizon / possible-branch multipliers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from vaner.intent.deep_run import (
+    DeepRunFocus,
+    DeepRunHorizonBias,
+    DeepRunPreset,
+    DeepRunSession,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DeepRunPresetSpec:
+    """The bundle of runtime overrides for one preset.
+
+    Field meanings mirror the spec §7.2 table. Multipliers are applied
+    multiplicatively to the corresponding base values; biases are
+    additive on top of the base ratios. Thresholds replace the base
+    drafter values for the duration of the session.
+    """
+
+    exploit_ratio_bias: float
+    invest_ratio_bias: float
+    no_regret_ratio_bias: float
+    artefact_alignment_weight_multiplier: float
+    long_horizon_bonus_multiplier: float
+    possible_branch_bonus_multiplier: float
+    draft_evidence_threshold: float
+    draft_volatility_ceiling: float
+    max_revisits_per_prediction: int
+    improvement_threshold_to_persist: float
+    maturation_budget_share_per_cycle: float
+    remote_budget_per_hour_cap: int
+    adaptive_cycle_utilisation: float
+    idle_curve_multiplier: float
+
+
+@dataclass(frozen=True, slots=True)
+class HorizonBiasSpec:
+    """The bundle of horizon-bias multipliers for one bias mode.
+
+    Applied as additive scoring on top of the preset's existing
+    weights; see spec §7.4. Suppression values < 1.0 reduce the
+    score for the named hypothesis class; multipliers > 1.0 boost.
+    """
+
+    likely_next_multiplier: float
+    long_horizon_multiplier: float
+    finish_partials_multiplier: float
+    new_queued_suppression: float
+
+
+# ---------------------------------------------------------------------------
+# The preset table (spec §7.2). Immutable; values are the single source
+# of truth for "what does Conservative / Balanced / Aggressive do."
+# ---------------------------------------------------------------------------
+
+
+PRESETS: Final[dict[DeepRunPreset, DeepRunPresetSpec]] = {
+    "conservative": DeepRunPresetSpec(
+        # Lean into exploiting / finishing existing high-confidence work;
+        # raise drafting bars so only well-evidenced predictions promote.
+        exploit_ratio_bias=0.10,
+        invest_ratio_bias=-0.05,
+        no_regret_ratio_bias=0.05,
+        artefact_alignment_weight_multiplier=1.5,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.0,
+        draft_evidence_threshold=0.55,
+        draft_volatility_ceiling=0.30,
+        max_revisits_per_prediction=2,
+        improvement_threshold_to_persist=0.10,
+        maturation_budget_share_per_cycle=0.30,
+        remote_budget_per_hour_cap=30,
+        adaptive_cycle_utilisation=0.80,
+        idle_curve_multiplier=1.5,
+    ),
+    "balanced": DeepRunPresetSpec(
+        # Default overnight setting. Moderate exploration, moderate
+        # drafting depth, broader artefact alignment, moderate maturation.
+        exploit_ratio_bias=0.0,
+        invest_ratio_bias=0.05,
+        no_regret_ratio_bias=0.05,
+        artefact_alignment_weight_multiplier=1.5,
+        long_horizon_bonus_multiplier=1.5,
+        possible_branch_bonus_multiplier=1.3,
+        draft_evidence_threshold=0.50,
+        draft_volatility_ceiling=0.40,
+        max_revisits_per_prediction=4,
+        improvement_threshold_to_persist=0.05,
+        maturation_budget_share_per_cycle=0.50,
+        remote_budget_per_hour_cap=60,
+        adaptive_cycle_utilisation=0.95,
+        idle_curve_multiplier=0.7,
+    ),
+    "aggressive": DeepRunPresetSpec(
+        # Wider exploration frontier, stronger long-tail / possible-branch
+        # weighting, larger drafting + maturation budgets. Relax drafting
+        # bar so more predictions reach READY and are then matured upward.
+        exploit_ratio_bias=-0.10,
+        invest_ratio_bias=0.15,
+        no_regret_ratio_bias=0.0,
+        artefact_alignment_weight_multiplier=2.0,
+        long_horizon_bonus_multiplier=2.0,
+        possible_branch_bonus_multiplier=1.8,
+        draft_evidence_threshold=0.45,
+        draft_volatility_ceiling=0.50,
+        max_revisits_per_prediction=8,
+        improvement_threshold_to_persist=0.02,
+        maturation_budget_share_per_cycle=0.65,
+        remote_budget_per_hour_cap=120,
+        adaptive_cycle_utilisation=1.0,
+        idle_curve_multiplier=0.5,
+    ),
+}
+
+
+HORIZON_BIASES: Final[dict[DeepRunHorizonBias, HorizonBiasSpec]] = {
+    "likely_next": HorizonBiasSpec(
+        likely_next_multiplier=1.4,
+        long_horizon_multiplier=1.0,
+        finish_partials_multiplier=1.0,
+        new_queued_suppression=1.0,
+    ),
+    "long_horizon": HorizonBiasSpec(
+        likely_next_multiplier=0.8,
+        long_horizon_multiplier=1.6,
+        finish_partials_multiplier=1.0,
+        new_queued_suppression=1.0,
+    ),
+    "finish_partials": HorizonBiasSpec(
+        likely_next_multiplier=1.0,
+        long_horizon_multiplier=1.0,
+        # Boost partials that are already in flight (grounding /
+        # evidence_gathering / drafting); softer boost for READY
+        # predictions that are still maturable. The "finishing" prefix
+        # is the operative principle: complete a partial before
+        # starting a new one.
+        finish_partials_multiplier=1.5,
+        new_queued_suppression=0.7,
+    ),
+    "balanced": HorizonBiasSpec(
+        likely_next_multiplier=1.0,
+        long_horizon_multiplier=1.0,
+        finish_partials_multiplier=1.0,
+        new_queued_suppression=1.0,
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Lookups + utility helpers
+# ---------------------------------------------------------------------------
+
+
+def preset_for(session: DeepRunSession) -> DeepRunPresetSpec:
+    """Return the preset bundle for an active session.
+
+    Raises :class:`KeyError` if the session's preset is unknown — that
+    would be a schema-migration bug, not a runtime concern. Callers
+    should not catch.
+    """
+
+    return PRESETS[session.preset]
+
+
+def horizon_bias_for(session: DeepRunSession) -> HorizonBiasSpec:
+    """Return the horizon-bias multipliers for an active session."""
+
+    return HORIZON_BIASES[session.horizon_bias]
+
+
+def applies_focus_to_anchor(
+    session: DeepRunSession,
+    *,
+    goal_status: str | None,
+    anchor_path: str | None,
+) -> bool:
+    """Frontier admission gate for a candidate prediction anchor.
+
+    Returns ``True`` if the candidate clears the active session's focus
+    setting, ``False`` if it should be excluded.
+
+    - ``active_goals``: only goals whose status is in
+      ``{"active", "dormant"}`` contribute admissions; other goals'
+      anchors are excluded.
+    - ``current_workspace``: only anchors under the session's
+      ``workspace_root`` are admitted (path-prefix match).
+      ``anchor_path == None`` admits (it is not a workspace-bound
+      anchor).
+    - ``all_recent``: no admission gate; always returns ``True``.
+    """
+
+    focus: DeepRunFocus = session.focus
+    if focus == "all_recent":
+        return True
+    if focus == "active_goals":
+        if goal_status is None:
+            return True
+        return goal_status in ("active", "dormant")
+    if focus == "current_workspace":
+        if anchor_path is None:
+            return True
+        return anchor_path.startswith(session.workspace_root)
+    return True
+
+
+__all__ = [
+    "HORIZON_BIASES",
+    "PRESETS",
+    "DeepRunPresetSpec",
+    "HorizonBiasSpec",
+    "applies_focus_to_anchor",
+    "horizon_bias_for",
+    "preset_for",
+]

--- a/src/vaner/intent/governor.py
+++ b/src/vaner/intent/governor.py
@@ -12,6 +12,13 @@ class PredictionGovernor:
         BACKGROUND = "background"
         DEDICATED = "dedicated"
         BUDGET = "budget"
+        # 0.8.3 WS2: Deep-Run mode. Behaves like DEDICATED (always
+        # continue unless explicitly stopped) but signals to the engine
+        # that a long-window policy is in effect — preset overrides
+        # apply to ratios / drafter thresholds / cycle utilisation, and
+        # resource / cost / locality gates are evaluated each cycle.
+        # Bound to a persisted ``DeepRunSession`` row.
+        DEEP_RUN = "deep_run"
 
     mode: Mode = Mode.BACKGROUND
     budget_units: int = 100
@@ -33,6 +40,11 @@ class PredictionGovernor:
         if self.mode == self.Mode.BACKGROUND:
             return not self._user_request_active
         if self.mode == self.Mode.DEDICATED:
+            return True
+        if self.mode == self.Mode.DEEP_RUN:
+            # Deep-Run continues regardless of per-cycle units; pause
+            # gating is handled by the engine via DeepRun resource +
+            # cost + locality probes (see vaner.intent.deep_run_gates).
             return True
         return self._remaining_units >= units
 

--- a/src/vaner/intent/prediction.py
+++ b/src/vaner/intent/prediction.py
@@ -93,6 +93,20 @@ class PredictionRun:
     ``invalidation_reason`` is populated when a signal fires to stale the
     prediction; ``spent`` is flipped on adoption so the prediction doesn't
     resurface until the underlying evidence is invalidated.
+
+    0.8.3 WS3 (Deep-Run maturation): ``revision`` increments each time a
+    maturation pass produces a kept improvement. ``last_matured_cycle``
+    is the cycle index of the most recent kept pass.
+    ``probationary_until_cycle`` is the cycle index up to (and
+    including) which the most recent kept maturation is treated as
+    probationary — during that window the prediction is excluded from
+    further maturation, and a contradicting reconciliation signal can
+    roll it back. ``failed_revisits`` counts consecutive *discarded*
+    maturation attempts; once it reaches the per-preset failure cap,
+    the prediction is excluded from further maturation entirely.
+    ``maturation_eligible`` is a per-source opt-out for short-horizon
+    specs whose value collapses if matured (e.g. "what's the next
+    arc?" predictions).
     """
 
     weight: float
@@ -107,6 +121,12 @@ class PredictionRun:
     last_seen_cycle: int = 0
     invalidation_reason: str = ""
     spent: bool = False
+    # 0.8.3 WS3 — Deep-Run maturation lifecycle.
+    revision: int = 0
+    last_matured_cycle: int | None = None
+    probationary_until_cycle: int | None = None
+    failed_revisits: int = 0
+    maturation_eligible: bool = True
 
 
 @dataclass(slots=True)

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -581,6 +581,96 @@ def build_server(
                     ),
                     inputSchema={"type": "object", "properties": {}},
                 ),
+                # 0.8.3 WS4 — Deep-Run lifecycle MCP surface.
+                Tool(
+                    name="vaner.deep_run.start",
+                    description=(
+                        "Start a Deep-Run session declaring a long uninterrupted "
+                        "preparation window. Cost cap defaults to 0 (no remote "
+                        "spend). Returns the persisted session record."
+                    ),
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "ends_at": {
+                                "type": "number",
+                                "description": "Absolute epoch end timestamp.",
+                            },
+                            "preset": {
+                                "type": "string",
+                                "enum": ["conservative", "balanced", "aggressive"],
+                                "default": "balanced",
+                            },
+                            "focus": {
+                                "type": "string",
+                                "enum": ["active_goals", "current_workspace", "all_recent"],
+                                "default": "active_goals",
+                            },
+                            "horizon_bias": {
+                                "type": "string",
+                                "enum": [
+                                    "likely_next",
+                                    "long_horizon",
+                                    "finish_partials",
+                                    "balanced",
+                                ],
+                                "default": "balanced",
+                            },
+                            "locality": {
+                                "type": "string",
+                                "enum": ["local_only", "local_preferred", "allow_cloud"],
+                                "default": "local_preferred",
+                            },
+                            "cost_cap_usd": {"type": "number", "default": 0.0},
+                            "metadata": {"type": "object"},
+                        },
+                        "required": ["ends_at"],
+                    },
+                ),
+                Tool(
+                    name="vaner.deep_run.stop",
+                    description=(
+                        "Stop the active Deep-Run session. Returns the summary "
+                        "(four-counter honesty: kept / discarded / rolled_back "
+                        "/ failed) or null if no session was active."
+                    ),
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "kill": {"type": "boolean", "default": False},
+                            "reason": {"type": "string"},
+                        },
+                    },
+                ),
+                Tool(
+                    name="vaner.deep_run.status",
+                    description="Return the active Deep-Run session, or null.",
+                    inputSchema={"type": "object", "properties": {}},
+                ),
+                Tool(
+                    name="vaner.deep_run.list",
+                    description="List recent Deep-Run sessions, newest first.",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "limit": {
+                                "type": "integer",
+                                "default": 20,
+                                "minimum": 1,
+                                "maximum": 200,
+                            },
+                        },
+                    },
+                ),
+                Tool(
+                    name="vaner.deep_run.show",
+                    description="Show one Deep-Run session by id (active or historical).",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {"session_id": {"type": "string"}},
+                        "required": ["session_id"],
+                    },
+                ),
             ]
         )
 
@@ -659,6 +749,20 @@ def build_server(
                 },
                 "memory": {"counts": memory_counts, "quality": quality, "calibration": calibration},
             }
+            # 0.8.3 WS4: surface active Deep-Run session state under
+            # ``deep_run`` so cockpit / desktop / agents can render the
+            # current policy mode without a second round-trip.
+            try:
+                from vaner.cli.commands.deep_run import _session_to_dict
+                from vaner.server import astatus_deep_run
+
+                deep_run_session = await astatus_deep_run(active_repo_root)
+                payload["deep_run"] = {
+                    "active": deep_run_session is not None,
+                    "session": _session_to_dict(deep_run_session) if deep_run_session else None,
+                }
+            except Exception:
+                payload["deep_run"] = {"active": False, "session": None}
             append_log(repo_root, tool=name, label="status", decision_id=None, provenance_mode=None, memory_state=None)
             await _record("ok")
             return _json_result(payload)
@@ -1641,6 +1745,96 @@ def build_server(
                 {"code": "invalid_input", "message": f"unknown goals tool: {name}"},
                 is_error=True,
             )
+
+        # ------------------------------------------------------------------
+        # 0.8.3 WS4 — Deep-Run lifecycle MCP tools.
+        # ------------------------------------------------------------------
+        if name.startswith("vaner.deep_run."):
+            from vaner.cli.commands.deep_run import (
+                _session_to_dict,
+                _summary_to_dict,
+            )
+            from vaner.server import (
+                alist_deep_run_sessions,
+                aresolve_deep_run_session,
+                astart_deep_run,
+                astatus_deep_run,
+                astop_deep_run,
+            )
+
+            if name == "vaner.deep_run.start":
+                ends_at = args.get("ends_at")
+                if not isinstance(ends_at, (int, float)):
+                    await _record("error")
+                    return _json_result(
+                        {
+                            "code": "invalid_input",
+                            "message": "ends_at (epoch number) is required",
+                        },
+                        is_error=True,
+                    )
+                try:
+                    session = await astart_deep_run(
+                        active_repo_root,
+                        ends_at=float(ends_at),
+                        preset=str(args.get("preset", "balanced")),
+                        focus=str(args.get("focus", "active_goals")),
+                        horizon_bias=str(args.get("horizon_bias", "balanced")),
+                        locality=str(args.get("locality", "local_preferred")),
+                        cost_cap_usd=float(args.get("cost_cap_usd", 0.0)),
+                        metadata=(dict(args.get("metadata") or {}) | {"caller": "mcp"}),
+                    )
+                except Exception as exc:
+                    await _record("error")
+                    return _json_result(
+                        {
+                            "code": "deep_run_start_failed",
+                            "message": str(exc),
+                        },
+                        is_error=True,
+                    )
+                await _record("ok")
+                return _json_result(_session_to_dict(session))
+
+            if name == "vaner.deep_run.stop":
+                summary = await astop_deep_run(
+                    active_repo_root,
+                    kill=bool(args.get("kill", False)),
+                    reason=args.get("reason") if isinstance(args.get("reason"), str) else None,
+                )
+                await _record("ok")
+                if summary is None:
+                    return _json_result({"summary": None})
+                return _json_result({"summary": _summary_to_dict(summary)})
+
+            if name == "vaner.deep_run.status":
+                session = await astatus_deep_run(active_repo_root)
+                await _record("ok")
+                return _json_result({"session": _session_to_dict(session) if session else None})
+
+            if name == "vaner.deep_run.list":
+                limit = max(1, min(200, int(args.get("limit", 20))))
+                sessions = await alist_deep_run_sessions(active_repo_root, limit=limit)
+                await _record("ok")
+                return _json_result({"sessions": [_session_to_dict(s) for s in sessions]})
+
+            if name == "vaner.deep_run.show":
+                session_id = str(args.get("session_id", "")).strip()
+                if not session_id:
+                    await _record("error")
+                    return _json_result(
+                        {"code": "invalid_input", "message": "session_id required"},
+                        is_error=True,
+                    )
+                session = await aresolve_deep_run_session(active_repo_root, session_id)
+                if session is None:
+                    await _record("error")
+                    return _json_result(
+                        {"code": "not_found", "message": f"session {session_id!r} not found"},
+                        is_error=True,
+                    )
+                await _record("ok")
+                return _json_result(_session_to_dict(session))
 
         if name == "vaner.debug.trace":
             if str(__import__("os").environ.get("VANER_MCP_DEBUG", "0")) != "1":

--- a/src/vaner/router/backends.py
+++ b/src/vaner/router/backends.py
@@ -85,6 +85,51 @@ def _is_local_backend(base_url: str) -> bool:
     return "localhost" in lowered or "127.0.0.1" in lowered or "0.0.0.0" in lowered
 
 
+# 0.8.3 WS2 — Deep-Run remote-call gate. Pre-call check that consults
+# the active Deep-Run session (if any) and blocks remote calls that
+# violate locality or cost constraints. Local-URL calls are never
+# gated. When no Deep-Run session is active, this function is a
+# zero-cost no-op — router behaviour is unchanged.
+_DEEP_RUN_DEFAULT_REMOTE_CALL_ESTIMATE_USD = 0.01
+
+
+class DeepRunRemoteCallBlockedError(RuntimeError):
+    """Raised when a remote backend call is blocked by an active
+    Deep-Run session's locality or cost gate. The error message names
+    the session id and the constraint so surfaces can render a clear
+    "Deep-Run blocked this call" notice."""
+
+
+def _enforce_deep_run_gates_for_remote(
+    base_url: str,
+    *,
+    estimated_usd: float = _DEEP_RUN_DEFAULT_REMOTE_CALL_ESTIMATE_USD,
+) -> None:
+    """Raise :class:`DeepRunRemoteCallBlockedError` if the active Deep-Run
+    session blocks this remote call. No-op for local URLs and for the
+    case where no session is active."""
+
+    if _is_local_backend(base_url):
+        return
+    # Imports are deferred so the router does not pull in the intent
+    # layer at module load (keeps the import graph cycle-safe).
+    from vaner.intent.deep_run_gates import (
+        get_active_session_for_routing,
+        is_remote_call_allowed,
+        try_consume_cost,
+    )
+
+    session = get_active_session_for_routing()
+    if session is None:
+        return
+    if not is_remote_call_allowed(base_url):
+        raise DeepRunRemoteCallBlockedError(f"Deep-Run session {session.id} is local_only; remote call to {base_url} blocked.")
+    if not try_consume_cost(estimated_usd):
+        raise DeepRunRemoteCallBlockedError(
+            f"Deep-Run session {session.id} cost cap (${session.cost_cap_usd:.2f}) would be exceeded by this call."
+        )
+
+
 def _budget_state_path(repo_root: Path) -> Path:
     return repo_root / ".vaner" / "runtime" / "remote_budget.json"
 
@@ -225,12 +270,15 @@ async def forward_chat_completion_with_request(
     try:
         # If no primary credentials exist and fallback is configured, skip straight to fallback.
         if api_key or _is_local_backend(backend.base_url):
+            _enforce_deep_run_gates_for_remote(backend.base_url)
             return await _post_chat(backend, payload, use_fallback=False)
         primary_error = RuntimeError("Primary backend credentials are missing.")
     except Exception as exc:
         primary_error = exc
 
     if _should_use_fallback(config, primary_failed=True):
+        fallback_url = backend.fallback_base_url or backend.base_url
+        _enforce_deep_run_gates_for_remote(fallback_url)
         if not _consume_remote_budget(config.repo_root, backend.remote_budget_per_hour):
             raise RuntimeError("Remote fallback budget exhausted for this hour.") from primary_error
         return await _post_chat(backend, payload, use_fallback=True)
@@ -315,12 +363,15 @@ async def stream_chat_completion_with_request(
     api_key = os.getenv(backend.api_key_env, "")
     try:
         if api_key or _is_local_backend(backend.base_url):
+            _enforce_deep_run_gates_for_remote(backend.base_url)
             async for chunk in _stream_chat(backend, payload, use_fallback=False):
                 yield chunk
             return
         raise RuntimeError("Primary backend credentials are missing.")
     except Exception as exc:
         if _should_use_fallback(config, primary_failed=True):
+            fallback_url = backend.fallback_base_url or backend.base_url
+            _enforce_deep_run_gates_for_remote(fallback_url)
             if not _consume_remote_budget(config.repo_root, backend.remote_budget_per_hour):
                 raise RuntimeError("Remote fallback budget exhausted for this hour.") from exc
             async for chunk in _stream_chat(backend, payload, use_fallback=True):

--- a/src/vaner/server.py
+++ b/src/vaner/server.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any
 
 from vaner.cli.commands.config import load_config
 from vaner.engine import build_default_engine
+from vaner.intent.deep_run import DeepRunSession, DeepRunSummary
 from vaner.models.config import VanerConfig
 from vaner.models.context import ContextPackage
 from vaner.models.decision import DecisionRecord
@@ -86,6 +88,116 @@ async def aprecompute(
         pass
     engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
     return await engine.precompute_cycle()
+
+
+# ---------------------------------------------------------------------------
+# 0.8.3 WS4 — Deep-Run lifecycle helpers (async + sync)
+# ---------------------------------------------------------------------------
+
+
+async def astart_deep_run(
+    repo: Path | str | None = None,
+    *,
+    ends_at: float,
+    preset: str = "balanced",
+    focus: str = "active_goals",
+    horizon_bias: str = "balanced",
+    locality: str = "local_preferred",
+    cost_cap_usd: float = 0.0,
+    workspace_root: str | None = None,
+    metadata: dict[str, str] | None = None,
+    config: VanerConfig | None = None,
+) -> DeepRunSession:
+    """Start a Deep-Run session and return the persisted record.
+
+    Literal validation for ``preset`` / ``focus`` / ``horizon_bias`` /
+    ``locality`` happens at the engine boundary; this wrapper accepts
+    plain ``str`` so CLI / MCP / HTTP surfaces don't have to import
+    the literal types.
+    """
+    repo_root = _resolve_repo_root(repo)
+    engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
+    return await engine.start_deep_run(
+        ends_at=ends_at,
+        preset=preset,  # type: ignore[arg-type]
+        focus=focus,  # type: ignore[arg-type]
+        horizon_bias=horizon_bias,  # type: ignore[arg-type]
+        locality=locality,  # type: ignore[arg-type]
+        cost_cap_usd=cost_cap_usd,
+        workspace_root=workspace_root,
+        metadata=metadata,
+    )
+
+
+async def astop_deep_run(
+    repo: Path | str | None = None,
+    *,
+    kill: bool = False,
+    reason: str | None = None,
+    config: VanerConfig | None = None,
+) -> DeepRunSummary | None:
+    """Stop the currently active Deep-Run session and return the summary."""
+    repo_root = _resolve_repo_root(repo)
+    engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
+    return await engine.stop_deep_run(kill=kill, reason=reason)
+
+
+async def astatus_deep_run(
+    repo: Path | str | None = None,
+    *,
+    config: VanerConfig | None = None,
+) -> DeepRunSession | None:
+    """Return the active Deep-Run session, or ``None``."""
+    repo_root = _resolve_repo_root(repo)
+    engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
+    return await engine.current_deep_run()
+
+
+async def alist_deep_run_sessions(
+    repo: Path | str | None = None,
+    *,
+    limit: int = 20,
+    config: VanerConfig | None = None,
+) -> list[DeepRunSession]:
+    """List recent Deep-Run sessions, newest first."""
+    repo_root = _resolve_repo_root(repo)
+    engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
+    return await engine.list_deep_run_sessions(limit=limit)
+
+
+async def aresolve_deep_run_session(
+    repo: Path | str | None,
+    session_id: str,
+    *,
+    config: VanerConfig | None = None,
+) -> DeepRunSession | None:
+    """Look up a Deep-Run session by id (active or historical)."""
+    from vaner.store import deep_run as deep_run_store
+
+    repo_root = _resolve_repo_root(repo)
+    engine = build_default_engine(repo_root, _resolve_config(repo_root, config))
+    await engine.initialize()
+    return await deep_run_store.get_session(engine.store.db_path, session_id)
+
+
+def start_deep_run(*args: Any, **kwargs: Any) -> DeepRunSession:
+    return asyncio.run(astart_deep_run(*args, **kwargs))
+
+
+def stop_deep_run(*args: Any, **kwargs: Any) -> DeepRunSummary | None:
+    return asyncio.run(astop_deep_run(*args, **kwargs))
+
+
+def status_deep_run(*args: Any, **kwargs: Any) -> DeepRunSession | None:
+    return asyncio.run(astatus_deep_run(*args, **kwargs))
+
+
+def list_deep_run_sessions(*args: Any, **kwargs: Any) -> list[DeepRunSession]:
+    return asyncio.run(alist_deep_run_sessions(*args, **kwargs))
+
+
+def resolve_deep_run_session(*args: Any, **kwargs: Any) -> DeepRunSession | None:
+    return asyncio.run(aresolve_deep_run_session(*args, **kwargs))
 
 
 async def ainspect(repo: Path | str | None = None, config: VanerConfig | None = None) -> str:

--- a/src/vaner/store/artefacts.py
+++ b/src/vaner/store/artefacts.py
@@ -430,6 +430,12 @@ class ArtefactStore:
             await db.execute(
                 "CREATE INDEX IF NOT EXISTS idx_intent_reconciliation_outcomes_pass_at ON intent_reconciliation_outcomes(pass_at DESC)"
             )
+            # 0.8.3 WS1 — Deep-Run sessions + pass log. Owned by
+            # vaner.store.deep_run; declared here so all artefact-DB tables
+            # share one initialize() call and one connection lifecycle.
+            from vaner.store.deep_run import create_deep_run_tables
+
+            await create_deep_run_tables(db)
             async with db.execute("PRAGMA table_info(signal_events)") as cursor:
                 signal_columns = [row[1] for row in await cursor.fetchall()]
             if "corpus_id" not in signal_columns:

--- a/src/vaner/store/deep_run.py
+++ b/src/vaner/store/deep_run.py
@@ -39,9 +39,6 @@ from vaner.intent.deep_run import (
     DeepRunStatus,
 )
 
-_SESSIONS_TABLE = "deep_run_sessions"
-_PASS_LOG_TABLE = "deep_run_pass_log"
-
 
 async def create_deep_run_tables(db: aiosqlite.Connection) -> None:
     """Create the Deep-Run tables and indices on an open connection.

--- a/src/vaner/store/deep_run.py
+++ b/src/vaner/store/deep_run.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — SQLite persistence for Deep-Run sessions and pass log (0.8.3).
+
+Two tables:
+
+- ``deep_run_sessions`` — one row per declared away window.
+  Single-active-session is enforced by a UNIQUE partial index on
+  ``status='active'`` plus a defensive check in :func:`create_session`.
+- ``deep_run_pass_log`` — one row per per-prediction action during a
+  session (maturation kept / discarded / rolled-back / failed, plus
+  ``promoted`` / ``explored``). Append-only audit trail; never updated
+  in place.
+
+DDL is owned by :func:`create_deep_run_tables`, which is called from
+``ArtefactStore.initialize()`` so all tables in the artefact DB are
+declared together. DAO functions are module-level and take ``db_path``
+to match the ``ArtefactStore`` per-method-connection pattern; the engine
+imports them directly.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import cast
+
+import aiosqlite
+
+from vaner.intent.deep_run import (
+    DeepRunFocus,
+    DeepRunHorizonBias,
+    DeepRunLocality,
+    DeepRunPassAction,
+    DeepRunPassLogEntry,
+    DeepRunPauseReason,
+    DeepRunPreset,
+    DeepRunSession,
+    DeepRunStatus,
+)
+
+_SESSIONS_TABLE = "deep_run_sessions"
+_PASS_LOG_TABLE = "deep_run_pass_log"
+
+
+async def create_deep_run_tables(db: aiosqlite.Connection) -> None:
+    """Create the Deep-Run tables and indices on an open connection.
+
+    Called from :meth:`ArtefactStore.initialize` so DDL happens inside
+    the same connection / transaction the rest of the artefact DB uses.
+    Safe to call repeatedly — every statement is ``IF NOT EXISTS``.
+    """
+
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS deep_run_sessions (
+            id TEXT PRIMARY KEY,
+            started_at REAL NOT NULL,
+            ends_at REAL NOT NULL,
+            preset TEXT NOT NULL,
+            focus TEXT NOT NULL,
+            horizon_bias TEXT NOT NULL,
+            locality TEXT NOT NULL,
+            cost_cap_usd REAL NOT NULL DEFAULT 0.0,
+            workspace_root TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            pause_reasons_json TEXT NOT NULL DEFAULT '[]',
+            spend_usd REAL NOT NULL DEFAULT 0.0,
+            cycles_run INTEGER NOT NULL DEFAULT 0,
+            matured_kept INTEGER NOT NULL DEFAULT 0,
+            matured_discarded INTEGER NOT NULL DEFAULT 0,
+            matured_rolled_back INTEGER NOT NULL DEFAULT 0,
+            matured_failed INTEGER NOT NULL DEFAULT 0,
+            promoted_count INTEGER NOT NULL DEFAULT 0,
+            ended_at REAL,
+            cancelled_reason TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        )
+        """
+    )
+    # The UNIQUE partial index gives us belt-and-braces single-active-
+    # session enforcement at the DB layer; create_session() also checks
+    # explicitly to give callers a clean error rather than an
+    # IntegrityError surface.
+    await db.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_deep_run_sessions_active ON deep_run_sessions(status) WHERE status = 'active'")
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_deep_run_sessions_started_at ON deep_run_sessions(started_at DESC)")
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_deep_run_sessions_status ON deep_run_sessions(status)")
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS deep_run_pass_log (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            prediction_id TEXT NOT NULL,
+            pass_at REAL NOT NULL,
+            action TEXT NOT NULL,
+            cycle_index INTEGER NOT NULL,
+            before_evidence_score REAL,
+            after_evidence_score REAL,
+            before_draft_hash TEXT,
+            after_draft_hash TEXT,
+            contract_json TEXT,
+            judge_verdict_json TEXT
+        )
+        """
+    )
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_deep_run_pass_log_session_id ON deep_run_pass_log(session_id)")
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_deep_run_pass_log_prediction_id ON deep_run_pass_log(prediction_id)")
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_deep_run_pass_log_pass_at ON deep_run_pass_log(pass_at DESC)")
+
+
+class DeepRunActiveSessionExistsError(RuntimeError):
+    """Raised when a caller tries to start a second Deep-Run session
+    while one is already active. The engine surfaces this to the CLI /
+    MCP / cockpit / desktop with a stable error message so all surfaces
+    can render a consistent "another session is active" notice."""
+
+
+def _row_to_session(row: aiosqlite.Row) -> DeepRunSession:
+    pause_reasons_raw = json.loads(row["pause_reasons_json"] or "[]")
+    metadata_raw = json.loads(row["metadata_json"] or "{}")
+    return DeepRunSession(
+        id=str(row["id"]),
+        started_at=float(row["started_at"]),
+        ends_at=float(row["ends_at"]),
+        preset=cast(DeepRunPreset, str(row["preset"])),
+        focus=cast(DeepRunFocus, str(row["focus"])),
+        horizon_bias=cast(DeepRunHorizonBias, str(row["horizon_bias"])),
+        locality=cast(DeepRunLocality, str(row["locality"])),
+        cost_cap_usd=float(row["cost_cap_usd"]),
+        workspace_root=str(row["workspace_root"]),
+        status=cast(DeepRunStatus, str(row["status"])),
+        pause_reasons=[cast(DeepRunPauseReason, str(r)) for r in pause_reasons_raw],
+        spend_usd=float(row["spend_usd"]),
+        cycles_run=int(row["cycles_run"]),
+        matured_kept=int(row["matured_kept"]),
+        matured_discarded=int(row["matured_discarded"]),
+        matured_rolled_back=int(row["matured_rolled_back"]),
+        matured_failed=int(row["matured_failed"]),
+        promoted_count=int(row["promoted_count"]),
+        ended_at=None if row["ended_at"] is None else float(row["ended_at"]),
+        cancelled_reason=None if row["cancelled_reason"] is None else str(row["cancelled_reason"]),
+        metadata={str(k): str(v) for k, v in metadata_raw.items()},
+    )
+
+
+_SESSION_COLUMNS = (
+    "id, started_at, ends_at, preset, focus, horizon_bias, locality, "
+    "cost_cap_usd, workspace_root, status, pause_reasons_json, spend_usd, "
+    "cycles_run, matured_kept, matured_discarded, matured_rolled_back, "
+    "matured_failed, promoted_count, ended_at, metadata_json, cancelled_reason"
+)
+
+
+async def create_session(db_path: Path, session: DeepRunSession) -> DeepRunSession:
+    """Insert a new active session.
+
+    Raises :class:`DeepRunActiveSessionExistsError` if another session is
+    already active. The defensive check runs inside the same connection
+    as the insert to avoid a TOCTOU window — the UNIQUE partial index
+    is the second line of defense if a caller bypasses this function.
+    """
+
+    if session.status != "active":
+        raise ValueError(f"create_session requires status='active', got {session.status!r}")
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute("PRAGMA busy_timeout=5000")
+        async with db.execute("SELECT id FROM deep_run_sessions WHERE status = 'active' LIMIT 1") as cursor:
+            existing = await cursor.fetchone()
+        if existing is not None:
+            raise DeepRunActiveSessionExistsError(f"another Deep-Run session is already active: {existing[0]}")
+        await db.execute(
+            f"""
+            INSERT INTO deep_run_sessions ({_SESSION_COLUMNS})
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session.id,
+                float(session.started_at),
+                float(session.ends_at),
+                session.preset,
+                session.focus,
+                session.horizon_bias,
+                session.locality,
+                float(session.cost_cap_usd),
+                session.workspace_root,
+                session.status,
+                json.dumps(list(session.pause_reasons)),
+                float(session.spend_usd),
+                int(session.cycles_run),
+                int(session.matured_kept),
+                int(session.matured_discarded),
+                int(session.matured_rolled_back),
+                int(session.matured_failed),
+                int(session.promoted_count),
+                None if session.ended_at is None else float(session.ended_at),
+                json.dumps(dict(session.metadata)),
+                session.cancelled_reason,
+            ),
+        )
+        await db.commit()
+    return session
+
+
+async def get_active_session(db_path: Path) -> DeepRunSession | None:
+    """Return the single active session, or ``None`` if none.
+
+    Treats both ``status='active'`` and ``status='paused'`` as
+    "currently in flight" — the engine resumes a paused session when
+    its pause reasons clear, so it is still the canonical record the
+    surfaces should render.
+    """
+
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            f"SELECT {_SESSION_COLUMNS} FROM deep_run_sessions WHERE status IN ('active', 'paused') ORDER BY started_at DESC LIMIT 1"
+        ) as cursor:
+            row = await cursor.fetchone()
+    return None if row is None else _row_to_session(row)
+
+
+async def get_session(db_path: Path, session_id: str) -> DeepRunSession | None:
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            f"SELECT {_SESSION_COLUMNS} FROM deep_run_sessions WHERE id = ?",
+            (session_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+    return None if row is None else _row_to_session(row)
+
+
+async def list_sessions(
+    db_path: Path,
+    *,
+    limit: int = 20,
+    status: DeepRunStatus | None = None,
+) -> list[DeepRunSession]:
+    query = f"SELECT {_SESSION_COLUMNS} FROM deep_run_sessions"
+    params: list[object] = []
+    if status is not None:
+        query += " WHERE status = ?"
+        params.append(status)
+    query += " ORDER BY started_at DESC LIMIT ?"
+    params.append(int(limit))
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(query, params) as cursor:
+            rows = await cursor.fetchall()
+    return [_row_to_session(r) for r in rows]
+
+
+async def update_session_status(
+    db_path: Path,
+    session_id: str,
+    *,
+    status: DeepRunStatus,
+    ended_at: float | None = None,
+    cancelled_reason: str | None = None,
+    pause_reasons: Iterable[DeepRunPauseReason] | None = None,
+) -> bool:
+    """Update the status of a session. Returns ``True`` if a row matched."""
+
+    fields: list[str] = ["status = ?"]
+    params: list[object] = [status]
+    if ended_at is not None:
+        fields.append("ended_at = ?")
+        params.append(float(ended_at))
+    if cancelled_reason is not None:
+        fields.append("cancelled_reason = ?")
+        params.append(cancelled_reason)
+    if pause_reasons is not None:
+        fields.append("pause_reasons_json = ?")
+        params.append(json.dumps([str(r) for r in pause_reasons]))
+    params.append(session_id)
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            f"UPDATE deep_run_sessions SET {', '.join(fields)} WHERE id = ?",
+            params,
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+
+async def increment_session_counters(
+    db_path: Path,
+    session_id: str,
+    *,
+    cycles_run: int = 0,
+    matured_kept: int = 0,
+    matured_discarded: int = 0,
+    matured_rolled_back: int = 0,
+    matured_failed: int = 0,
+    promoted_count: int = 0,
+    spend_usd: float = 0.0,
+) -> bool:
+    """Atomically increment cumulative counters on the session row."""
+
+    if not any(
+        v != 0
+        for v in (
+            cycles_run,
+            matured_kept,
+            matured_discarded,
+            matured_rolled_back,
+            matured_failed,
+            promoted_count,
+            spend_usd,
+        )
+    ):
+        return False
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            """
+            UPDATE deep_run_sessions
+            SET cycles_run = cycles_run + ?,
+                matured_kept = matured_kept + ?,
+                matured_discarded = matured_discarded + ?,
+                matured_rolled_back = matured_rolled_back + ?,
+                matured_failed = matured_failed + ?,
+                promoted_count = promoted_count + ?,
+                spend_usd = spend_usd + ?
+            WHERE id = ?
+            """,
+            (
+                int(cycles_run),
+                int(matured_kept),
+                int(matured_discarded),
+                int(matured_rolled_back),
+                int(matured_failed),
+                int(promoted_count),
+                float(spend_usd),
+                session_id,
+            ),
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+
+async def insert_pass_log_entry(db_path: Path, entry: DeepRunPassLogEntry) -> None:
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            """
+            INSERT INTO deep_run_pass_log (
+                id, session_id, prediction_id, pass_at, action, cycle_index,
+                before_evidence_score, after_evidence_score,
+                before_draft_hash, after_draft_hash,
+                contract_json, judge_verdict_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                entry.id,
+                entry.session_id,
+                entry.prediction_id,
+                float(entry.pass_at),
+                entry.action,
+                int(entry.cycle_index),
+                entry.before_evidence_score,
+                entry.after_evidence_score,
+                entry.before_draft_hash,
+                entry.after_draft_hash,
+                entry.contract_json,
+                entry.judge_verdict_json,
+            ),
+        )
+        await db.commit()
+
+
+async def list_pass_log_entries(
+    db_path: Path,
+    *,
+    session_id: str | None = None,
+    prediction_id: str | None = None,
+    action: DeepRunPassAction | None = None,
+    limit: int = 100,
+) -> list[DeepRunPassLogEntry]:
+    query = (
+        "SELECT id, session_id, prediction_id, pass_at, action, cycle_index, "
+        "before_evidence_score, after_evidence_score, before_draft_hash, "
+        "after_draft_hash, contract_json, judge_verdict_json "
+        "FROM deep_run_pass_log WHERE 1=1"
+    )
+    params: list[object] = []
+    if session_id is not None:
+        query += " AND session_id = ?"
+        params.append(session_id)
+    if prediction_id is not None:
+        query += " AND prediction_id = ?"
+        params.append(prediction_id)
+    if action is not None:
+        query += " AND action = ?"
+        params.append(action)
+    query += " ORDER BY pass_at DESC LIMIT ?"
+    params.append(int(limit))
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(query, params) as cursor:
+            rows = await cursor.fetchall()
+    return [
+        DeepRunPassLogEntry(
+            id=str(r["id"]),
+            session_id=str(r["session_id"]),
+            prediction_id=str(r["prediction_id"]),
+            pass_at=float(r["pass_at"]),
+            action=cast(DeepRunPassAction, str(r["action"])),
+            cycle_index=int(r["cycle_index"]),
+            before_evidence_score=None if r["before_evidence_score"] is None else float(r["before_evidence_score"]),
+            after_evidence_score=None if r["after_evidence_score"] is None else float(r["after_evidence_score"]),
+            before_draft_hash=None if r["before_draft_hash"] is None else str(r["before_draft_hash"]),
+            after_draft_hash=None if r["after_draft_hash"] is None else str(r["after_draft_hash"]),
+            contract_json=None if r["contract_json"] is None else str(r["contract_json"]),
+            judge_verdict_json=None if r["judge_verdict_json"] is None else str(r["judge_verdict_json"]),
+        )
+        for r in rows
+    ]
+
+
+async def close_expired_sessions(db_path: Path, *, now: float) -> int:
+    """Close any active/paused sessions whose ``ends_at`` is in the past.
+
+    Called by the engine on startup so a daemon that was killed during a
+    Deep-Run window does not leave a dangling "active" record long after
+    the user expected it to end. Returns the number of sessions closed.
+
+    Sessions whose ``ends_at`` is still in the future are left alone —
+    the engine's resume-on-restart logic picks them up via
+    :func:`get_active_session`.
+    """
+
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            """
+            UPDATE deep_run_sessions
+            SET status = 'ended', ended_at = ?,
+                cancelled_reason = COALESCE(cancelled_reason, 'expired_on_restart')
+            WHERE status IN ('active', 'paused') AND ends_at <= ?
+            """,
+            (float(now), float(now)),
+        )
+        await db.commit()
+        return cursor.rowcount
+
+
+__all__ = [
+    "DeepRunActiveSessionExistsError",
+    "close_expired_sessions",
+    "create_deep_run_tables",
+    "create_session",
+    "get_active_session",
+    "get_session",
+    "increment_session_counters",
+    "insert_pass_log_entry",
+    "list_pass_log_entries",
+    "list_sessions",
+    "update_session_status",
+]

--- a/tests/test_cli/test_deep_run.py
+++ b/tests/test_cli/test_deep_run.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS4 — `vaner deep-run` CLI tests (0.8.3)."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+from vaner.cli.commands.deep_run import _parse_until
+from vaner.intent.deep_run_gates import (
+    reset_cost_gate,
+    set_active_session_for_routing,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singletons():
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+    yield
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def hi():\n    return 'hi'\n")
+    return repo
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# `--until` parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseUntil:
+    def test_duration_hours(self) -> None:
+        ts = _parse_until("8h", now=1000.0)
+        assert ts == 1000.0 + 8 * 3600
+
+    def test_duration_minutes(self) -> None:
+        assert _parse_until("45m", now=0.0) == 45 * 60
+
+    def test_duration_days(self) -> None:
+        assert _parse_until("2d", now=0.0) == 2 * 86400
+
+    def test_duration_seconds(self) -> None:
+        assert _parse_until("90s", now=0.0) == 90.0
+
+    def test_zero_duration_rejected(self) -> None:
+        import typer
+
+        with pytest.raises(typer.BadParameter):
+            _parse_until("0h", now=0.0)
+
+    def test_time_of_day_today(self) -> None:
+        # Pick a base time well before noon so 14:00 today is in the future.
+        morning = datetime(2026, 4, 24, 8, 0).astimezone().timestamp()
+        ts = _parse_until("14:00", now=morning)
+        assert ts > morning
+        assert ts - morning < 24 * 3600
+
+    def test_time_of_day_already_past_rolls_to_tomorrow(self) -> None:
+        evening = datetime(2026, 4, 24, 22, 0).astimezone().timestamp()
+        ts = _parse_until("07:00", now=evening)
+        # Roll-forward by ~9 hours; not exactly 24h because the original
+        # date may be 22:00 → next day 07:00 (9h jump).
+        assert ts > evening
+        assert ts - evening > 6 * 3600
+
+    def test_iso_8601_absolute(self) -> None:
+        ts = _parse_until("2026-12-31T07:00:00")
+        # Sanity: parsed as 31-Dec-2026 in local TZ; must be >> base time
+        assert ts > time.time()
+
+    def test_invalid_form_rejects_with_typer_bad_param(self) -> None:
+        import typer
+
+        with pytest.raises(typer.BadParameter):
+            _parse_until("nonsense")
+
+    def test_empty_string_rejects(self) -> None:
+        import typer
+
+        with pytest.raises(typer.BadParameter):
+            _parse_until("   ")
+
+
+# ---------------------------------------------------------------------------
+# CLI lifecycle: start → status → list → show → stop
+# ---------------------------------------------------------------------------
+
+
+class TestDeepRunCli:
+    def test_status_when_no_session_human(self, runner: CliRunner, repo_root: Path) -> None:
+        result = runner.invoke(app, ["deep-run", "status", "--path", str(repo_root)])
+        assert result.exit_code == 0, result.output
+        assert "No active Deep-Run session" in result.output
+
+    def test_status_when_no_session_json(self, runner: CliRunner, repo_root: Path) -> None:
+        result = runner.invoke(app, ["deep-run", "status", "--json", "--path", str(repo_root)])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) is None
+
+    def test_start_status_stop_lifecycle_json(self, runner: CliRunner, repo_root: Path) -> None:
+        # Start
+        start_res = runner.invoke(
+            app,
+            [
+                "deep-run",
+                "start",
+                "--until",
+                "1h",
+                "--preset",
+                "balanced",
+                "--locality",
+                "local_only",
+                "--json",
+                "--path",
+                str(repo_root),
+            ],
+        )
+        assert start_res.exit_code == 0, start_res.output
+        started = json.loads(start_res.output)
+        assert started["status"] == "active"
+        assert started["preset"] == "balanced"
+        assert started["locality"] == "local_only"
+        assert started["cost_cap_usd"] == 0.0
+
+        # Status reflects the active session
+        status_res = runner.invoke(app, ["deep-run", "status", "--json", "--path", str(repo_root)])
+        assert status_res.exit_code == 0
+        status_payload = json.loads(status_res.output)
+        assert status_payload is not None
+        assert status_payload["id"] == started["id"]
+
+        # List shows the session
+        list_res = runner.invoke(app, ["deep-run", "list", "--json", "--path", str(repo_root)])
+        assert list_res.exit_code == 0
+        listed = json.loads(list_res.output)
+        assert any(s["id"] == started["id"] for s in listed)
+
+        # Show by id
+        show_res = runner.invoke(
+            app,
+            [
+                "deep-run",
+                "show",
+                started["id"],
+                "--json",
+                "--path",
+                str(repo_root),
+            ],
+        )
+        assert show_res.exit_code == 0
+        shown = json.loads(show_res.output)
+        assert shown["id"] == started["id"]
+
+        # Stop returns the summary
+        stop_res = runner.invoke(app, ["deep-run", "stop", "--json", "--path", str(repo_root)])
+        assert stop_res.exit_code == 0
+        summary = json.loads(stop_res.output)
+        assert summary["session_id"] == started["id"]
+        assert summary["final_status"] == "ended"
+        # Honest 4-counter discipline: all four fields present
+        assert "matured_kept" in summary
+        assert "matured_discarded" in summary
+        assert "matured_rolled_back" in summary
+        assert "matured_failed" in summary
+
+        # Status now empty
+        post_status = runner.invoke(app, ["deep-run", "status", "--json", "--path", str(repo_root)])
+        assert json.loads(post_status.output) is None
+
+    def test_stop_with_kill_records_killed_status(self, runner: CliRunner, repo_root: Path) -> None:
+        runner.invoke(
+            app,
+            ["deep-run", "start", "--until", "1h", "--json", "--path", str(repo_root)],
+        )
+        result = runner.invoke(
+            app,
+            [
+                "deep-run",
+                "stop",
+                "--kill",
+                "--reason",
+                "user_request",
+                "--json",
+                "--path",
+                str(repo_root),
+            ],
+        )
+        assert result.exit_code == 0
+        summary = json.loads(result.output)
+        assert summary["final_status"] == "killed"
+
+    def test_double_start_fails(self, runner: CliRunner, repo_root: Path) -> None:
+        runner.invoke(
+            app,
+            ["deep-run", "start", "--until", "1h", "--json", "--path", str(repo_root)],
+        )
+        result = runner.invoke(
+            app,
+            ["deep-run", "start", "--until", "1h", "--json", "--path", str(repo_root)],
+        )
+        assert result.exit_code != 0
+
+    def test_stop_with_no_session_json_returns_null(self, runner: CliRunner, repo_root: Path) -> None:
+        result = runner.invoke(app, ["deep-run", "stop", "--json", "--path", str(repo_root)])
+        assert result.exit_code == 0
+        assert json.loads(result.output) is None
+
+    def test_show_unknown_session_exit_nonzero(self, runner: CliRunner, repo_root: Path) -> None:
+        result = runner.invoke(
+            app,
+            ["deep-run", "show", "ffffffffffffffff", "--path", str(repo_root)],
+        )
+        assert result.exit_code != 0
+
+    def test_start_human_output_renders_panel(self, runner: CliRunner, repo_root: Path) -> None:
+        result = runner.invoke(app, ["deep-run", "start", "--until", "1h", "--path", str(repo_root)])
+        assert result.exit_code == 0, result.output
+        assert "Deep-Run started" in result.output
+        assert "preset" in result.output
+        assert "balanced" in result.output
+
+    def test_status_human_output_when_active(self, runner: CliRunner, repo_root: Path) -> None:
+        runner.invoke(app, ["deep-run", "start", "--until", "1h", "--path", str(repo_root)])
+        result = runner.invoke(app, ["deep-run", "status", "--path", str(repo_root)])
+        assert result.exit_code == 0
+        assert "session" in result.output
+        assert "balanced" in result.output
+
+    def test_list_human_when_empty(self, runner: CliRunner, repo_root: Path) -> None:
+        result = runner.invoke(app, ["deep-run", "list", "--path", str(repo_root)])
+        assert result.exit_code == 0
+        assert "No Deep-Run sessions" in result.output

--- a/tests/test_daemon/test_deep_run_http.py
+++ b/tests/test_daemon/test_deep_run_http.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS4 — Daemon HTTP /deep-run/* endpoint tests (0.8.3)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+from vaner.cli.commands.config import load_config
+from vaner.cli.commands.init import init_repo
+from vaner.daemon.http import create_daemon_http_app
+from vaner.intent.deep_run_gates import (
+    reset_cost_gate,
+    set_active_session_for_routing,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singletons():
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+    yield
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return repo
+
+
+@pytest.fixture
+def client(repo_root: Path) -> TestClient:
+    init_repo(repo_root)
+    config = load_config(repo_root)
+    app = create_daemon_http_app(config)
+    return TestClient(app)
+
+
+def test_status_when_no_session(client: TestClient) -> None:
+    resp = client.get("/deep-run/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"session": None}
+
+
+def test_lifecycle_start_status_list_show_stop(client: TestClient) -> None:
+    # start
+    start = client.post(
+        "/deep-run/start",
+        json={
+            "ends_at": time.time() + 3600,
+            "preset": "balanced",
+            "locality": "local_only",
+        },
+    )
+    assert start.status_code == 200, start.text
+    started = start.json()
+    assert started["status"] == "active"
+    assert started["preset"] == "balanced"
+
+    # status
+    status_resp = client.get("/deep-run/status")
+    assert status_resp.status_code == 200
+    payload = status_resp.json()
+    assert payload["session"]["id"] == started["id"]
+
+    # list
+    listed = client.get("/deep-run/sessions").json()
+    assert any(s["id"] == started["id"] for s in listed["sessions"])
+
+    # show
+    shown = client.get(f"/deep-run/sessions/{started['id']}").json()
+    assert shown["id"] == started["id"]
+
+    # stop
+    stop = client.post("/deep-run/stop", json={})
+    assert stop.status_code == 200
+    summary = stop.json()["summary"]
+    assert summary["session_id"] == started["id"]
+    assert summary["final_status"] == "ended"
+    # Four-counter honesty preserved across the surface
+    for k in ("matured_kept", "matured_discarded", "matured_rolled_back", "matured_failed"):
+        assert k in summary
+
+
+def test_start_missing_ends_at_returns_400(client: TestClient) -> None:
+    resp = client.post("/deep-run/start", json={})
+    assert resp.status_code == 400
+
+
+def test_double_start_returns_409(client: TestClient) -> None:
+    client.post("/deep-run/start", json={"ends_at": time.time() + 60})
+    second = client.post("/deep-run/start", json={"ends_at": time.time() + 60})
+    assert second.status_code == 409
+
+
+def test_show_unknown_session_returns_404(client: TestClient) -> None:
+    resp = client.get("/deep-run/sessions/ffffffffffffffff")
+    assert resp.status_code == 404
+
+
+def test_stop_with_kill_records_killed(client: TestClient) -> None:
+    client.post("/deep-run/start", json={"ends_at": time.time() + 60})
+    resp = client.post("/deep-run/stop", json={"kill": True, "reason": "user_kill"})
+    assert resp.status_code == 200
+    summary = resp.json()["summary"]
+    assert summary["final_status"] == "killed"
+    assert summary["cancelled_reason"] == "user_kill"
+
+
+def test_list_limit_bounds_clamped(client: TestClient) -> None:
+    # limit=999 should be silently clamped to 200, not rejected
+    resp = client.get("/deep-run/sessions?limit=999")
+    assert resp.status_code == 200

--- a/tests/test_engine/test_deep_run_gate_evaluation.py
+++ b/tests/test_engine/test_deep_run_gate_evaluation.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS2 — Engine-level gate evaluation tests (0.8.3).
+
+End-to-end-ish integration: the engine's ``evaluate_deep_run_gates``
+must reflect the active session's pause state in both the in-memory
+cache AND the persisted store row, so the cockpit / desktop / CLI all
+see the same truth.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from vaner.engine import VanerEngine
+from vaner.intent.adapter import CodeRepoAdapter
+from vaner.intent.deep_run_gates import (
+    NoOpResourceGateProbe,
+    ResourceGateConfig,
+    reset_cost_gate,
+    set_active_session_for_routing,
+)
+from vaner.store import deep_run as deep_run_store
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singletons():
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+    yield
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+
+
+async def _stub_llm(_prompt: str) -> str:
+    return '{"ranked_files": [], "semantic_intent": "", "confidence": 0.0, "follow_on": []}'
+
+
+def _seed_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "sample.py").write_text("def hi():\n    return 'hi'\n")
+
+
+def _engine(repo_root: Path) -> VanerEngine:
+    _seed_repo(repo_root)
+    engine = VanerEngine(adapter=CodeRepoAdapter(repo_root), llm=_stub_llm)
+    engine.config.compute.idle_only = False
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# evaluate_deep_run_gates
+# ---------------------------------------------------------------------------
+
+
+async def test_no_session_means_no_constraints(tmp_path) -> None:
+    engine = _engine(tmp_path / "repo")
+    reasons = await engine.evaluate_deep_run_gates()
+    assert reasons == []
+
+
+async def test_default_probe_means_no_pause(tmp_path) -> None:
+    engine = _engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600)
+    reasons = await engine.evaluate_deep_run_gates()
+    assert reasons == []
+    cached = await engine.current_deep_run()
+    assert cached is not None
+    assert cached.status == "active"
+    assert cached.pause_reasons == []
+
+
+async def test_battery_low_flips_status_to_paused(tmp_path) -> None:
+    engine = _engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600)
+    probe = NoOpResourceGateProbe(on_battery=True, battery_pct=15)
+    engine.set_resource_gate_probe(probe)
+
+    reasons = await engine.evaluate_deep_run_gates()
+    assert "battery" in reasons
+    cached = await engine.current_deep_run()
+    assert cached is not None
+    assert cached.status == "paused"
+    assert cached.pause_reasons == reasons
+
+    # Persisted row matches the in-memory cache (cockpit-canonical
+    # invariant: every surface reads the same record).
+    persisted = await deep_run_store.get_session(engine.store.db_path, cached.id)
+    assert persisted is not None
+    assert persisted.status == "paused"
+    assert persisted.pause_reasons == reasons
+
+
+async def test_constraints_clearing_resumes_session(tmp_path) -> None:
+    engine = _engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600)
+    probe = NoOpResourceGateProbe(on_battery=True, battery_pct=15)
+    engine.set_resource_gate_probe(probe)
+    await engine.evaluate_deep_run_gates()
+
+    # User plugs the laptop back in mid-session.
+    probe.on_battery = False
+    reasons = await engine.evaluate_deep_run_gates()
+    assert reasons == []
+    cached = await engine.current_deep_run()
+    assert cached is not None
+    assert cached.status == "active"
+    assert cached.pause_reasons == []
+
+
+async def test_unchanged_constraints_do_not_rewrite(tmp_path) -> None:
+    """Two consecutive evaluations with the same probe state should
+    be a no-op on the store (avoids spurious DB writes per cycle)."""
+    engine = _engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600)
+    engine.set_resource_gate_probe(NoOpResourceGateProbe(on_battery=True, battery_pct=15))
+    first = await engine.evaluate_deep_run_gates()
+    second = await engine.evaluate_deep_run_gates()
+    assert first == second
+    cached = await engine.current_deep_run()
+    assert cached is not None
+    assert cached.status == "paused"
+
+
+async def test_custom_resource_gate_config_overrides_thresholds(tmp_path) -> None:
+    engine = _engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600)
+    probe = NoOpResourceGateProbe(on_battery=True, battery_pct=25)
+    engine.set_resource_gate_probe(
+        probe,
+        config=ResourceGateConfig(battery_pause_charge_threshold=20),
+    )
+    # Now the threshold is 20%, charge is 25% → no pause.
+    reasons = await engine.evaluate_deep_run_gates()
+    assert "battery" not in reasons
+
+
+# ---------------------------------------------------------------------------
+# start_deep_run / stop_deep_run publish to the routing singleton
+# ---------------------------------------------------------------------------
+
+
+async def test_start_publishes_to_routing_singleton(tmp_path) -> None:
+    from vaner.intent.deep_run_gates import get_active_session_for_routing
+
+    engine = _engine(tmp_path / "repo")
+    assert get_active_session_for_routing() is None
+    started = await engine.start_deep_run(ends_at=time.time() + 60)
+    fetched = get_active_session_for_routing()
+    assert fetched is not None
+    assert fetched.id == started.id
+
+
+async def test_stop_clears_routing_singleton(tmp_path) -> None:
+    from vaner.intent.deep_run_gates import get_active_session_for_routing
+
+    engine = _engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 60)
+    await engine.stop_deep_run()
+    assert get_active_session_for_routing() is None
+
+
+async def test_resume_on_restart_republishes_to_routing(tmp_path) -> None:
+    """A daemon restart with an in-flight session should re-arm the
+    routing singleton so the router enforces gates again from cycle
+    one — not just after the user issues a new start command."""
+    from vaner.intent.deep_run_gates import get_active_session_for_routing
+
+    repo = tmp_path / "repo"
+    engine_a = _engine(repo)
+    started = await engine_a.start_deep_run(ends_at=time.time() + 3600, locality="local_only")
+    set_active_session_for_routing(None)  # simulate process restart
+
+    engine_b = _engine(repo)
+    cached = await engine_b.current_deep_run()
+    assert cached is not None
+    assert cached.id == started.id
+    fetched = get_active_session_for_routing()
+    assert fetched is not None
+    assert fetched.id == started.id
+    assert fetched.locality == "local_only"
+
+
+# ---------------------------------------------------------------------------
+# flush_deep_run_cost_to_store
+# ---------------------------------------------------------------------------
+
+
+async def test_flush_cost_persists_in_memory_spend(tmp_path) -> None:
+    from vaner.intent.deep_run_gates import try_consume_cost
+
+    engine = _engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600, locality="allow_cloud", cost_cap_usd=2.0)
+    # Simulate three remote calls consuming budget.
+    assert try_consume_cost(0.20) is True
+    assert try_consume_cost(0.30) is True
+    assert try_consume_cost(0.10) is True
+    persisted_spend = await engine.flush_deep_run_cost_to_store()
+    assert persisted_spend == pytest.approx(0.60)
+    cached = await engine.current_deep_run()
+    assert cached is not None
+    assert cached.spend_usd == pytest.approx(0.60)
+
+
+# ---------------------------------------------------------------------------
+# increment_deep_run_cycle_counter
+# ---------------------------------------------------------------------------
+
+
+async def test_cycle_counter_increments(tmp_path) -> None:
+    engine = _engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 60)
+    await engine.increment_deep_run_cycle_counter()
+    await engine.increment_deep_run_cycle_counter(promoted_count=3)
+    cached = await engine.current_deep_run()
+    assert cached is not None
+    assert cached.cycles_run == 2
+    assert cached.promoted_count == 3

--- a/tests/test_engine/test_deep_run_lifecycle.py
+++ b/tests/test_engine/test_deep_run_lifecycle.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Deep-Run engine API tests (0.8.3).
+
+Engine integration: ``start_deep_run`` / ``stop_deep_run`` /
+``current_deep_run`` / ``list_deep_run_sessions`` plus restart-safety
+(resume vs. expire) and single-active error surfacing.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from vaner.engine import VanerEngine
+from vaner.intent.adapter import CodeRepoAdapter
+from vaner.intent.deep_run import DeepRunSession
+from vaner.store import deep_run as deep_run_store
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _stub_llm(_prompt: str) -> str:
+    return '{"ranked_files": [], "semantic_intent": "", "confidence": 0.0, "follow_on": []}'
+
+
+def _seed_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "sample.py").write_text("def hello():\n    return 'hi'\n")
+
+
+def _make_engine(repo_root: Path) -> VanerEngine:
+    _seed_repo(repo_root)
+    engine = VanerEngine(adapter=CodeRepoAdapter(repo_root), llm=_stub_llm)
+    engine.config.compute.idle_only = False
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: start / current / stop
+# ---------------------------------------------------------------------------
+
+
+async def test_start_then_current_returns_same_session(tmp_path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    session = await engine.start_deep_run(
+        ends_at=time.time() + 3600,
+        preset="balanced",
+    )
+    assert session.status == "active"
+    assert session.preset == "balanced"
+    cached = await engine.current_deep_run()
+    assert cached is not None
+    assert cached.id == session.id
+
+
+async def test_start_records_workspace_root_default(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    engine = _make_engine(repo)
+    session = await engine.start_deep_run(ends_at=time.time() + 3600)
+    assert session.workspace_root == str(repo)
+
+
+async def test_start_then_stop_returns_summary_and_clears_cache(tmp_path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600)
+    summary = await engine.stop_deep_run()
+    assert summary is not None
+    assert summary.final_status == "ended"
+    assert summary.cycles_run == 0
+    assert summary.matured_kept == 0
+    assert await engine.current_deep_run() is None
+
+
+async def test_stop_with_kill_records_killed_status(tmp_path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600)
+    summary = await engine.stop_deep_run(kill=True, reason="user_kill")
+    assert summary is not None
+    assert summary.final_status == "killed"
+    # The persisted row also carries the cancelled_reason for the
+    # audit log.
+    sessions = await engine.list_deep_run_sessions(limit=5)
+    assert len(sessions) == 1
+    assert sessions[0].cancelled_reason == "user_kill"
+
+
+async def test_stop_without_active_session_returns_none(tmp_path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    summary = await engine.stop_deep_run()
+    assert summary is None
+
+
+# ---------------------------------------------------------------------------
+# Single-active enforcement (the core WS1 invariant from the engine API)
+# ---------------------------------------------------------------------------
+
+
+async def test_start_twice_raises(tmp_path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    await engine.start_deep_run(ends_at=time.time() + 3600)
+    with pytest.raises(deep_run_store.DeepRunActiveSessionExistsError):
+        await engine.start_deep_run(ends_at=time.time() + 3600)
+
+
+async def test_can_restart_after_clean_stop(tmp_path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    first = await engine.start_deep_run(ends_at=time.time() + 60)
+    await engine.stop_deep_run()
+    second = await engine.start_deep_run(ends_at=time.time() + 60)
+    assert first.id != second.id
+    cached = await engine.current_deep_run()
+    assert cached is not None
+    assert cached.id == second.id
+
+
+# ---------------------------------------------------------------------------
+# list_deep_run_sessions
+# ---------------------------------------------------------------------------
+
+
+async def test_list_includes_terminated_sessions_newest_first(tmp_path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    first = await engine.start_deep_run(ends_at=time.time() + 60)
+    await engine.stop_deep_run()
+    second = await engine.start_deep_run(ends_at=time.time() + 60)
+    sessions = await engine.list_deep_run_sessions(limit=10)
+    ids = [s.id for s in sessions]
+    assert ids[0] == second.id
+    assert first.id in ids
+
+
+# ---------------------------------------------------------------------------
+# Restart safety: pre-existing active session in DB is restored;
+# expired sessions are auto-closed.
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_restores_in_flight_session(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    engine_a = _make_engine(repo)
+    started = await engine_a.start_deep_run(ends_at=time.time() + 3600)
+
+    # Simulate a daemon restart: a fresh engine over the same repo /
+    # store should pick the active session straight back up.
+    engine_b = _make_engine(repo)
+    cached = await engine_b.current_deep_run()
+    assert cached is not None
+    assert cached.id == started.id
+    assert cached.status == "active"
+
+
+async def test_resume_expires_past_ends_at_session(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    engine_a = _make_engine(repo)
+    # Construct a session whose ends_at is already past, persist it
+    # directly, then simulate a fresh engine restart. The resume hook
+    # should auto-close it with cancelled_reason="expired_on_restart".
+    await engine_a.initialize()
+    expired = DeepRunSession.new(
+        ends_at=time.time() - 30,
+        preset="balanced",
+        focus="active_goals",
+        horizon_bias="balanced",
+        locality="local_preferred",
+        cost_cap_usd=0.0,
+        workspace_root=str(repo),
+    )
+    await deep_run_store.create_session(engine_a.store.db_path, expired)
+
+    engine_b = _make_engine(repo)
+    cached = await engine_b.current_deep_run()
+    assert cached is None
+    fetched = await deep_run_store.get_session(engine_b.store.db_path, expired.id)
+    assert fetched is not None
+    assert fetched.status == "ended"
+    assert fetched.cancelled_reason == "expired_on_restart"

--- a/tests/test_intent/test_deep_run_gates.py
+++ b/tests/test_intent/test_deep_run_gates.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS2 — Deep-Run gates tests (0.8.3).
+
+Resource gates, cost gate, locality gate, routing-state singleton.
+The gates are pure functions on a probe + an optional active session;
+state is managed via process-wide singletons that the engine maintains.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from vaner.intent.deep_run import DeepRunSession
+from vaner.intent.deep_run_gates import (
+    NoOpResourceGateProbe,
+    ResourceGateConfig,
+    cost_gate_spent_usd,
+    evaluate_resource_gates,
+    get_active_session_for_routing,
+    is_remote_call_allowed,
+    remaining_cost_budget,
+    reset_cost_gate,
+    set_active_session_for_routing,
+    try_consume_cost,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singletons():
+    """Each test starts with a clean routing pointer + cost gate.
+
+    The deep_run_gates module exposes process-wide state for the router
+    to consult; tests that mutate it must reset between cases or they
+    will bleed state into each other (and into unrelated test files).
+    """
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+    yield
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+
+
+def _session(**overrides: object) -> DeepRunSession:
+    defaults: dict[str, object] = {
+        "ends_at": time.time() + 3600,
+        "preset": "balanced",
+        "focus": "active_goals",
+        "horizon_bias": "balanced",
+        "locality": "local_preferred",
+        "cost_cap_usd": 0.0,
+        "workspace_root": "/tmp/repo",
+    }
+    defaults.update(overrides)
+    return DeepRunSession.new(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Resource gates
+# ---------------------------------------------------------------------------
+
+
+def test_noop_probe_yields_no_pause_reasons() -> None:
+    reasons = evaluate_resource_gates(probe=NoOpResourceGateProbe())
+    assert reasons == []
+
+
+def test_battery_low_pauses() -> None:
+    probe = NoOpResourceGateProbe(on_battery=True, battery_pct=20)
+    reasons = evaluate_resource_gates(probe=probe)
+    assert "battery" in reasons
+
+
+def test_battery_low_but_plugged_in_does_not_pause() -> None:
+    """Charge below threshold but on AC ⇒ no pause. The battery gate
+    cares about the *combination* of low + on-battery."""
+    probe = NoOpResourceGateProbe(on_battery=False, battery_pct=10)
+    reasons = evaluate_resource_gates(probe=probe)
+    assert "battery" not in reasons
+
+
+def test_thermal_throttle_pauses() -> None:
+    probe = NoOpResourceGateProbe(thermal_throttled=True)
+    assert "thermal" in evaluate_resource_gates(probe=probe)
+
+
+def test_gpu_temp_above_ceiling_pauses() -> None:
+    probe = NoOpResourceGateProbe(gpu_temp=90)
+    assert "thermal" in evaluate_resource_gates(probe=probe)
+
+
+def test_thermal_only_recorded_once_when_both_signals_fire() -> None:
+    probe = NoOpResourceGateProbe(thermal_throttled=True, gpu_temp=95)
+    reasons = evaluate_resource_gates(probe=probe)
+    assert reasons.count("thermal") == 1
+
+
+def test_thermal_disabled_via_config() -> None:
+    probe = NoOpResourceGateProbe(thermal_throttled=True)
+    cfg = ResourceGateConfig(cpu_throttle_pause_enabled=False)
+    reasons = evaluate_resource_gates(probe=probe, config=cfg)
+    # GPU temp is None here so thermal should not appear at all.
+    assert "thermal" not in reasons
+
+
+def test_user_input_recent_pauses() -> None:
+    probe = NoOpResourceGateProbe(seconds_idle=10.0)
+    cfg = ResourceGateConfig(user_input_pause_grace_seconds=60)
+    reasons = evaluate_resource_gates(probe=probe, config=cfg)
+    assert "user_input_observed" in reasons
+
+
+def test_user_input_old_does_not_pause() -> None:
+    probe = NoOpResourceGateProbe(seconds_idle=120.0)
+    cfg = ResourceGateConfig(user_input_pause_grace_seconds=60)
+    reasons = evaluate_resource_gates(probe=probe, config=cfg)
+    assert "user_input_observed" not in reasons
+
+
+def test_engine_error_rate_above_threshold_pauses() -> None:
+    probe = NoOpResourceGateProbe(failure_rate=0.20)
+    cfg = ResourceGateConfig(engine_error_rate_pause_threshold=0.10)
+    reasons = evaluate_resource_gates(probe=probe, config=cfg)
+    assert "engine_error_rate" in reasons
+
+
+def test_multiple_constraints_all_reported() -> None:
+    probe = NoOpResourceGateProbe(on_battery=True, battery_pct=15, thermal_throttled=True, seconds_idle=5.0)
+    reasons = evaluate_resource_gates(probe=probe)
+    assert {"battery", "thermal", "user_input_observed"} <= set(reasons)
+
+
+# ---------------------------------------------------------------------------
+# Cost gate
+# ---------------------------------------------------------------------------
+
+
+def test_cost_gate_no_session_always_allows() -> None:
+    """No active session ⇒ try_consume_cost is a no-op pass-through."""
+    assert try_consume_cost(0.5) is True
+    assert try_consume_cost(100.0) is True
+
+
+def test_cost_gate_zero_cap_blocks_any_positive_spend() -> None:
+    session = _session(cost_cap_usd=0.0)
+    reset_cost_gate(session)
+    assert try_consume_cost(0.001) is False
+    assert try_consume_cost(0.0) is True  # zero-cost calls (cache hits) always ok
+
+
+def test_cost_gate_consumes_until_cap() -> None:
+    session = _session(cost_cap_usd=1.0)
+    reset_cost_gate(session)
+    assert try_consume_cost(0.4) is True
+    assert try_consume_cost(0.4) is True
+    assert try_consume_cost(0.3) is False  # would exceed
+    assert try_consume_cost(0.2) is True  # fits exactly
+    assert remaining_cost_budget() == pytest.approx(0.0)
+
+
+def test_cost_gate_remaining_budget_tracks_spend() -> None:
+    session = _session(cost_cap_usd=2.0)
+    reset_cost_gate(session)
+    assert remaining_cost_budget() == pytest.approx(2.0)
+    try_consume_cost(0.5)
+    assert remaining_cost_budget() == pytest.approx(1.5)
+
+
+def test_cost_gate_is_thread_safe_under_concurrent_consumers() -> None:
+    """100 threads each trying to consume $0.05 against a $1.00 cap.
+
+    The contract under test is the *safety* property: the gate never
+    overshoots the cap, regardless of concurrent grants. Float drift
+    on cumulative $0.05 sums means the gate may grant 19 or 20 calls
+    (the 20th fails by ~1e-17 in float arithmetic). Both outcomes
+    satisfy the safety property; the wrong outcome would be 21+.
+    """
+    session = _session(cost_cap_usd=1.0)
+    reset_cost_gate(session)
+    successes: list[bool] = []
+    success_lock = threading.Lock()
+
+    def worker() -> None:
+        ok = try_consume_cost(0.05)
+        with success_lock:
+            successes.append(ok)
+
+    threads = [threading.Thread(target=worker) for _ in range(100)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    granted = sum(1 for s in successes if s)
+    assert granted in (19, 20), f"granted={granted} — gate overshot the cap"
+    spent = cost_gate_spent_usd()
+    assert spent is not None
+    assert spent <= 1.0 + 1e-9, f"overshot the cap: spent={spent}"
+
+
+def test_reset_cost_gate_with_none_clears_state() -> None:
+    session = _session(cost_cap_usd=1.0)
+    reset_cost_gate(session)
+    try_consume_cost(0.5)
+    reset_cost_gate(None)
+    assert remaining_cost_budget() is None
+    assert cost_gate_spent_usd() is None
+
+
+# ---------------------------------------------------------------------------
+# Locality gate
+# ---------------------------------------------------------------------------
+
+
+def test_locality_no_session_allows_remote() -> None:
+    assert is_remote_call_allowed("https://api.openai.com/v1") is True
+
+
+def test_locality_local_only_blocks_remote() -> None:
+    session = _session(locality="local_only")
+    set_active_session_for_routing(session)
+    assert is_remote_call_allowed("https://api.openai.com/v1") is False
+
+
+def test_locality_local_only_allows_local_urls() -> None:
+    session = _session(locality="local_only")
+    set_active_session_for_routing(session)
+    assert is_remote_call_allowed("http://localhost:11434/v1") is True
+    assert is_remote_call_allowed("http://127.0.0.1:8080") is True
+
+
+def test_locality_local_preferred_does_not_hard_block_remote() -> None:
+    """local_preferred is an *advisory* preference enforced by the
+    router's own fallback logic; the locality gate does not itself
+    hard-block remote calls in that mode."""
+    session = _session(locality="local_preferred")
+    set_active_session_for_routing(session)
+    assert is_remote_call_allowed("https://api.openai.com/v1") is True
+
+
+def test_locality_allow_cloud_unrestricted() -> None:
+    session = _session(locality="allow_cloud")
+    set_active_session_for_routing(session)
+    assert is_remote_call_allowed("https://api.openai.com/v1") is True
+
+
+# ---------------------------------------------------------------------------
+# Routing-state singleton
+# ---------------------------------------------------------------------------
+
+
+def test_routing_singleton_set_and_get() -> None:
+    assert get_active_session_for_routing() is None
+    session = _session()
+    set_active_session_for_routing(session)
+    fetched = get_active_session_for_routing()
+    assert fetched is not None
+    assert fetched.id == session.id
+    set_active_session_for_routing(None)
+    assert get_active_session_for_routing() is None

--- a/tests/test_intent/test_deep_run_maturation.py
+++ b/tests/test_intent/test_deep_run_maturation.py
@@ -1,0 +1,473 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS3 — Deep-Run maturation tests (0.8.3).
+
+Coverage: contract builder, default rubric judge (skeptical-default
+discipline), candidate selection (eligibility + ranking +
+diminishing-returns + probation), mature_one orchestrator (kept
+path, discarded path, evidence-score increment, probation arming),
+rollback hook.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from vaner.intent.deep_run import DeepRunSession
+from vaner.intent.deep_run_maturation import (
+    MaturationContract,
+    MaturationVerdict,
+    build_contract,
+    default_rubric_judge,
+    mature_one,
+    rollback_kept_maturation,
+    score_maturation_value,
+    select_maturation_candidates,
+)
+from vaner.intent.prediction import (
+    PredictedPrompt,
+    PredictionArtifacts,
+    PredictionRun,
+    PredictionSpec,
+    prediction_id,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _session(**overrides: object) -> DeepRunSession:
+    defaults: dict[str, object] = {
+        "ends_at": time.time() + 3600,
+        "preset": "balanced",
+        "focus": "active_goals",
+        "horizon_bias": "balanced",
+        "locality": "local_preferred",
+        "cost_cap_usd": 0.0,
+        "workspace_root": "/tmp/repo",
+    }
+    defaults.update(overrides)
+    return DeepRunSession.new(**defaults)  # type: ignore[arg-type]
+
+
+def _prediction(
+    *,
+    draft: str | None = "Initial draft.",
+    evidence_score: float = 0.3,
+    readiness: str = "ready",
+    revision: int = 0,
+    failed_revisits: int = 0,
+    probationary_until_cycle: int | None = None,
+    maturation_eligible: bool = True,
+    label: str | None = None,
+) -> PredictedPrompt:
+    # Default label is uuid-suffixed so two predictions built in the
+    # same test get distinct ids (prediction_id hashes source+anchor+label).
+    label = label if label is not None else f"test-{uuid.uuid4().hex[:8]}"
+    spec = PredictionSpec(
+        id=prediction_id("history", "anchor", label),
+        label=label,
+        description="",
+        source="history",
+        anchor="anchor",
+        confidence=0.7,
+        hypothesis_type="likely_next",
+        specificity="anchor",
+    )
+    run = PredictionRun(
+        weight=1.0,
+        token_budget=1024,
+        readiness=readiness,  # type: ignore[arg-type]
+        revision=revision,
+        failed_revisits=failed_revisits,
+        probationary_until_cycle=probationary_until_cycle,
+        maturation_eligible=maturation_eligible,
+    )
+    artifacts = PredictionArtifacts(draft_answer=draft, evidence_score=evidence_score)
+    return PredictedPrompt(spec=spec, run=run, artifacts=artifacts)
+
+
+# ---------------------------------------------------------------------------
+# Contract builder
+# ---------------------------------------------------------------------------
+
+
+def test_contract_low_evidence_demands_two_new_refs() -> None:
+    pred = _prediction(evidence_score=0.10)
+    contract = build_contract(pred, pass_id="p1")
+    assert contract.target_weakness == "low_evidence"
+    assert contract.required_new_evidence_refs == 2
+
+
+def test_contract_shallow_draft_demands_paragraph_and_ref() -> None:
+    pred = _prediction(draft="short.", evidence_score=0.9)
+    contract = build_contract(pred, pass_id="p1")
+    assert contract.target_weakness == "shallow_draft"
+    keys = [c.key for c in contract.must_clauses]
+    assert "add_substantive_paragraph_min_80_words" in keys
+    assert "new_evidence_refs_min_1" in keys
+
+
+def test_contract_universally_forbids_length_only_growth() -> None:
+    pred = _prediction()
+    contract = build_contract(pred, pass_id="p1")
+    keys = [c.key for c in contract.forbidden_clauses]
+    assert "no_length_only_growth" in keys
+    assert "no_evidence_ref_removal" in keys
+    assert "anchor_preserved" in keys
+
+
+# ---------------------------------------------------------------------------
+# Default rubric judge — skeptical-default discipline
+# ---------------------------------------------------------------------------
+
+
+async def test_judge_rejects_empty_new_draft() -> None:
+    pred = _prediction()
+    contract = build_contract(pred, pass_id="p1")
+    verdict = await default_rubric_judge(
+        prediction=pred,
+        contract=contract,
+        old_draft=pred.artifacts.draft_answer,
+        new_draft="   ",
+        new_evidence_refs=["a", "b"],
+    )
+    assert verdict.kept is False
+    assert verdict.failed_clause == "empty_new_draft"
+
+
+async def test_judge_rejects_length_only_growth_with_no_new_refs() -> None:
+    pred = _prediction(draft="A short draft.", evidence_score=0.9)
+    contract = build_contract(pred, pass_id="p1")
+    new = (
+        "A much longer draft that simply adds many more words, repeats existing "
+        "content, restates the original sentence, and pads with synonyms and "
+        "filler phrases without adding any new evidence whatsoever."
+    )
+    verdict = await default_rubric_judge(
+        prediction=pred,
+        contract=contract,
+        old_draft=pred.artifacts.draft_answer,
+        new_draft=new,
+        new_evidence_refs=[],
+    )
+    assert verdict.kept is False
+    assert verdict.failed_clause == "no_length_only_growth"
+
+
+async def test_judge_accepts_when_low_evidence_clause_satisfied() -> None:
+    pred = _prediction(evidence_score=0.10, draft="initial body.")
+    contract = build_contract(pred, pass_id="p1")
+    verdict = await default_rubric_judge(
+        prediction=pred,
+        contract=contract,
+        old_draft=pred.artifacts.draft_answer,
+        new_draft="initial body. plus refinement.",
+        new_evidence_refs=["ref-a", "ref-b"],
+    )
+    assert verdict.kept is True
+    assert "new_evidence_refs_min_2" in verdict.satisfied_clauses
+
+
+async def test_judge_rejects_low_evidence_when_too_few_new_refs() -> None:
+    pred = _prediction(evidence_score=0.10)
+    contract = build_contract(pred, pass_id="p1")
+    verdict = await default_rubric_judge(
+        prediction=pred,
+        contract=contract,
+        old_draft=pred.artifacts.draft_answer,
+        new_draft="something different",
+        new_evidence_refs=["ref-a"],  # only 1, need 2
+    )
+    assert verdict.kept is False
+    assert verdict.failed_clause == "new_evidence_refs_min_2"
+
+
+async def test_judge_accepts_shallow_draft_with_substantive_paragraph_and_ref() -> None:
+    pred = _prediction(draft="terse.", evidence_score=0.9)  # high evidence forces shallow_draft target
+    contract = build_contract(pred, pass_id="p1")
+    new_paragraph = " ".join(["substantive"] * 90)
+    new_draft = f"terse.\n\n{new_paragraph}"
+    verdict = await default_rubric_judge(
+        prediction=pred,
+        contract=contract,
+        old_draft=pred.artifacts.draft_answer,
+        new_draft=new_draft,
+        new_evidence_refs=["ref-x"],
+    )
+    assert verdict.kept is True
+
+
+async def test_judge_rejects_shallow_draft_with_only_paraphrase() -> None:
+    pred = _prediction(draft="terse content.", evidence_score=0.9)
+    contract = build_contract(pred, pass_id="p1")
+    new_draft = "TERSE Content."  # paraphrase / case-only
+    verdict = await default_rubric_judge(
+        prediction=pred,
+        contract=contract,
+        old_draft=pred.artifacts.draft_answer,
+        new_draft=new_draft,
+        new_evidence_refs=["ref-x"],
+    )
+    assert verdict.kept is False
+    assert verdict.failed_clause == "add_substantive_paragraph_min_80_words"
+
+
+# ---------------------------------------------------------------------------
+# score_maturation_value
+# ---------------------------------------------------------------------------
+
+
+def test_maturation_value_diminishes_with_revision() -> None:
+    base = _prediction(revision=0, evidence_score=0.2)
+    later = _prediction(revision=3, evidence_score=0.2)
+    assert score_maturation_value(base) > score_maturation_value(later)
+
+
+def test_maturation_value_higher_when_evidence_lower() -> None:
+    weak = _prediction(evidence_score=0.1)
+    strong = _prediction(evidence_score=0.9)
+    assert score_maturation_value(weak) > score_maturation_value(strong)
+
+
+def test_maturation_value_pending_state_outranks_complete() -> None:
+    p = _prediction(evidence_score=0.4)
+    assert score_maturation_value(p, item_state="pending") > score_maturation_value(p, item_state="complete")
+
+
+def test_maturation_value_scales_with_goal_confidence_and_alignment() -> None:
+    p = _prediction()
+    low = score_maturation_value(p, goal_confidence=0.2, artefact_alignment_score=0.5)
+    high = score_maturation_value(p, goal_confidence=0.9, artefact_alignment_score=2.0)
+    assert high > low
+
+
+# ---------------------------------------------------------------------------
+# select_maturation_candidates — eligibility + ranking
+# ---------------------------------------------------------------------------
+
+
+def test_selection_excludes_non_ready_predictions() -> None:
+    session = _session()
+    drafting = _prediction(readiness="drafting")
+    ready = _prediction(readiness="ready")
+    candidates = select_maturation_candidates([drafting, ready], session=session, cycle_index=10, max_candidates=10)
+    eligible_ids = {c.prediction.spec.id for c in candidates if c.eligible}
+    assert ready.spec.id in eligible_ids
+    assert drafting.spec.id not in eligible_ids
+
+
+def test_selection_excludes_probationary_predictions() -> None:
+    session = _session()
+    p = _prediction(probationary_until_cycle=12)
+    candidates = select_maturation_candidates([p], session=session, cycle_index=10, max_candidates=10)
+    eligible = [c for c in candidates if c.eligible]
+    assert eligible == []
+    skipped = [c for c in candidates if not c.eligible]
+    assert "probationary" in (skipped[0].skip_reason or "")
+
+
+def test_selection_admits_after_probation_window_closes() -> None:
+    session = _session()
+    p = _prediction(probationary_until_cycle=8)
+    candidates = select_maturation_candidates([p], session=session, cycle_index=10, max_candidates=10)
+    eligible = [c for c in candidates if c.eligible]
+    assert len(eligible) == 1
+
+
+def test_selection_excludes_at_revision_cap() -> None:
+    """Balanced preset has max_revisits_per_prediction=4; a prediction
+    with revision=4 must be excluded from further maturation."""
+    session = _session(preset="balanced")
+    p = _prediction(revision=4)
+    candidates = select_maturation_candidates([p], session=session, cycle_index=10, max_candidates=10)
+    assert all(not c.eligible for c in candidates)
+
+
+def test_selection_excludes_at_failure_cap() -> None:
+    session = _session(preset="balanced")
+    p = _prediction(failed_revisits=4)
+    candidates = select_maturation_candidates([p], session=session, cycle_index=10, max_candidates=10)
+    assert all(not c.eligible for c in candidates)
+
+
+def test_selection_respects_maturation_eligible_opt_out() -> None:
+    session = _session()
+    p = _prediction(maturation_eligible=False)
+    candidates = select_maturation_candidates([p], session=session, cycle_index=10, max_candidates=10)
+    assert all(not c.eligible for c in candidates)
+
+
+def test_selection_orders_by_score_descending() -> None:
+    session = _session()
+    weak = _prediction(evidence_score=0.1, label="weak")
+    strong = _prediction(evidence_score=0.8, label="strong")
+    candidates = select_maturation_candidates([strong, weak], session=session, cycle_index=10, max_candidates=10)
+    eligible = [c for c in candidates if c.eligible]
+    assert [c.prediction.spec.label for c in eligible] == ["weak", "strong"]
+
+
+def test_selection_caps_at_max_candidates() -> None:
+    session = _session()
+    preds = [_prediction(label=f"p{i}", evidence_score=0.1 * i) for i in range(10)]
+    candidates = select_maturation_candidates(preds, session=session, cycle_index=10, max_candidates=3)
+    eligible = [c for c in candidates if c.eligible]
+    assert len(eligible) == 3
+
+
+def test_aggressive_preset_allows_more_revisits_than_conservative() -> None:
+    """Aggressive max_revisits=8, Conservative=2. Same prediction at
+    revision=4 should be eligible under Aggressive but not Conservative."""
+    p = _prediction(revision=4)
+    cons = select_maturation_candidates([p], session=_session(preset="conservative"), cycle_index=10, max_candidates=10)
+    agg = select_maturation_candidates([p], session=_session(preset="aggressive"), cycle_index=10, max_candidates=10)
+    assert all(not c.eligible for c in cons)
+    assert any(c.eligible for c in agg)
+
+
+# ---------------------------------------------------------------------------
+# mature_one — kept path, discarded path, probation arming, rollback
+# ---------------------------------------------------------------------------
+
+
+async def _drafter_returning(text: str, refs: list[str]):
+    async def _stub(_pred, _contract):
+        return text, refs
+
+    return _stub
+
+
+async def test_mature_one_kept_path_persists_and_arms_probation() -> None:
+    pred = _prediction(draft="initial draft", evidence_score=0.10, revision=0)
+    session = _session()
+    drafter = await _drafter_returning("initial draft. with refinement.", ["ref-a", "ref-b"])
+    outcome = await mature_one(
+        pred,
+        session=session,
+        drafter=drafter,
+        cycle_index=5,
+        pass_id="p1",
+    )
+    assert outcome.action == "matured_kept"
+    assert outcome.verdict.kept is True
+    assert pred.artifacts.draft_answer == "initial draft. with refinement."
+    assert pred.run.revision == 1
+    assert pred.run.last_matured_cycle == 5
+    assert pred.run.probationary_until_cycle == 5 + 3  # _PROBATION_CYCLES
+    assert pred.run.failed_revisits == 0
+
+
+async def test_mature_one_discarded_path_keeps_old_draft_and_increments_failures() -> None:
+    pred = _prediction(draft="initial draft", evidence_score=0.10, revision=0)
+    session = _session()
+    drafter = await _drafter_returning("initial draft. plus refinement.", [])
+    outcome = await mature_one(
+        pred,
+        session=session,
+        drafter=drafter,
+        cycle_index=5,
+        pass_id="p1",
+    )
+    assert outcome.action == "matured_discarded"
+    assert outcome.verdict.kept is False
+    assert pred.artifacts.draft_answer == "initial draft"
+    assert pred.run.revision == 0
+    assert pred.run.failed_revisits == 1
+    assert pred.run.probationary_until_cycle is None
+
+
+async def test_mature_one_kept_resets_failed_revisits_counter() -> None:
+    pred = _prediction(failed_revisits=2, evidence_score=0.10)
+    session = _session()
+    drafter = await _drafter_returning(pred.artifacts.draft_answer + " plus refinement.", ["a", "b"])
+    await mature_one(
+        pred,
+        session=session,
+        drafter=drafter,
+        cycle_index=1,
+        pass_id="px",
+    )
+    assert pred.run.failed_revisits == 0
+    assert pred.run.revision == 1
+
+
+async def test_mature_one_uses_custom_judge() -> None:
+    pred = _prediction()
+
+    async def _always_kept_judge(**kwargs) -> MaturationVerdict:
+        return MaturationVerdict(
+            kept=True,
+            satisfied_clauses=("custom",),
+            failed_clause=None,
+            reason="custom judge",
+        )
+
+    drafter = await _drafter_returning("anything", [])
+    outcome = await mature_one(
+        pred,
+        session=_session(),
+        drafter=drafter,
+        judge=_always_kept_judge,
+        cycle_index=1,
+        pass_id="p",
+    )
+    assert outcome.verdict.kept is True
+    assert "custom" in outcome.verdict.satisfied_clauses
+
+
+# ---------------------------------------------------------------------------
+# Rollback hook
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_restores_prior_draft_and_decrements_revision() -> None:
+    pred = _prediction(
+        draft="matured-draft",
+        evidence_score=0.6,
+        revision=2,
+        failed_revisits=0,
+        probationary_until_cycle=12,
+    )
+    rollback_kept_maturation(
+        pred,
+        rollback_to_draft="prior-draft",
+        rollback_to_evidence_score=0.4,
+        cycle_index=11,
+    )
+    assert pred.artifacts.draft_answer == "prior-draft"
+    assert pred.artifacts.evidence_score == pytest.approx(0.4)
+    assert pred.run.revision == 1
+    assert pred.run.failed_revisits == 1
+    assert pred.run.probationary_until_cycle is None
+    assert pred.run.last_matured_cycle == 11
+
+
+def test_rollback_floors_revision_at_zero() -> None:
+    pred = _prediction(revision=0)
+    rollback_kept_maturation(pred, rollback_to_draft=None, rollback_to_evidence_score=0.0, cycle_index=1)
+    assert pred.run.revision == 0
+
+
+# ---------------------------------------------------------------------------
+# MaturationContract / MaturationVerdict are immutable dataclasses
+# ---------------------------------------------------------------------------
+
+
+def test_contract_is_frozen() -> None:
+    contract = MaturationContract(
+        pass_id="p",
+        target_weakness="low_evidence",
+        must_clauses=(),
+        forbidden_clauses=(),
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        contract.pass_id = "other"  # type: ignore[misc]
+
+
+def test_verdict_is_frozen() -> None:
+    verdict = MaturationVerdict(kept=True, satisfied_clauses=(), failed_clause=None, reason="")
+    with pytest.raises((AttributeError, TypeError)):
+        verdict.kept = False  # type: ignore[misc]

--- a/tests/test_intent/test_deep_run_policy.py
+++ b/tests/test_intent/test_deep_run_policy.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS2 — Preset table + applicator tests (0.8.3).
+
+Pure-data invariants on the three presets and the four horizon biases,
+plus the ``applies_focus_to_anchor`` admission gate.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from vaner.intent.deep_run import DeepRunSession
+from vaner.intent.deep_run_policy import (
+    HORIZON_BIASES,
+    PRESETS,
+    applies_focus_to_anchor,
+    horizon_bias_for,
+    preset_for,
+)
+
+
+def _session(**overrides: object) -> DeepRunSession:
+    defaults: dict[str, object] = {
+        "ends_at": time.time() + 3600,
+        "preset": "balanced",
+        "focus": "active_goals",
+        "horizon_bias": "balanced",
+        "locality": "local_preferred",
+        "cost_cap_usd": 0.0,
+        "workspace_root": "/tmp/repo",
+    }
+    defaults.update(overrides)
+    return DeepRunSession.new(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Preset table invariants
+# ---------------------------------------------------------------------------
+
+
+def test_three_presets_defined() -> None:
+    assert set(PRESETS.keys()) == {"conservative", "balanced", "aggressive"}
+
+
+@pytest.mark.parametrize("preset", ["conservative", "balanced", "aggressive"])
+def test_preset_for_returns_matching_spec(preset: str) -> None:
+    session = _session(preset=preset)
+    spec = preset_for(session)
+    assert spec is PRESETS[preset]
+
+
+def test_preset_progression_aggressive_explores_more_than_conservative() -> None:
+    """Sanity check: the 'aggressive' preset exists to spend more on
+    exploration than 'conservative'. If invariants here are ever
+    violated, the preset table has drifted from spec §7.2."""
+    cons = PRESETS["conservative"]
+    agg = PRESETS["aggressive"]
+    assert agg.invest_ratio_bias > cons.invest_ratio_bias
+    assert agg.exploit_ratio_bias < cons.exploit_ratio_bias
+    assert agg.maturation_budget_share_per_cycle > cons.maturation_budget_share_per_cycle
+    assert agg.max_revisits_per_prediction > cons.max_revisits_per_prediction
+    assert agg.draft_evidence_threshold < cons.draft_evidence_threshold
+    assert agg.idle_curve_multiplier < cons.idle_curve_multiplier
+
+
+def test_balanced_is_between_conservative_and_aggressive() -> None:
+    """Balanced should sit (loosely) between the other two on the
+    headline knobs. This is an editorial promise of the preset table."""
+    cons = PRESETS["conservative"]
+    bal = PRESETS["balanced"]
+    agg = PRESETS["aggressive"]
+    assert cons.maturation_budget_share_per_cycle <= bal.maturation_budget_share_per_cycle <= agg.maturation_budget_share_per_cycle
+    assert cons.max_revisits_per_prediction <= bal.max_revisits_per_prediction <= agg.max_revisits_per_prediction
+
+
+# ---------------------------------------------------------------------------
+# Horizon-bias table
+# ---------------------------------------------------------------------------
+
+
+def test_four_horizon_biases_defined() -> None:
+    assert set(HORIZON_BIASES.keys()) == {
+        "likely_next",
+        "long_horizon",
+        "finish_partials",
+        "balanced",
+    }
+
+
+def test_finish_partials_suppresses_new_queued() -> None:
+    bias = HORIZON_BIASES["finish_partials"]
+    assert bias.new_queued_suppression < 1.0
+    assert bias.finish_partials_multiplier > 1.0
+
+
+def test_long_horizon_suppresses_likely_next() -> None:
+    bias = HORIZON_BIASES["long_horizon"]
+    assert bias.likely_next_multiplier < 1.0
+    assert bias.long_horizon_multiplier > 1.0
+
+
+def test_balanced_horizon_is_no_op() -> None:
+    """Balanced bias should not move any score; values are all 1.0."""
+    bias = HORIZON_BIASES["balanced"]
+    assert bias.likely_next_multiplier == 1.0
+    assert bias.long_horizon_multiplier == 1.0
+    assert bias.finish_partials_multiplier == 1.0
+    assert bias.new_queued_suppression == 1.0
+
+
+def test_horizon_bias_for_session() -> None:
+    session = _session(horizon_bias="long_horizon")
+    assert horizon_bias_for(session) is HORIZON_BIASES["long_horizon"]
+
+
+# ---------------------------------------------------------------------------
+# Focus admission gate
+# ---------------------------------------------------------------------------
+
+
+def test_focus_all_recent_admits_everything() -> None:
+    session = _session(focus="all_recent")
+    assert applies_focus_to_anchor(session, goal_status="abandoned", anchor_path="/elsewhere/x.md")
+
+
+def test_focus_active_goals_excludes_terminated_goals() -> None:
+    session = _session(focus="active_goals")
+    assert applies_focus_to_anchor(session, goal_status="active", anchor_path=None)
+    assert applies_focus_to_anchor(session, goal_status="dormant", anchor_path=None)
+    assert not applies_focus_to_anchor(session, goal_status="abandoned", anchor_path=None)
+    assert not applies_focus_to_anchor(session, goal_status="achieved", anchor_path=None)
+
+
+def test_focus_active_goals_admits_when_no_goal_attached() -> None:
+    """Anchors without a goal attachment (raw scenario admissions) are
+    not gated by goal-status focus — the gate is a *positive* filter
+    on goal-attached anchors only."""
+    session = _session(focus="active_goals")
+    assert applies_focus_to_anchor(session, goal_status=None, anchor_path="/repo/x.md")
+
+
+def test_focus_current_workspace_path_prefix_match() -> None:
+    session = _session(focus="current_workspace", workspace_root="/repo")
+    assert applies_focus_to_anchor(session, goal_status=None, anchor_path="/repo/sub/x.py")
+    assert not applies_focus_to_anchor(session, goal_status=None, anchor_path="/elsewhere/x.py")
+
+
+def test_focus_current_workspace_admits_pathless_anchors() -> None:
+    session = _session(focus="current_workspace", workspace_root="/repo")
+    assert applies_focus_to_anchor(session, goal_status=None, anchor_path=None)

--- a/tests/test_intent/test_deep_run_types.py
+++ b/tests/test_intent/test_deep_run_types.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Deep-Run types tests (0.8.3).
+
+Type-level invariants only. Store-layer + engine-layer behavior is
+covered by tests/test_store/test_deep_run.py and
+tests/test_engine/test_deep_run_lifecycle.py.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from vaner.intent.deep_run import (
+    DeepRunPassLogEntry,
+    DeepRunSession,
+    DeepRunSummary,
+    new_deep_run_pass_id,
+    new_deep_run_session_id,
+)
+
+
+def test_session_new_defaults_to_active() -> None:
+    session = DeepRunSession.new(
+        ends_at=time.time() + 3600,
+        preset="balanced",
+        focus="active_goals",
+        horizon_bias="balanced",
+        locality="local_preferred",
+        cost_cap_usd=0.0,
+        workspace_root="/tmp/repo",
+    )
+    assert session.status == "active"
+    assert session.cycles_run == 0
+    assert session.spend_usd == 0.0
+    assert session.matured_total == 0
+    assert not session.is_terminal
+    assert session.metadata == {}
+
+
+def test_session_metadata_is_copied_not_aliased() -> None:
+    """Caller-supplied metadata dict must not bleed back through the
+    session — the field is its own dict so mutations stay local."""
+    payload = {"caller": "cli", "tag": "overnight"}
+    session = DeepRunSession.new(
+        ends_at=time.time() + 3600,
+        preset="aggressive",
+        focus="active_goals",
+        horizon_bias="long_horizon",
+        locality="local_only",
+        cost_cap_usd=0.0,
+        workspace_root="/tmp/repo",
+        metadata=payload,
+    )
+    payload["tag"] = "MUTATED"
+    assert session.metadata == {"caller": "cli", "tag": "overnight"}
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        ("active", False),
+        ("paused", False),
+        ("ended", True),
+        ("killed", True),
+    ],
+)
+def test_is_terminal_matches_status(status: str, expected: bool) -> None:
+    session = DeepRunSession.new(
+        ends_at=time.time() + 60,
+        preset="balanced",
+        focus="active_goals",
+        horizon_bias="balanced",
+        locality="local_preferred",
+        cost_cap_usd=0.0,
+        workspace_root="/tmp/repo",
+    )
+    session.status = status  # type: ignore[assignment]
+    assert session.is_terminal is expected
+
+
+def test_matured_total_sums_the_four_counters() -> None:
+    """The honesty discipline (§9.2) demands four separate counters be
+    surfaced. ``matured_total`` is provided for arithmetic, not to
+    flatten reporting."""
+    session = DeepRunSession.new(
+        ends_at=time.time() + 60,
+        preset="balanced",
+        focus="active_goals",
+        horizon_bias="balanced",
+        locality="local_preferred",
+        cost_cap_usd=0.0,
+        workspace_root="/tmp/repo",
+    )
+    session.matured_kept = 12
+    session.matured_discarded = 8
+    session.matured_rolled_back = 3
+    session.matured_failed = 2
+    assert session.matured_total == 25
+
+
+def test_summary_from_session_requires_ended_at() -> None:
+    session = DeepRunSession.new(
+        ends_at=time.time() + 60,
+        preset="balanced",
+        focus="active_goals",
+        horizon_bias="balanced",
+        locality="local_preferred",
+        cost_cap_usd=0.0,
+        workspace_root="/tmp/repo",
+    )
+    with pytest.raises(ValueError, match="ended_at"):
+        DeepRunSummary.from_session(session)
+
+
+def test_summary_from_session_carries_all_four_counters() -> None:
+    session = DeepRunSession.new(
+        ends_at=time.time() + 60,
+        preset="aggressive",
+        focus="active_goals",
+        horizon_bias="balanced",
+        locality="local_preferred",
+        cost_cap_usd=2.0,
+        workspace_root="/tmp/repo",
+    )
+    session.status = "ended"
+    session.ended_at = time.time()
+    session.matured_kept = 11
+    session.matured_discarded = 7
+    session.matured_rolled_back = 2
+    session.matured_failed = 1
+    session.promoted_count = 4
+    session.cycles_run = 30
+    session.spend_usd = 1.42
+    session.pause_reasons = ["thermal", "user_input_observed"]
+    summary = DeepRunSummary.from_session(session)
+    assert summary.session_id == session.id
+    assert summary.matured_kept == 11
+    assert summary.matured_discarded == 7
+    assert summary.matured_rolled_back == 2
+    assert summary.matured_failed == 1
+    assert summary.promoted_count == 4
+    assert summary.cycles_run == 30
+    assert summary.spend_usd == pytest.approx(1.42)
+    assert summary.pause_reasons == ("thermal", "user_input_observed")
+    assert summary.final_status == "ended"
+
+
+def test_pass_log_entry_factory_stamps_id_and_pass_at() -> None:
+    entry = DeepRunPassLogEntry.new(
+        session_id="sess-1",
+        prediction_id="pred-1",
+        action="matured_kept",
+        cycle_index=4,
+    )
+    assert entry.id  # uuid string, non-empty
+    assert entry.pass_at > 0
+    assert entry.action == "matured_kept"
+    assert entry.cycle_index == 4
+    assert entry.before_evidence_score is None
+    assert entry.contract_json is None
+
+
+def test_session_and_pass_id_factories_are_unique() -> None:
+    """Two consecutive id generations must differ — required because
+    the store uses ``id`` as the primary key and a collision would
+    silently drop a record."""
+    assert new_deep_run_session_id() != new_deep_run_session_id()
+    assert new_deep_run_pass_id() != new_deep_run_pass_id()

--- a/tests/test_mcp/test_deep_run_tools.py
+++ b/tests/test_mcp/test_deep_run_tools.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS4 — MCP `vaner.deep_run.*` tool tests (0.8.3)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+
+pytest.importorskip("mcp")
+from mcp.types import CallToolRequest, ListToolsRequest
+
+from vaner.intent.deep_run_gates import (
+    reset_cost_gate,
+    set_active_session_for_routing,
+)
+from vaner.mcp.server import build_server
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singletons():
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+    yield
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+
+
+def _payload(result) -> dict:
+    return json.loads(result.root.content[0].text)
+
+
+def _seed_repo(repo_root) -> None:
+    (repo_root / ".vaner").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".vaner" / "config.toml").write_text(
+        '[backend]\nbase_url = "http://127.0.0.1:11434/v1"\nmodel = "llama3.2:3b"\n',
+        encoding="utf-8",
+    )
+
+
+def test_deep_run_lifecycle_through_mcp(temp_repo, monkeypatch) -> None:
+    async def _run() -> None:
+        _seed_repo(temp_repo)
+        server = build_server(temp_repo)
+        list_handler = server.request_handlers[ListToolsRequest]
+        call_handler = server.request_handlers[CallToolRequest]
+
+        # All five tools advertised
+        listed = await list_handler(ListToolsRequest(method="tools/list"))
+        names = {t.name for t in listed.root.tools}
+        for tool_name in (
+            "vaner.deep_run.start",
+            "vaner.deep_run.stop",
+            "vaner.deep_run.status",
+            "vaner.deep_run.list",
+            "vaner.deep_run.show",
+        ):
+            assert tool_name in names
+
+        # Start a session
+        start_resp = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={
+                    "name": "vaner.deep_run.start",
+                    "arguments": {
+                        "ends_at": time.time() + 3600,
+                        "preset": "balanced",
+                        "locality": "local_only",
+                    },
+                },
+            )
+        )
+        started = _payload(start_resp)
+        assert started["status"] == "active"
+        assert started["preset"] == "balanced"
+        assert started["locality"] == "local_only"
+
+        # Status reflects the new session
+        status_resp = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "vaner.deep_run.status", "arguments": {}},
+            )
+        )
+        status_payload = _payload(status_resp)
+        assert status_payload["session"] is not None
+        assert status_payload["session"]["id"] == started["id"]
+
+        # vaner.status should also surface deep_run state
+        monkeypatch.setattr(
+            "vaner.mcp.server.aprecompute",
+            lambda *args, **kwargs: asyncio.sleep(0, result=1),
+        )
+        global_status = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "vaner.status", "arguments": {}},
+            )
+        )
+        global_payload = _payload(global_status)
+        assert "deep_run" in global_payload
+        assert global_payload["deep_run"]["active"] is True
+        assert global_payload["deep_run"]["session"]["id"] == started["id"]
+
+        # List + show
+        list_resp = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "vaner.deep_run.list", "arguments": {"limit": 5}},
+            )
+        )
+        listed_sessions = _payload(list_resp)["sessions"]
+        assert any(s["id"] == started["id"] for s in listed_sessions)
+
+        show_resp = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={
+                    "name": "vaner.deep_run.show",
+                    "arguments": {"session_id": started["id"]},
+                },
+            )
+        )
+        shown = _payload(show_resp)
+        assert shown["id"] == started["id"]
+
+        # Stop
+        stop_resp = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "vaner.deep_run.stop", "arguments": {}},
+            )
+        )
+        summary = _payload(stop_resp)["summary"]
+        assert summary is not None
+        assert summary["session_id"] == started["id"]
+        assert summary["final_status"] == "ended"
+        # Honest 4-counter discipline
+        for k in ("matured_kept", "matured_discarded", "matured_rolled_back", "matured_failed"):
+            assert k in summary
+
+    asyncio.run(_run())
+
+
+def test_deep_run_start_rejects_missing_ends_at(temp_repo) -> None:
+    async def _run() -> None:
+        _seed_repo(temp_repo)
+        server = build_server(temp_repo)
+        call_handler = server.request_handlers[CallToolRequest]
+        resp = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "vaner.deep_run.start", "arguments": {}},
+            )
+        )
+        assert resp.root.isError is True
+
+    asyncio.run(_run())
+
+
+def test_deep_run_show_unknown_session_returns_not_found(temp_repo) -> None:
+    async def _run() -> None:
+        _seed_repo(temp_repo)
+        server = build_server(temp_repo)
+        call_handler = server.request_handlers[CallToolRequest]
+        resp = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={
+                    "name": "vaner.deep_run.show",
+                    "arguments": {"session_id": "ffffffffffffffff"},
+                },
+            )
+        )
+        assert resp.root.isError is True
+
+    asyncio.run(_run())
+
+
+def test_deep_run_stop_with_no_session_returns_null_summary(temp_repo) -> None:
+    async def _run() -> None:
+        _seed_repo(temp_repo)
+        server = build_server(temp_repo)
+        call_handler = server.request_handlers[CallToolRequest]
+        resp = await call_handler(
+            CallToolRequest(
+                method="tools/call",
+                params={"name": "vaner.deep_run.stop", "arguments": {}},
+            )
+        )
+        body = _payload(resp)
+        assert body.get("summary") is None
+
+    asyncio.run(_run())

--- a/tests/test_mcp/test_protocol_roundtrip.py
+++ b/tests/test_mcp/test_protocol_roundtrip.py
@@ -71,6 +71,12 @@ def test_mcp_protocol_roundtrip(temp_repo: Path, monkeypatch: pytest.MonkeyPatch
                 "vaner.artefacts.set_status",
                 "vaner.artefacts.influence",
                 "vaner.sources.status",
+                # 0.8.3 WS4: Deep-Run lifecycle.
+                "vaner.deep_run.start",
+                "vaner.deep_run.stop",
+                "vaner.deep_run.status",
+                "vaner.deep_run.list",
+                "vaner.deep_run.show",
             }
 
             status = await session.call_tool("vaner.status", {})

--- a/tests/test_mcp/test_scenario_tools.py
+++ b/tests/test_mcp/test_scenario_tools.py
@@ -73,6 +73,12 @@ def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
             "vaner.artefacts.set_status",
             "vaner.artefacts.influence",
             "vaner.sources.status",
+            # 0.8.3 WS4: Deep-Run lifecycle.
+            "vaner.deep_run.start",
+            "vaner.deep_run.stop",
+            "vaner.deep_run.status",
+            "vaner.deep_run.list",
+            "vaner.deep_run.show",
         }
 
         monkeypatch.setattr("vaner.mcp.server.aprecompute", lambda *args, **kwargs: asyncio.sleep(0, result=1))

--- a/tests/test_mcp/test_server_boot.py
+++ b/tests/test_mcp/test_server_boot.py
@@ -19,9 +19,10 @@ def test_server_boot_initialize_lists_tools_and_status(temp_repo) -> None:
             listed = await session.list_tools()
             names = [tool.name for tool in listed.tools]
             # WS7 added 4 goal tools → 16. 0.8.2 WS1 adds 4 artefact
-            # tools + 1 sources.status → 21 total. Exact set is asserted
-            # in test_protocol_roundtrip; here we just check smoke.
-            assert len(names) == 21
+            # tools + 1 sources.status → 21. 0.8.3 WS4 adds 5 deep_run
+            # tools → 26 total. Exact set is asserted in
+            # test_protocol_roundtrip; here we just check smoke.
+            assert len(names) == 26
             assert "vaner.status" in names
             assert "vaner.predictions.active" in names
             assert "vaner.predictions.adopt" in names
@@ -29,6 +30,7 @@ def test_server_boot_initialize_lists_tools_and_status(temp_repo) -> None:
             assert "vaner.artefacts.list" in names
             assert "vaner.artefacts.influence" in names
             assert "vaner.sources.status" in names
+            assert "vaner.deep_run.start" in names
             status = await session.call_tool("vaner.status", {})
             assert json.loads(status.content[0].text)["ready"] is True
 

--- a/tests/test_router/test_deep_run_gate_integration.py
+++ b/tests/test_router/test_deep_run_gate_integration.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS2 — Router-layer Deep-Run gate integration tests (0.8.3).
+
+The router's ``_enforce_deep_run_gates_for_remote`` helper is the
+hard-block surface for locality + cost. These tests verify the four
+contracts that matter at the router boundary:
+
+1. No active session ⇒ no-op (existing behaviour preserved).
+2. Local URL ⇒ no-op (gates only fire on remote calls).
+3. local_only session + remote URL ⇒ DeepRunRemoteCallBlockedError.
+4. cost cap exhausted + remote URL ⇒ DeepRunRemoteCallBlockedError.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from vaner.intent.deep_run import DeepRunSession
+from vaner.intent.deep_run_gates import (
+    reset_cost_gate,
+    set_active_session_for_routing,
+)
+from vaner.router.backends import (
+    DeepRunRemoteCallBlockedError,
+    _enforce_deep_run_gates_for_remote,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singletons():
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+    yield
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+
+
+def _session(**overrides: object) -> DeepRunSession:
+    defaults: dict[str, object] = {
+        "ends_at": time.time() + 3600,
+        "preset": "balanced",
+        "focus": "active_goals",
+        "horizon_bias": "balanced",
+        "locality": "local_preferred",
+        "cost_cap_usd": 0.0,
+        "workspace_root": "/tmp/repo",
+    }
+    defaults.update(overrides)
+    return DeepRunSession.new(**defaults)  # type: ignore[arg-type]
+
+
+def test_no_session_is_noop() -> None:
+    """Whole point of the gate's safety design: zero behaviour change
+    when no Deep-Run session is active."""
+    _enforce_deep_run_gates_for_remote("https://api.openai.com/v1")  # no raise
+
+
+def test_local_url_is_noop_even_with_local_only_session() -> None:
+    session = _session(locality="local_only")
+    set_active_session_for_routing(session)
+    reset_cost_gate(session)
+    _enforce_deep_run_gates_for_remote("http://127.0.0.1:11434/v1")  # no raise
+    _enforce_deep_run_gates_for_remote("http://localhost:8080")  # no raise
+
+
+def test_local_only_blocks_remote_with_clear_error() -> None:
+    session = _session(locality="local_only")
+    set_active_session_for_routing(session)
+    reset_cost_gate(session)
+    with pytest.raises(DeepRunRemoteCallBlockedError) as excinfo:
+        _enforce_deep_run_gates_for_remote("https://api.openai.com/v1")
+    assert "local_only" in str(excinfo.value)
+    assert session.id in str(excinfo.value)
+
+
+def test_cost_cap_exhausted_blocks_remote() -> None:
+    session = _session(locality="allow_cloud", cost_cap_usd=0.0)
+    set_active_session_for_routing(session)
+    reset_cost_gate(session)
+    with pytest.raises(DeepRunRemoteCallBlockedError) as excinfo:
+        _enforce_deep_run_gates_for_remote("https://api.openai.com/v1")
+    assert "cost cap" in str(excinfo.value)
+
+
+def test_cost_cap_with_room_permits_call() -> None:
+    session = _session(locality="allow_cloud", cost_cap_usd=1.0)
+    set_active_session_for_routing(session)
+    reset_cost_gate(session)
+    # Default per-call estimate is $0.01 — well within $1.00.
+    _enforce_deep_run_gates_for_remote("https://api.openai.com/v1")  # no raise
+
+
+def test_cost_cap_explicit_estimate_overrides_default() -> None:
+    session = _session(locality="allow_cloud", cost_cap_usd=0.05)
+    set_active_session_for_routing(session)
+    reset_cost_gate(session)
+    # An explicit estimate above the cap blocks immediately.
+    with pytest.raises(DeepRunRemoteCallBlockedError):
+        _enforce_deep_run_gates_for_remote("https://api.openai.com/v1", estimated_usd=0.10)

--- a/tests/test_store/test_deep_run_store.py
+++ b/tests/test_store/test_deep_run_store.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Deep-Run store + DAO tests (0.8.3).
+
+Schema, lifecycle, single-active-session enforcement, expired-session
+cleanup, and pass-log round-trip. Engine wiring is covered separately
+by tests/test_engine/test_deep_run_lifecycle.py.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from vaner.intent.deep_run import (
+    DeepRunPassLogEntry,
+    DeepRunSession,
+)
+from vaner.store import deep_run as deep_run_store
+from vaner.store.artefacts import ArtefactStore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _initialized_store(tmp_path):
+    store = ArtefactStore(tmp_path / "store.db")
+    await store.initialize()
+    return store
+
+
+def _make_session(ends_in_seconds: float = 3600) -> DeepRunSession:
+    return DeepRunSession.new(
+        ends_at=time.time() + ends_in_seconds,
+        preset="balanced",
+        focus="active_goals",
+        horizon_bias="balanced",
+        locality="local_preferred",
+        cost_cap_usd=0.0,
+        workspace_root="/tmp/repo",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session create / read
+# ---------------------------------------------------------------------------
+
+
+async def test_create_session_round_trip(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    session = _make_session()
+    created = await deep_run_store.create_session(store.db_path, session)
+    assert created.id == session.id
+
+    fetched = await deep_run_store.get_active_session(store.db_path)
+    assert fetched is not None
+    assert fetched.id == session.id
+    assert fetched.preset == "balanced"
+    assert fetched.cost_cap_usd == 0.0
+    assert fetched.status == "active"
+    assert fetched.metadata == {}
+
+
+async def test_create_session_rejects_non_active_status(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    session = _make_session()
+    session.status = "ended"
+    with pytest.raises(ValueError, match="status='active'"):
+        await deep_run_store.create_session(store.db_path, session)
+
+
+async def test_create_session_persists_metadata_and_pause_reasons(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    session = DeepRunSession.new(
+        ends_at=time.time() + 60,
+        preset="aggressive",
+        focus="current_workspace",
+        horizon_bias="long_horizon",
+        locality="local_only",
+        cost_cap_usd=2.5,
+        workspace_root="/tmp/repo",
+        metadata={"caller": "cli", "tag": "overnight"},
+    )
+    session.pause_reasons = ["thermal"]
+    await deep_run_store.create_session(store.db_path, session)
+    fetched = await deep_run_store.get_session(store.db_path, session.id)
+    assert fetched is not None
+    assert fetched.metadata == {"caller": "cli", "tag": "overnight"}
+    assert fetched.pause_reasons == ["thermal"]
+    assert fetched.preset == "aggressive"
+    assert fetched.locality == "local_only"
+    assert fetched.cost_cap_usd == pytest.approx(2.5)
+
+
+# ---------------------------------------------------------------------------
+# Single-active-session enforcement (the core WS1 invariant)
+# ---------------------------------------------------------------------------
+
+
+async def test_single_active_session_enforced(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    first = _make_session()
+    await deep_run_store.create_session(store.db_path, first)
+
+    second = _make_session()
+    with pytest.raises(deep_run_store.DeepRunActiveSessionExistsError):
+        await deep_run_store.create_session(store.db_path, second)
+
+    # Original session is unchanged.
+    fetched = await deep_run_store.get_active_session(store.db_path)
+    assert fetched is not None
+    assert fetched.id == first.id
+
+
+async def test_can_start_session_after_previous_is_ended(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    first = _make_session()
+    await deep_run_store.create_session(store.db_path, first)
+    await deep_run_store.update_session_status(store.db_path, first.id, status="ended", ended_at=time.time())
+
+    second = _make_session()
+    await deep_run_store.create_session(store.db_path, second)
+    fetched = await deep_run_store.get_active_session(store.db_path)
+    assert fetched is not None
+    assert fetched.id == second.id
+
+
+# ---------------------------------------------------------------------------
+# Status updates + active lookup semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_paused_session_is_returned_by_get_active(tmp_path) -> None:
+    """``get_active_session`` returns paused sessions too — the engine
+    resumes them when pause reasons clear, so they're still in flight."""
+    store = await _initialized_store(tmp_path)
+    session = _make_session()
+    await deep_run_store.create_session(store.db_path, session)
+    await deep_run_store.update_session_status(
+        store.db_path,
+        session.id,
+        status="paused",
+        pause_reasons=["thermal", "battery"],
+    )
+    fetched = await deep_run_store.get_active_session(store.db_path)
+    assert fetched is not None
+    assert fetched.status == "paused"
+    assert fetched.pause_reasons == ["thermal", "battery"]
+
+
+async def test_ended_session_not_returned_by_get_active(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    session = _make_session()
+    await deep_run_store.create_session(store.db_path, session)
+    await deep_run_store.update_session_status(
+        store.db_path,
+        session.id,
+        status="killed",
+        ended_at=time.time(),
+        cancelled_reason="user_kill",
+    )
+    assert await deep_run_store.get_active_session(store.db_path) is None
+    fetched = await deep_run_store.get_session(store.db_path, session.id)
+    assert fetched is not None
+    assert fetched.status == "killed"
+    assert fetched.cancelled_reason == "user_kill"
+
+
+# ---------------------------------------------------------------------------
+# Counter increments
+# ---------------------------------------------------------------------------
+
+
+async def test_increment_session_counters_atomic_add(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    session = _make_session()
+    await deep_run_store.create_session(store.db_path, session)
+    await deep_run_store.increment_session_counters(
+        store.db_path,
+        session.id,
+        cycles_run=1,
+        matured_kept=2,
+        matured_discarded=1,
+        spend_usd=0.05,
+    )
+    await deep_run_store.increment_session_counters(
+        store.db_path,
+        session.id,
+        cycles_run=1,
+        matured_kept=3,
+        matured_failed=1,
+        spend_usd=0.10,
+    )
+    fetched = await deep_run_store.get_session(store.db_path, session.id)
+    assert fetched is not None
+    assert fetched.cycles_run == 2
+    assert fetched.matured_kept == 5
+    assert fetched.matured_discarded == 1
+    assert fetched.matured_failed == 1
+    assert fetched.spend_usd == pytest.approx(0.15)
+
+
+async def test_increment_with_all_zero_is_noop(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    session = _make_session()
+    await deep_run_store.create_session(store.db_path, session)
+    changed = await deep_run_store.increment_session_counters(store.db_path, session.id)
+    assert changed is False
+
+
+# ---------------------------------------------------------------------------
+# list_sessions
+# ---------------------------------------------------------------------------
+
+
+async def test_list_sessions_newest_first_with_status_filter(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    older = _make_session()
+    older.started_at = time.time() - 120
+    await deep_run_store.create_session(store.db_path, older)
+    await deep_run_store.update_session_status(store.db_path, older.id, status="ended", ended_at=time.time() - 60)
+    newer = _make_session()
+    newer.started_at = time.time()
+    await deep_run_store.create_session(store.db_path, newer)
+
+    all_sessions = await deep_run_store.list_sessions(store.db_path, limit=10)
+    assert [s.id for s in all_sessions] == [newer.id, older.id]
+
+    only_active = await deep_run_store.list_sessions(store.db_path, status="active")
+    assert [s.id for s in only_active] == [newer.id]
+
+    only_ended = await deep_run_store.list_sessions(store.db_path, status="ended")
+    assert [s.id for s in only_ended] == [older.id]
+
+
+# ---------------------------------------------------------------------------
+# Expiry / restart cleanup
+# ---------------------------------------------------------------------------
+
+
+async def test_close_expired_sessions_closes_past_ends_at(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    expired = _make_session(ends_in_seconds=-10)  # ends_at in the past
+    await deep_run_store.create_session(store.db_path, expired)
+
+    closed_count = await deep_run_store.close_expired_sessions(store.db_path, now=time.time())
+    assert closed_count == 1
+    fetched = await deep_run_store.get_session(store.db_path, expired.id)
+    assert fetched is not None
+    assert fetched.status == "ended"
+    assert fetched.cancelled_reason == "expired_on_restart"
+    assert fetched.ended_at is not None
+
+
+async def test_close_expired_sessions_leaves_future_sessions_alone(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    in_flight = _make_session(ends_in_seconds=3600)
+    await deep_run_store.create_session(store.db_path, in_flight)
+    closed_count = await deep_run_store.close_expired_sessions(store.db_path, now=time.time())
+    assert closed_count == 0
+    fetched = await deep_run_store.get_active_session(store.db_path)
+    assert fetched is not None
+    assert fetched.id == in_flight.id
+
+
+async def test_close_expired_sessions_handles_paused_too(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    paused_expired = _make_session(ends_in_seconds=-10)
+    await deep_run_store.create_session(store.db_path, paused_expired)
+    await deep_run_store.update_session_status(
+        store.db_path,
+        paused_expired.id,
+        status="paused",
+        pause_reasons=["battery"],
+    )
+    closed_count = await deep_run_store.close_expired_sessions(store.db_path, now=time.time())
+    assert closed_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Pass-log round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_pass_log_round_trip_with_filters(tmp_path) -> None:
+    store = await _initialized_store(tmp_path)
+    session = _make_session()
+    await deep_run_store.create_session(store.db_path, session)
+    a = DeepRunPassLogEntry.new(
+        session_id=session.id,
+        prediction_id="pred-A",
+        action="matured_kept",
+        cycle_index=1,
+        before_evidence_score=0.4,
+        after_evidence_score=0.7,
+    )
+    b = DeepRunPassLogEntry.new(
+        session_id=session.id,
+        prediction_id="pred-A",
+        action="matured_discarded",
+        cycle_index=2,
+    )
+    c = DeepRunPassLogEntry.new(
+        session_id=session.id,
+        prediction_id="pred-B",
+        action="explored",
+        cycle_index=2,
+    )
+    for entry in (a, b, c):
+        await deep_run_store.insert_pass_log_entry(store.db_path, entry)
+
+    all_entries = await deep_run_store.list_pass_log_entries(store.db_path, session_id=session.id)
+    assert {e.id for e in all_entries} == {a.id, b.id, c.id}
+
+    by_prediction = await deep_run_store.list_pass_log_entries(store.db_path, session_id=session.id, prediction_id="pred-A")
+    assert {e.id for e in by_prediction} == {a.id, b.id}
+
+    only_kept = await deep_run_store.list_pass_log_entries(store.db_path, session_id=session.id, action="matured_kept")
+    assert [e.id for e in only_kept] == [a.id]
+    assert only_kept[0].before_evidence_score == pytest.approx(0.4)
+    assert only_kept[0].after_evidence_score == pytest.approx(0.7)

--- a/ui/cockpit/src/api/deepRun.ts
+++ b/ui/cockpit/src/api/deepRun.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// 0.8.3 WS4 — Cockpit fetch helpers for the daemon's /deep-run/*
+// endpoints.  Mirrors the schema shipped by src/vaner/daemon/http.py.
+//
+// `API_BASE` follows the same convention as the rest of the cockpit
+// (the daemon listens on 127.0.0.1:8473 by default; override via
+// `VITE_VANER_DAEMON_URL` at build time).  When the daemon is not
+// reachable, every helper rejects with a Response-shaped Error so
+// callers can surface a clear "daemon offline" state rather than
+// silently absorbing failures.
+
+import type {
+  DeepRunSession,
+  DeepRunSummary,
+  StartDeepRunRequest,
+  StopDeepRunRequest,
+} from '../types/deepRun'
+
+const API_BASE: string =
+  (typeof import.meta !== 'undefined' &&
+    (import.meta as { env?: Record<string, string> }).env?.VITE_VANER_DAEMON_URL) ||
+  'http://127.0.0.1:8473'
+
+async function _request<T>(
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: { 'content-type': 'application/json', ...(init?.headers || {}) },
+    ...init,
+  })
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`${response.status} ${response.statusText}: ${text}`)
+  }
+  return (await response.json()) as T
+}
+
+export async function startDeepRun(
+  body: StartDeepRunRequest,
+): Promise<DeepRunSession> {
+  return _request<DeepRunSession>('/deep-run/start', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+export async function stopDeepRun(
+  body: StopDeepRunRequest = {},
+): Promise<{ summary: DeepRunSummary | null }> {
+  return _request<{ summary: DeepRunSummary | null }>('/deep-run/stop', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+export async function getDeepRunStatus(): Promise<{ session: DeepRunSession | null }> {
+  return _request<{ session: DeepRunSession | null }>('/deep-run/status')
+}
+
+export async function listDeepRunSessions(
+  limit: number = 20,
+): Promise<{ sessions: DeepRunSession[] }> {
+  return _request<{ sessions: DeepRunSession[] }>(
+    `/deep-run/sessions?limit=${encodeURIComponent(limit)}`,
+  )
+}
+
+export async function getDeepRunSession(
+  sessionId: string,
+): Promise<DeepRunSession> {
+  return _request<DeepRunSession>(
+    `/deep-run/sessions/${encodeURIComponent(sessionId)}`,
+  )
+}

--- a/ui/cockpit/src/components/DeepRunPanel.tsx
+++ b/ui/cockpit/src/components/DeepRunPanel.tsx
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+// 0.8.3 WS4 — Cockpit Deep-Run panel.  One self-contained React
+// component that renders both the active-session pill and the
+// start-controls form.  Drop into any layout slot in App.tsx; once
+// the cockpit's missing api/client.ts lands the existing components
+// can compose this without further wiring.
+//
+// Honest 4-counter discipline (spec §9.2 / §14.1): the active-session
+// pill always renders kept / discarded / rolled-back / failed as four
+// separate numbers, never collapsed into a single "matured" total.
+
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  getDeepRunStatus,
+  listDeepRunSessions,
+  startDeepRun,
+  stopDeepRun,
+} from '../api/deepRun'
+import type {
+  DeepRunHorizonBias,
+  DeepRunFocus,
+  DeepRunLocality,
+  DeepRunPreset,
+  DeepRunSession,
+} from '../types/deepRun'
+
+const PRESET_OPTIONS: DeepRunPreset[] = ['conservative', 'balanced', 'aggressive']
+const FOCUS_OPTIONS: DeepRunFocus[] = ['active_goals', 'current_workspace', 'all_recent']
+const HORIZON_OPTIONS: DeepRunHorizonBias[] = [
+  'likely_next',
+  'long_horizon',
+  'finish_partials',
+  'balanced',
+]
+const LOCALITY_OPTIONS: DeepRunLocality[] = [
+  'local_only',
+  'local_preferred',
+  'allow_cloud',
+]
+
+type DeepRunFormState = {
+  untilHours: number
+  preset: DeepRunPreset
+  focus: DeepRunFocus
+  horizon: DeepRunHorizonBias
+  locality: DeepRunLocality
+  costCapUsd: number
+}
+
+const DEFAULT_FORM: DeepRunFormState = {
+  untilHours: 8,
+  preset: 'balanced',
+  focus: 'active_goals',
+  horizon: 'balanced',
+  locality: 'local_preferred',
+  costCapUsd: 0,
+}
+
+function _formatTime(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function _formatRemaining(endsAt: number): string {
+  const remainingSec = Math.max(0, endsAt - Date.now() / 1000)
+  if (remainingSec <= 0) return 'expired'
+  const h = Math.floor(remainingSec / 3600)
+  const m = Math.floor((remainingSec % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m left`
+  return `${m}m left`
+}
+
+interface DeepRunPillProps {
+  session: DeepRunSession
+  onStop: () => void | Promise<void>
+}
+
+export function DeepRunPill({ session, onStop }: DeepRunPillProps): JSX.Element {
+  const totalAttempts =
+    session.matured_kept +
+    session.matured_discarded +
+    session.matured_rolled_back +
+    session.matured_failed
+  return (
+    <div
+      className={`deep-run-pill deep-run-pill--${session.preset}`}
+      data-testid="deep-run-pill"
+    >
+      <span className="deep-run-pill__badge">
+        {session.status === 'paused' ? '⏸︎ paused' : '🌙 deep-run'}
+      </span>
+      <span className="deep-run-pill__preset">{session.preset}</span>
+      <span className="deep-run-pill__remaining">
+        {_formatRemaining(session.ends_at)} (until {_formatTime(session.ends_at)})
+      </span>
+      <span className="deep-run-pill__cycles">cycle {session.cycles_run}</span>
+      {/* Honest 4-counter discipline — surface every outcome separately. */}
+      <span className="deep-run-pill__matured" title="kept / discarded / rolled-back / failed">
+        matured: {session.matured_kept}/{session.matured_discarded}/
+        {session.matured_rolled_back}/{session.matured_failed} of {totalAttempts}
+      </span>
+      {session.cost_cap_usd > 0 ? (
+        <span className="deep-run-pill__spend">
+          ${session.spend_usd.toFixed(2)} / ${session.cost_cap_usd.toFixed(2)}
+        </span>
+      ) : (
+        <span className="deep-run-pill__spend">local-only (no remote spend)</span>
+      )}
+      {session.pause_reasons.length > 0 ? (
+        <span className="deep-run-pill__pause-reasons">
+          paused: {session.pause_reasons.join(', ')}
+        </span>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => {
+          void onStop()
+        }}
+        className="deep-run-pill__stop"
+        data-testid="deep-run-stop"
+      >
+        stop
+      </button>
+    </div>
+  )
+}
+
+interface DeepRunStartCardProps {
+  onStarted: (session: DeepRunSession) => void
+}
+
+export function DeepRunStartCard({ onStarted }: DeepRunStartCardProps): JSX.Element {
+  const [form, setForm] = useState<DeepRunFormState>(DEFAULT_FORM)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = useCallback(async () => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const session = await startDeepRun({
+        ends_at: Date.now() / 1000 + form.untilHours * 3600,
+        preset: form.preset,
+        focus: form.focus,
+        horizon_bias: form.horizon,
+        locality: form.locality,
+        cost_cap_usd: form.costCapUsd,
+        metadata: { caller: 'cockpit' },
+      })
+      onStarted(session)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }, [form, onStarted])
+
+  return (
+    <div className="deep-run-start-card" data-testid="deep-run-start-card">
+      <h3>Start Deep-Run</h3>
+      <label>
+        Until (hours)
+        <input
+          type="number"
+          min={0.25}
+          step={0.25}
+          value={form.untilHours}
+          onChange={(e) => setForm({ ...form, untilHours: Number(e.target.value) })}
+        />
+      </label>
+      <label>
+        Preset
+        <select
+          value={form.preset}
+          onChange={(e) => setForm({ ...form, preset: e.target.value as DeepRunPreset })}
+        >
+          {PRESET_OPTIONS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Focus
+        <select
+          value={form.focus}
+          onChange={(e) => setForm({ ...form, focus: e.target.value as DeepRunFocus })}
+        >
+          {FOCUS_OPTIONS.map((f) => (
+            <option key={f} value={f}>
+              {f}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Horizon bias
+        <select
+          value={form.horizon}
+          onChange={(e) =>
+            setForm({ ...form, horizon: e.target.value as DeepRunHorizonBias })
+          }
+        >
+          {HORIZON_OPTIONS.map((h) => (
+            <option key={h} value={h}>
+              {h}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Locality
+        <select
+          value={form.locality}
+          onChange={(e) =>
+            setForm({ ...form, locality: e.target.value as DeepRunLocality })
+          }
+        >
+          {LOCALITY_OPTIONS.map((l) => (
+            <option key={l} value={l}>
+              {l}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Cost cap (USD; 0 ⇒ no remote spend)
+        <input
+          type="number"
+          min={0}
+          step={0.5}
+          value={form.costCapUsd}
+          onChange={(e) => setForm({ ...form, costCapUsd: Number(e.target.value) })}
+        />
+      </label>
+      {error ? (
+        <div className="deep-run-start-card__error" role="alert">
+          {error}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        disabled={submitting}
+        onClick={() => {
+          void submit()
+        }}
+      >
+        {submitting ? 'Starting…' : 'Start Deep-Run'}
+      </button>
+    </div>
+  )
+}
+
+export function DeepRunPanel(): JSX.Element {
+  const [session, setSession] = useState<DeepRunSession | null>(null)
+  const [history, setHistory] = useState<DeepRunSession[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const [statusResp, listResp] = await Promise.all([
+        getDeepRunStatus(),
+        listDeepRunSessions(10),
+      ])
+      setSession(statusResp.session)
+      setHistory(listResp.sessions)
+    } catch {
+      // Daemon offline / network error — leave state as-is and let the
+      // poll retry on the next interval.
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const interval = window.setInterval(() => {
+      void refresh()
+    }, 5000)
+    return () => window.clearInterval(interval)
+  }, [refresh])
+
+  const onStop = useCallback(async () => {
+    await stopDeepRun()
+    await refresh()
+  }, [refresh])
+
+  const onStarted = useCallback(
+    (started: DeepRunSession) => {
+      setSession(started)
+      void refresh()
+    },
+    [refresh],
+  )
+
+  return (
+    <div className="deep-run-panel">
+      {loading ? (
+        <div className="deep-run-panel__loading">Loading Deep-Run state…</div>
+      ) : session ? (
+        <DeepRunPill session={session} onStop={onStop} />
+      ) : (
+        <DeepRunStartCard onStarted={onStarted} />
+      )}
+      {history.length > 0 ? (
+        <details className="deep-run-panel__history">
+          <summary>History ({history.length})</summary>
+          <table>
+            <thead>
+              <tr>
+                <th>id</th>
+                <th>status</th>
+                <th>preset</th>
+                <th>started</th>
+                <th>cycles</th>
+                <th>matured (k/d/r/f)</th>
+                <th>spend</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map((s) => (
+                <tr key={s.id}>
+                  <td>
+                    <code>{s.id.slice(0, 8)}</code>
+                  </td>
+                  <td>{s.status}</td>
+                  <td>{s.preset}</td>
+                  <td>{_formatTime(s.started_at)}</td>
+                  <td>{s.cycles_run}</td>
+                  <td>
+                    {s.matured_kept}/{s.matured_discarded}/
+                    {s.matured_rolled_back}/{s.matured_failed}
+                  </td>
+                  <td>${s.spend_usd.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      ) : null}
+    </div>
+  )
+}

--- a/ui/cockpit/src/types/deepRun.ts
+++ b/ui/cockpit/src/types/deepRun.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// 0.8.3 WS4 — TypeScript mirrors of the Python DeepRunSession /
+// DeepRunSummary schema.  Kept here so cockpit code can import strict
+// types without hand-rolling them at every call site.  The Python
+// canonical definitions live in src/vaner/intent/deep_run.py and the
+// daemon HTTP surface in src/vaner/daemon/http.py serialises rows in
+// this exact shape.  Keep the field names byte-for-byte aligned with
+// the server-side _session_to_dict / _summary_to_dict helpers in
+// src/vaner/cli/commands/deep_run.py — those are the on-the-wire schema.
+
+export type DeepRunPreset = 'conservative' | 'balanced' | 'aggressive'
+export type DeepRunFocus = 'active_goals' | 'current_workspace' | 'all_recent'
+export type DeepRunHorizonBias =
+  | 'likely_next'
+  | 'long_horizon'
+  | 'finish_partials'
+  | 'balanced'
+export type DeepRunLocality = 'local_only' | 'local_preferred' | 'allow_cloud'
+export type DeepRunStatus = 'active' | 'paused' | 'ended' | 'killed'
+export type DeepRunPauseReason =
+  | 'battery'
+  | 'thermal'
+  | 'user_input_observed'
+  | 'engine_error_rate'
+  | 'cost_cap_exceeded'
+  | 'user_requested'
+
+export interface DeepRunSession {
+  id: string
+  status: DeepRunStatus
+  preset: DeepRunPreset
+  focus: DeepRunFocus
+  horizon_bias: DeepRunHorizonBias
+  locality: DeepRunLocality
+  cost_cap_usd: number
+  spend_usd: number
+  workspace_root: string
+  started_at: number
+  ends_at: number
+  ended_at: number | null
+  cycles_run: number
+  // Honest 4-counter discipline (spec §9.2 / §14.1): surfaces must show
+  // all four maturation outcome counts, never just `kept`.
+  matured_kept: number
+  matured_discarded: number
+  matured_rolled_back: number
+  matured_failed: number
+  promoted_count: number
+  pause_reasons: DeepRunPauseReason[]
+  cancelled_reason: string | null
+  metadata: Record<string, string>
+}
+
+export interface DeepRunSummary {
+  session_id: string
+  started_at: number
+  ended_at: number
+  preset: DeepRunPreset
+  cycles_run: number
+  matured_kept: number
+  matured_discarded: number
+  matured_rolled_back: number
+  matured_failed: number
+  promoted_count: number
+  spend_usd: number
+  pause_reasons: DeepRunPauseReason[]
+  cancelled_reason: string | null
+  final_status: DeepRunStatus
+}
+
+export interface StartDeepRunRequest {
+  ends_at: number
+  preset?: DeepRunPreset
+  focus?: DeepRunFocus
+  horizon_bias?: DeepRunHorizonBias
+  locality?: DeepRunLocality
+  cost_cap_usd?: number
+  metadata?: Record<string, string>
+}
+
+export interface StopDeepRunRequest {
+  kill?: boolean
+  reason?: string
+}


### PR DESCRIPTION
## Summary

Ships **0.8.3 — Overnight / Deep-Run Mode**, a policy layer that lets the user declare a long uninterrupted preparation window so Vaner can mature predictions, broaden coverage, and produce a better-prepared inventory by the time the user returns. Six commits, five work streams, one canonical record across CLI / MCP / HTTP / cockpit. Engineered against the well-known same-model self-judging anti-pattern with a generator/judge separation + per-pass `MaturationContract` + probationary persistence with rollback.

### What lands

- **WS1 — policy primitives + persistence.** `DeepRunSession` row, two SQLite tables, single-active enforced by UNIQUE partial index, four engine API methods, resume-on-restart with auto-expire of past-`ends_at` sessions.
- **WS2 — governor + gates + router enforcement.** `PredictionGovernor.Mode.DEEP_RUN`, three presets (Conservative / Balanced / Aggressive), four horizon biases, focus admission gate, `ResourceGateProbe` Protocol, thread-safe cost gate, locality gate. Router blocks remote calls when `local_only` or cost-cap exhausted via new `DeepRunRemoteCallBlockedError`.
- **WS3 — maturation revisiting.** The central new mechanism. Drafter and judge are distinct callables; default judge is programmatic, skeptical, rubric-based. Per-pass `MaturationContract` defines what counts as improvement *before* the drafter runs. Probationary persistence + `rollback_kept_maturation()` for contradicting reconciliation signals.
- **WS4 — surfaces.** `vaner deep-run start | stop | status | list | show` CLI, five `vaner.deep_run.*` MCP tools (with `vaner.status` extended to surface active session), five `/deep-run/*` daemon HTTP endpoints, cockpit React panel + types + API client, desktop SwiftUI hand-off doc.
- **WS5 — bench primitives + ship gates.** `compute_maturation_metrics()` + `evaluate_ship_gates()` in `Vaner-train/eval/deep_run_bench.py` (separate repo) with five binding ship gates: maturation_effectiveness, judge_external_agreement (κ ≥ 0.70 — the anti-self-judging gate), persistence_rate_in_band, probationary_rollback_rate, stale_by_morning_rate.

### Honest 4-counter discipline (spec §9.2 / §14.1)

Every surface that displays maturation activity shows `matured_kept`, `matured_discarded`, `matured_rolled_back`, `matured_failed` as **four separate values**, never collapsed into a single inflated "matured" total. This defends against the failure mode where a same-model self-judging loop confidently over-approves its own output.

### Hard safety gates (verified in code + tests)

- **Cost-cap compliance** — no overshoot under 100-thread concurrency.
- **Local-only fidelity** — zero remote calls when `local_only`.
- **Single-active session** — UNIQUE partial index + DAO defensive check; `DeepRunActiveSessionExistsError` on conflict.
- **Resume-on-restart** — in-flight sessions survive daemon restart; expired sessions auto-close.
- **Reconciliation rollback** — kept maturations rolled back if contradicted in probation window.
- **No new MCP write surfaces** beyond the five `vaner.deep_run.*` tools.

### What is intentionally NOT in this PR

- The labelled morning-briefing fixture corpus (≥10 sessions per archetype across writer / researcher / developer / planner) and the bench run that produces the 0.8.3 validation numbers — depends on human labelling work and an external judge model. Tracked in `docs/benchmarks/0.8.3-deep-run-validation.md`; ships as a follow-up.
- The desktop SwiftUI work in `vaner-desktop/` — separate repo, separate review cycle. Hand-off doc at `docs/0.8.3/desktop-hand-off.md`.
- Engine-cycle wiring of `mature_one()` invocations — the building blocks ship; the per-cycle hook into `precompute_cycle()` is a small, safe follow-up that ships when the labelled corpus exists to validate it.

### Local CI status

- `pytest tests/` — **1020 passing, 14 skipped** (zero new skips); +211 new tests.
- `ruff format --check .` — pass.
- `ruff check .` — pass.
- `mypy` (CI strict + 0.8.0 + legacy scopes per `.github/workflows/ci.yml`) — pass.
- `pre-commit run --all-files` — pass (after running `scripts/bump-plugin-version.sh --write`).
- `pip-audit` — pass (only OS packages couldn't be audited; no PyPI CVEs).
- Security review — no new HIGH/MEDIUM-confidence vulnerabilities introduced (the locality-gate substring matcher is a pre-existing hardening opportunity, not a new vuln; tracked separately).

## Test plan

- [ ] CI matrix passes: ubuntu-latest + macos-latest × Python 3.11/3.12/3.13 + windows-latest × Python 3.12.
- [ ] CodeQL clean.
- [ ] creds-tripwire clean.
- [ ] moat-guard clean.
- [ ] Replay regression passes.
- [ ] After merge: tag `v0.8.3` on the merge commit to trigger `docker-release.yml` (publishes to ghcr.io/borgels/vaner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)