### PR TITLE
feat(intent): 0.8.5 WS6 — UI card model + ETA estimator + readiness labels

### DIFF
--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -62,6 +62,7 @@ from vaner.cli.commands.init import (
 from vaner.cli.commands.inspect import inspect_decision as inspect_decision_output
 from vaner.cli.commands.inspect import inspect_last as inspect_last_output
 from vaner.cli.commands.inspect import list_decisions as list_decisions_output
+from vaner.cli.commands.integrations import integrations_app
 from vaner.cli.commands.primer import PRIMER_SURFACES, write_primers
 from vaner.cli.commands.profile import export_pins, import_pins, pin_fact, profile_show, unpin_fact
 from vaner.cli.commands.runtime_snapshot import runtime_snapshot
@@ -2143,6 +2144,7 @@ app.add_typer(profile_app, name="profile", rich_help_panel="Background and local
 app.add_typer(scenarios_app, name="scenarios", rich_help_panel="Use with an agent")
 app.add_typer(deep_run_app, name="deep-run", rich_help_panel="Background and local")
 app.add_typer(guidance_app, name="guidance", rich_help_panel="Use with an agent")
+app.add_typer(integrations_app, name="integrations", rich_help_panel="Inspect and debug")
 
 
 def run() -> None:

--- a/src/vaner/cli/commands/integrations.py
+++ b/src/vaner/cli/commands/integrations.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""`vaner integrations` CLI — introspect the client-facing integration surface."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Annotated, Any
+
+import httpx
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from vaner.cli.commands.config import load_config
+from vaner.integrations.guidance import current_version, load_guidance
+
+integrations_app = typer.Typer(
+    help="Inspect and diagnose Vaner's integration layer.",
+    no_args_is_help=True,
+)
+
+_DAEMON_URL = "http://127.0.0.1:8473"
+
+
+@integrations_app.command("doctor", help="Run the integration-layer health check.")
+def doctor_cmd(
+    repo_root: Annotated[
+        Path | None,
+        typer.Option("--repo-root", "-C", help="Repo root whose `.vaner/` directory holds the config."),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: pretty (default), json."),
+    ] = "pretty",
+    daemon_url: Annotated[
+        str,
+        typer.Option("--daemon-url", help="Override the local daemon URL."),
+    ] = _DAEMON_URL,
+) -> None:
+    root = repo_root if repo_root is not None else Path.cwd()
+    report = _collect_report(repo_root=root, daemon_url=daemon_url)
+    if format == "json":
+        typer.echo(json.dumps(report, indent=2, default=str))
+        return
+    _render_pretty(report)
+
+
+def _collect_report(*, repo_root: Path, daemon_url: str) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "repo_root": str(repo_root),
+        "daemon_url": daemon_url,
+    }
+
+    # Config snapshot
+    cfg = None
+    try:
+        cfg = load_config(repo_root)
+        integrations_cfg = cfg.integrations.model_dump(mode="json")
+    except Exception as exc:  # pragma: no cover - defensive
+        integrations_cfg = {"error": f"{type(exc).__name__}: {exc}"}
+    report["integrations_config"] = integrations_cfg
+
+    # Guidance asset
+    try:
+        doc = load_guidance("canonical")
+        report["guidance"] = {
+            "version": doc.version,
+            "minimum_vaner_version": doc.minimum_vaner_version,
+            "updated_at": doc.updated_at,
+            "source_path": str(doc.source_path),
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        report["guidance"] = {"error": f"{type(exc).__name__}: {exc}"}
+
+    # AGENTS.md primer parity
+    agents_md = _find_agents_md(repo_root)
+    if agents_md is not None:
+        report["agents_md_parity"] = _check_primer_parity(agents_md)
+    else:
+        report["agents_md_parity"] = {"present": False}
+
+    # Daemon reachability
+    report["daemon"] = _probe_daemon(daemon_url)
+
+    # Pending-adopt handoff freshness
+    report["handoff"] = _probe_handoff(repo_root)
+
+    # Overall ok/fail signal
+    report["ok"] = _overall_ok(report)
+    return report
+
+
+def _find_agents_md(repo_root: Path) -> Path | None:
+    candidate = repo_root / "AGENTS.md"
+    if candidate.exists():
+        return candidate
+    # Also check if we're running from a subdirectory of the Vaner repo itself.
+    mod_root = Path(__file__).resolve().parents[3]
+    candidate = mod_root / "AGENTS.md"
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _check_primer_parity(agents_md: Path) -> dict[str, Any]:
+    """Run `scripts/sync_agents_primer.py --check` if available; else heuristic."""
+    try:
+        mod_root = Path(__file__).resolve().parents[3]
+        script = mod_root / "scripts" / "sync_agents_primer.py"
+        if script.exists():
+            result = subprocess.run(
+                [sys.executable, str(script), "--check"],
+                cwd=str(mod_root),
+                capture_output=True,
+                text=True,
+            )
+            return {
+                "present": True,
+                "in_sync": result.returncode == 0,
+                "path": str(agents_md),
+                "detail": result.stderr.strip() if result.returncode != 0 else "synced",
+            }
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"present": True, "path": str(agents_md), "error": f"{type(exc).__name__}: {exc}"}
+
+    # Fallback: check the marker exists and includes a version.
+    text = agents_md.read_text(encoding="utf-8")
+    marker = "<!-- vaner-primer:start"
+    return {
+        "present": True,
+        "in_sync": marker in text,
+        "path": str(agents_md),
+        "detail": "marker_found" if marker in text else "marker_missing",
+    }
+
+
+def _probe_daemon(url: str) -> dict[str, Any]:
+    try:
+        with httpx.Client(timeout=1.5) as client:
+            resp = client.get(f"{url}/health")
+            resp.raise_for_status()
+            guidance_resp = client.get(f"{url}/integrations/guidance")
+            guidance_ok = guidance_resp.status_code == 200
+            return {
+                "reachable": True,
+                "url": url,
+                "health": resp.json() if resp.headers.get("content-type", "").startswith("application/json") else "ok",
+                "guidance_endpoint_ok": guidance_ok,
+            }
+    except httpx.HTTPError as exc:
+        return {"reachable": False, "url": url, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _probe_handoff(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / ".vaner" / "pending-adopt.json"
+    if not path.exists():
+        return {"present": False, "path": str(path)}
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        return {
+            "present": True,
+            "path": str(path),
+            "adopted_from_prediction_id": data.get("adopted_from_prediction_id"),
+            "resolution_id": data.get("resolution_id"),
+            "age_hint": data.get("adopted_at"),
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"present": True, "path": str(path), "parse_error": str(exc)}
+
+
+def _overall_ok(report: dict[str, Any]) -> bool:
+    if "error" in report.get("guidance", {}):
+        return False
+    if report.get("agents_md_parity", {}).get("present") and not report["agents_md_parity"].get("in_sync"):
+        return False
+    return True
+
+
+def _render_pretty(report: dict[str, Any]) -> None:
+    console = Console()
+    console.rule("[bold]Vaner integrations doctor[/bold]")
+    console.print(f"Repo root: [cyan]{report['repo_root']}[/cyan]")
+    console.print(f"Daemon URL: [cyan]{report['daemon_url']}[/cyan]")
+    console.print()
+
+    # Guidance
+    table = Table(title="Guidance asset", show_header=True, header_style="bold")
+    table.add_column("Field")
+    table.add_column("Value")
+    guidance = report["guidance"]
+    if "error" in guidance:
+        table.add_row("error", f"[red]{guidance['error']}[/red]")
+    else:
+        table.add_row("version", str(guidance["version"]))
+        table.add_row("minimum_vaner_version", guidance["minimum_vaner_version"])
+        table.add_row("updated_at", guidance["updated_at"])
+        table.add_row("source", guidance["source_path"])
+    console.print(table)
+
+    # Primer parity
+    parity = report["agents_md_parity"]
+    status = "✓ synced" if parity.get("in_sync") else ("[red]drift[/red]" if parity.get("present") else "[yellow]missing[/yellow]")
+    console.print(f"AGENTS.md primer: {status}")
+    if parity.get("detail"):
+        console.print(f"  {parity['detail']}")
+    console.print()
+
+    # Config
+    cfg_table = Table(title="Integrations config", show_header=True, header_style="bold")
+    cfg_table.add_column("Key")
+    cfg_table.add_column("Value")
+    cfg = report["integrations_config"]
+    if "error" in cfg:
+        cfg_table.add_row("error", f"[red]{cfg['error']}[/red]")
+    else:
+        cfg_table.add_row("guidance_variant", str(cfg["guidance_variant"]))
+        cfg_table.add_row("advertise_guidance_resource", str(cfg["advertise_guidance_resource"]))
+        cfg_table.add_row("capability_detection_enabled", str(cfg["capability_detection_enabled"]))
+        ci = cfg["context_injection"]
+        cfg_table.add_row("context_injection.mode", str(ci["mode"]))
+        cfg_table.add_row("context_injection.digest_token_budget", str(ci["digest_token_budget"]))
+        cfg_table.add_row(
+            "context_injection.adopted_package_token_budget",
+            str(ci["adopted_package_token_budget"]),
+        )
+        cfg_table.add_row(
+            "context_injection.max_context_fraction",
+            f"{ci['max_context_fraction']:.2f}",
+        )
+        cfg_table.add_row("context_injection.ttl_seconds", str(ci["ttl_seconds"]))
+    console.print(cfg_table)
+
+    # Daemon + handoff
+    daemon = report["daemon"]
+    if daemon["reachable"]:
+        console.print(f"Daemon: [green]reachable[/green]  guidance endpoint: {'ok' if daemon['guidance_endpoint_ok'] else 'FAIL'}")
+    else:
+        console.print(f"Daemon: [red]unreachable[/red]  ({daemon.get('error', 'unknown')})")
+    handoff = report["handoff"]
+    if handoff["present"]:
+        console.print(f"Pending handoff: present  ({handoff.get('path')})")
+    else:
+        console.print(f"Pending handoff: none  ({handoff.get('path')})")
+    console.print()
+    console.print("Overall: [green]OK[/green]" if report["ok"] else "Overall: [red]needs attention[/red]")
+
+
+@integrations_app.command("tier", help="Print the current guidance version; helpful in CI probes.")
+def tier_cmd() -> None:
+    typer.echo(f"guidance_version={current_version()}")

--- a/src/vaner/integrations/__init__.py
+++ b/src/vaner/integrations/__init__.py
@@ -6,6 +6,14 @@ single home for everything that bridges Vaner's prediction registry to the
 various surfaces (MCP tools, HTTP, MCP Apps UI, desktop handoff).
 """
 
+from vaner.integrations.capability import (
+    ClientCapabilityTier,
+    TierDetection,
+    current_detection,
+    current_tier,
+    detect_tier,
+    record_tier,
+)
 from vaner.integrations.guidance import (
     GuidanceDoc,
     GuidanceVariant,
@@ -26,16 +34,22 @@ from vaner.integrations.injection import (
 
 __all__ = [
     "AdoptedPackagePayload",
+    "ClientCapabilityTier",
     "ContextInjectionMode",
     "DigestEntry",
     "GuidanceDoc",
     "GuidanceVariant",
     "InjectionDecision",
     "InjectionInputs",
+    "TierDetection",
     "available_variants",
     "build_adopted_package",
     "build_digest",
+    "current_detection",
+    "current_tier",
     "current_version",
+    "detect_tier",
     "load_guidance",
+    "record_tier",
     "should_inject",
 ]

--- a/src/vaner/integrations/capability.py
+++ b/src/vaner/integrations/capability.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Client capability tiers.
+
+Vaner ships a single engine but the right delivery surface depends on what
+the connected client can do. We classify the client into one of four tiers
+during MCP ``initialize`` and pick defaults accordingly.
+
+Tier definitions (mirror the 0.8.5 plan):
+
+* Tier 1 — MCP only. Tools work; nothing else.
+* Tier 2 — MCP + prompt guidance. Accepts a canonical guidance block.
+* Tier 3 — MCP + prompt guidance + context mediation. Accepts injected
+  digest / adopted-package blocks.
+* Tier 4 — MCP Apps UI capable. Renders ``ui://`` resources inline.
+"""
+
+from __future__ import annotations
+
+import logging
+import weakref
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class ClientCapabilityTier(IntEnum):
+    UNKNOWN = 0
+    TIER_1 = 1
+    TIER_2 = 2
+    TIER_3 = 3
+    TIER_4 = 4
+
+
+_UI_EXT_KEY = "io.modelcontextprotocol/ui"
+_INJECTION_EXT_KEY = "vaner.context_injection"
+
+
+@dataclass(frozen=True)
+class TierDetection:
+    """Explainable tier classification — includes the signals used."""
+
+    tier: ClientCapabilityTier
+    client_name: str | None = None
+    client_version: str | None = None
+    reason: str = "heuristic"
+
+
+def detect_tier(client_params: Any | None) -> TierDetection:
+    """Classify *client_params* (an MCP ``InitializeRequestParams``) into a tier.
+
+    Returns :class:`TierDetection` so callers can log why a tier was chosen.
+    Degrades to :attr:`ClientCapabilityTier.UNKNOWN` on missing/malformed
+    input rather than raising.
+    """
+    if client_params is None:
+        return TierDetection(tier=ClientCapabilityTier.UNKNOWN, reason="no_client_params")
+
+    name = _safe_get(client_params, "clientInfo", "name")
+    version = _safe_get(client_params, "clientInfo", "version")
+    caps = _safe_attr(client_params, "capabilities")
+    if caps is None:
+        return TierDetection(
+            tier=ClientCapabilityTier.TIER_1,
+            client_name=name,
+            client_version=version,
+            reason="capabilities_absent",
+        )
+
+    experimental = _safe_attr(caps, "experimental") or {}
+    if isinstance(experimental, dict) and _UI_EXT_KEY in experimental:
+        return TierDetection(
+            tier=ClientCapabilityTier.TIER_4,
+            client_name=name,
+            client_version=version,
+            reason="ui_extension_advertised",
+        )
+    if isinstance(experimental, dict) and _INJECTION_EXT_KEY in experimental:
+        return TierDetection(
+            tier=ClientCapabilityTier.TIER_3,
+            client_name=name,
+            client_version=version,
+            reason="vaner_injection_extension_advertised",
+        )
+    if _safe_attr(caps, "roots") is not None or _safe_attr(caps, "sampling") is not None:
+        return TierDetection(
+            tier=ClientCapabilityTier.TIER_2,
+            client_name=name,
+            client_version=version,
+            reason="roots_or_sampling_present",
+        )
+    return TierDetection(
+        tier=ClientCapabilityTier.TIER_1,
+        client_name=name,
+        client_version=version,
+        reason="no_known_tier_markers",
+    )
+
+
+def _safe_attr(obj: Any, name: str) -> Any:
+    try:
+        return getattr(obj, name, None)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _safe_get(obj: Any, *path: str) -> Any:
+    cur: Any = obj
+    for part in path:
+        cur = _safe_attr(cur, part)
+        if cur is None:
+            return None
+    return cur
+
+
+# ---------------------------------------------------------------------------
+# Session cache
+# ---------------------------------------------------------------------------
+
+
+class _SessionTierCache:
+    """Cache tier detection per live MCP session.
+
+    Sessions are short-lived; we key by ``id(session)`` and hold a weak
+    reference so we don't pin memory. If the SDK drops the session the
+    entry disappears automatically.
+    """
+
+    def __init__(self) -> None:
+        self._by_id: dict[int, TierDetection] = {}
+        self._refs: dict[int, weakref.ReferenceType[Any]] = {}
+
+    def get(self, session: Any) -> TierDetection | None:
+        key = id(session)
+        if key not in self._by_id:
+            return None
+        ref = self._refs.get(key)
+        if ref is None or ref() is None:
+            self._by_id.pop(key, None)
+            self._refs.pop(key, None)
+            return None
+        return self._by_id[key]
+
+    def put(self, session: Any, detection: TierDetection) -> None:
+        key = id(session)
+
+        def _cleanup(_ref: Any, k: int = key) -> None:
+            self._by_id.pop(k, None)
+            self._refs.pop(k, None)
+
+        self._by_id[key] = detection
+        try:
+            self._refs[key] = weakref.ref(session, _cleanup)
+        except TypeError:
+            # Session not weakly-referenceable (e.g. a dict stub in tests);
+            # fall back to a strong reference in the dict but no-op cleanup.
+            self._refs[key] = weakref.ref(_DummyKeeper(session), _cleanup)
+
+
+class _DummyKeeper:
+    """Weakref target for objects that don't support weakref natively."""
+
+    __slots__ = ("__weakref__", "inner")
+
+    def __init__(self, inner: Any) -> None:
+        self.inner = inner
+
+
+_CACHE = _SessionTierCache()
+
+
+def record_tier(session: Any, detection: TierDetection) -> None:
+    _CACHE.put(session, detection)
+    logger.info(
+        "vaner.integrations.tier_detected",
+        extra={
+            "tier": int(detection.tier),
+            "tier_name": detection.tier.name,
+            "client_name": detection.client_name,
+            "client_version": detection.client_version,
+            "reason": detection.reason,
+        },
+    )
+
+
+def current_tier(session: Any) -> ClientCapabilityTier:
+    detection = _CACHE.get(session)
+    return detection.tier if detection is not None else ClientCapabilityTier.UNKNOWN
+
+
+def current_detection(session: Any) -> TierDetection | None:
+    return _CACHE.get(session)
+
+
+def reset_cache() -> None:
+    """Test-only helper — clear the per-session cache."""
+    _CACHE._by_id.clear()
+    _CACHE._refs.clear()

--- a/src/vaner/integrations/injection/__init__.py
+++ b/src/vaner/integrations/injection/__init__.py
@@ -5,6 +5,13 @@ from vaner.integrations.injection.adopted_package import (
     build_adopted_package,
 )
 from vaner.integrations.injection.digest import DigestEntry, build_digest
+from vaner.integrations.injection.handoff import (
+    DEFAULT_TTL_SECONDS,
+    HandoffResolution,
+    consume_handoff,
+    handoff_path,
+    read_handoff,
+)
 from vaner.integrations.injection.mode import ContextInjectionMode
 from vaner.integrations.injection.policy import (
     InjectionDecision,
@@ -14,14 +21,19 @@ from vaner.integrations.injection.policy import (
 from vaner.integrations.injection.tokens import count_tokens, truncate_to_budget
 
 __all__ = [
+    "DEFAULT_TTL_SECONDS",
     "AdoptedPackagePayload",
     "ContextInjectionMode",
     "DigestEntry",
+    "HandoffResolution",
     "InjectionDecision",
     "InjectionInputs",
     "build_adopted_package",
     "build_digest",
+    "consume_handoff",
     "count_tokens",
+    "handoff_path",
+    "read_handoff",
     "should_inject",
     "truncate_to_budget",
 ]

--- a/src/vaner/integrations/injection/handoff.py
+++ b/src/vaner/integrations/injection/handoff.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adopt-handoff file-drop reader.
+
+The macOS and Linux desktop clients (and in future, web cockpit / VS Code
+extension) stash the Resolution JSON at a platform-canonical path when the
+user clicks Adopt. This module is the daemon-side reader that lets the MCP
+`vaner.resolve` handler short-circuit when a fresh adopted package is
+already on disk for this user.
+
+Paths mirror the Rust `vaner_contract::handoff` module (see
+`crates/vaner-contract/src/handoff.rs`):
+
+- Linux:   `$XDG_STATE_HOME/vaner/pending-adopt.json`
+  (spec-compliant fallback `~/.local/state/vaner/pending-adopt.json`)
+- macOS:   `~/Library/Application Support/Vaner/pending-adopt.json`
+- Windows: `%LOCALAPPDATA%\\Vaner\\pending-adopt.json`
+- Fallback: `~/.vaner/pending-adopt.json`
+
+Consumers should ignore drops older than `DEFAULT_TTL_SECONDS` (CONTRACT.md
+recommends 10 min). The stash writer injects a top-level `stashed_at`
+epoch-seconds key exactly for this purpose.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 600
+"""10-minute freshness window — matches CONTRACT.md recommendation."""
+
+
+@dataclass(frozen=True)
+class HandoffResolution:
+    """A fresh adopted-package drop suitable for suppressing a resolve call."""
+
+    raw: dict[str, Any]
+    """Full resolution JSON as written by the desktop client (includes any
+    unknown-to-daemon keys — we pass through intact)."""
+
+    stashed_at: float
+    """Epoch seconds from the drop's `stashed_at` field."""
+
+    age_seconds: float
+    """How long ago the drop was written, at read time."""
+
+    path: Path
+    """Which file we read from — useful in logs."""
+
+    @property
+    def intent(self) -> str | None:
+        v = self.raw.get("intent")
+        return v if isinstance(v, str) else None
+
+    @property
+    def adopted_from_prediction_id(self) -> str | None:
+        v = self.raw.get("adopted_from_prediction_id")
+        return v if isinstance(v, str) else None
+
+    @property
+    def resolution_id(self) -> str | None:
+        v = self.raw.get("resolution_id")
+        return v if isinstance(v, str) else None
+
+    @property
+    def prepared_briefing(self) -> str | None:
+        v = self.raw.get("prepared_briefing")
+        return v if isinstance(v, str) else None
+
+    @property
+    def predicted_response(self) -> str | None:
+        v = self.raw.get("predicted_response")
+        return v if isinstance(v, str) else None
+
+
+def handoff_path() -> Path:
+    """Return the platform-canonical handoff file path."""
+    if sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+        return base / "Vaner" / "pending-adopt.json"
+    if sys.platform.startswith("linux"):
+        state = os.environ.get("XDG_STATE_HOME")
+        if state:
+            root = Path(state)
+        else:
+            root = Path.home() / ".local" / "state"
+        return root / "vaner" / "pending-adopt.json"
+    if sys.platform.startswith("win"):
+        local = os.environ.get("LOCALAPPDATA")
+        if local:
+            return Path(local) / "Vaner" / "pending-adopt.json"
+    # Fallback — matches the Rust crate's non-primary-platform branch.
+    return Path.home() / ".vaner" / "pending-adopt.json"
+
+
+def read_handoff(
+    *,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    now: float | None = None,
+    path: Path | None = None,
+) -> HandoffResolution | None:
+    """Return the stashed Resolution if it exists and is fresh, else None.
+
+    ``now`` is injectable for tests. ``path`` can override platform default
+    (e.g. in-repo test path via ``vaner integrations doctor --repo-root``).
+    """
+    target = path if path is not None else handoff_path()
+    if not target.exists():
+        return None
+    try:
+        raw_text = target.read_text(encoding="utf-8")
+        data = json.loads(raw_text)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.info("handoff read failed: %s (path=%s)", exc, target)
+        return None
+    if not isinstance(data, dict):
+        logger.debug("handoff payload is not an object (path=%s)", target)
+        return None
+    stashed_at_raw = data.get("stashed_at")
+    if not isinstance(stashed_at_raw, (int, float)):
+        # Older drops without stashed_at are ignored — the desktop clients
+        # started injecting this key in 0.8.4; a missing key means either
+        # a pre-0.8.4 drop (treat as stale) or a broken writer.
+        logger.debug("handoff payload missing stashed_at (path=%s)", target)
+        return None
+    stashed_at = float(stashed_at_raw)
+    current = float(now) if now is not None else time.time()
+    age = max(0.0, current - stashed_at)
+    if age > ttl_seconds:
+        logger.debug("handoff stale: age=%.1fs ttl=%ds (path=%s)", age, ttl_seconds, target)
+        return None
+    return HandoffResolution(raw=data, stashed_at=stashed_at, age_seconds=age, path=target)
+
+
+def consume_handoff(
+    *,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    now: float | None = None,
+    path: Path | None = None,
+) -> HandoffResolution | None:
+    """Read + delete the handoff file in a single step (one-shot semantics).
+
+    Used by the MCP resolve handler so a single adopted package doesn't
+    keep suppressing fresh queries forever. If read fails, no delete.
+    """
+    result = read_handoff(ttl_seconds=ttl_seconds, now=now, path=path)
+    if result is None:
+        return None
+    try:
+        result.path.unlink()
+    except OSError as exc:
+        logger.info("handoff consumed but delete failed: %s (path=%s)", exc, result.path)
+    return result

--- a/src/vaner/intent/prediction_card.py
+++ b/src/vaner/intent/prediction_card.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Server-side derivation of UI card fields from a PredictedPrompt.
+
+The MCP `vaner.predictions.dashboard` tool and the daemon HTTP
+`/predictions/active` endpoint both need the same derived fields
+(readiness_label, eta_bucket, adoptable, rank, ui_summary,
+suppression_reason, source_label). Keeping the derivation here, rather
+than duplicating in each surface, means the Rust / Swift / TS contract
+mirrors only need to ship the wire types — each client reads the same
+server-derived values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vaner.intent.prediction import PredictedPrompt
+from vaner.intent.readiness import (
+    EtaBucket,
+    eta_bucket,
+    eta_bucket_label,
+    is_adoptable,
+    readiness_label,
+    suppression_reason,
+)
+
+_SOURCE_LABELS: dict[str, str] = {
+    "arc": "Recent work",
+    "pattern": "Conversation pattern",
+    "llm_branch": "Model signal",
+    "macro": "Workspace signal",
+    "history": "Historical pattern",
+    "goal": "Active goal",
+}
+
+
+@dataclass(frozen=True)
+class CardDerivations:
+    """Flat derivation result — JSON-serializable via :meth:`as_dict`."""
+
+    readiness_label: str
+    eta_bucket: EtaBucket | None
+    eta_bucket_label: str | None
+    adoptable: bool
+    suppression_reason: str | None
+    source_label: str
+    ui_summary: str
+    scenarios_complete: int
+    scenarios_spawned: int
+    tokens_used: int
+    token_budget: int
+    has_briefing: bool
+    has_draft: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "readiness_label": self.readiness_label,
+            "eta_bucket": self.eta_bucket,
+            "eta_bucket_label": self.eta_bucket_label,
+            "adoptable": self.adoptable,
+            "suppression_reason": self.suppression_reason,
+            "source_label": self.source_label,
+            "ui_summary": self.ui_summary,
+            "scenarios_complete": self.scenarios_complete,
+            "scenarios_spawned": self.scenarios_spawned,
+            "tokens_used": self.tokens_used,
+            "token_budget": self.token_budget,
+            "has_briefing": self.has_briefing,
+            "has_draft": self.has_draft,
+        }
+
+
+def derive_card_fields(prompt: PredictedPrompt) -> CardDerivations:
+    """Compute the UI-facing card derivations for *prompt*."""
+    bucket = eta_bucket(prompt)
+    return CardDerivations(
+        readiness_label=readiness_label(prompt.run.readiness),
+        eta_bucket=bucket,
+        eta_bucket_label=eta_bucket_label(bucket),
+        adoptable=is_adoptable(prompt),
+        suppression_reason=suppression_reason(prompt),
+        source_label=_source_label(prompt),
+        ui_summary=_ui_summary(prompt),
+        scenarios_complete=prompt.run.scenarios_complete,
+        scenarios_spawned=prompt.run.scenarios_spawned,
+        tokens_used=prompt.run.tokens_used,
+        token_budget=prompt.run.token_budget,
+        has_briefing=bool(prompt.artifacts.prepared_briefing and prompt.artifacts.prepared_briefing.strip()),
+        has_draft=bool(prompt.artifacts.draft_answer and prompt.artifacts.draft_answer.strip()),
+    )
+
+
+def rank_cards(prompts: list[PredictedPrompt]) -> list[PredictedPrompt]:
+    """Order predictions for the dashboard: adoptable-first, ready > drafting.
+
+    Preserves the incoming order for everything below the adoptable bar so
+    the underlying ranker (which sorts by confidence × evidence × goal
+    alignment) stays visible.
+    """
+    readiness_priority = {
+        "ready": 0,
+        "drafting": 1,
+        "evidence_gathering": 2,
+        "grounding": 3,
+        "queued": 4,
+        "stale": 5,
+    }
+    return sorted(
+        prompts,
+        key=lambda p: (
+            0 if is_adoptable(p) else 1,
+            readiness_priority.get(p.run.readiness, 9),
+            -p.spec.confidence,
+        ),
+    )
+
+
+def _source_label(prompt: PredictedPrompt) -> str:
+    return _SOURCE_LABELS.get(prompt.spec.source, "Recent work")
+
+
+def _ui_summary(prompt: PredictedPrompt) -> str:
+    desc = prompt.spec.description or ""
+    label = prompt.spec.label
+    # Short summary — the UI card title is the label; summary is one sentence
+    # of supplementary context. Trim to ~140 chars to keep cards compact.
+    if not desc or desc.strip() == label.strip():
+        return label
+    summary = desc.strip()
+    if len(summary) > 140:
+        summary = summary[:137].rstrip() + "…"
+    return summary

--- a/src/vaner/intent/readiness.py
+++ b/src/vaner/intent/readiness.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""User-facing readiness labels + coarse ETA buckets + adoptability rules.
+
+These pure functions turn the internal `PredictedPrompt` state machine
+into UI-friendly signals for the MCP Apps dashboard, the text fallback,
+and the desktop clients' card rendering. Keep them free of engine
+imports so the Rust `vaner-contract` mirror can stay aligned.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from vaner.intent.prediction import PredictedPrompt, ReadinessState
+
+EtaBucket = Literal["ready_now", "under_20s", "under_1m", "working", "maturing"]
+"""Coarse ETA bucket. We intentionally avoid exact-second promises — the
+buckets are user-facing labels, not wall-clock predictions."""
+
+
+_READINESS_LABELS: dict[ReadinessState, str] = {
+    "queued": "Queued",
+    "grounding": "Grounding",
+    "evidence_gathering": "Gathering evidence",
+    "drafting": "Drafting",
+    "ready": "Ready",
+    "stale": "Stale",
+}
+
+
+_ETA_BUCKET_LABELS: dict[EtaBucket, str] = {
+    "ready_now": "Ready now",
+    "under_20s": "~10–20s",
+    "under_1m": "~1 min",
+    "working": "Working",
+    "maturing": "Maturing in background",
+}
+
+
+def readiness_label(state: ReadinessState) -> str:
+    """User-facing string for a readiness state. Falls back to title-case."""
+    return _READINESS_LABELS.get(state, state.title())
+
+
+def eta_bucket_label(bucket: EtaBucket | None) -> str | None:
+    if bucket is None:
+        return None
+    return _ETA_BUCKET_LABELS.get(bucket, bucket)
+
+
+def eta_bucket(prompt: PredictedPrompt) -> EtaBucket | None:
+    """Estimate an ETA bucket for *prompt* from its run state.
+
+    We avoid wall-clock predictions because the spawn/completion rhythm
+    is model-dependent and the user doesn't need precision — they need a
+    sense of whether to wait or move on.
+
+    Returns ``None`` for stale predictions (they shouldn't be surfaced as
+    ETA-bearing).
+    """
+    run = prompt.run
+    if run.readiness == "ready":
+        return "ready_now"
+    if run.readiness == "stale":
+        return None
+
+    spawned = max(0, run.scenarios_spawned)
+    complete = max(0, min(run.scenarios_complete, spawned))
+    progress = complete / spawned if spawned else 0.0
+    token_budget = max(1, run.token_budget)
+    tokens_pct = min(1.0, run.tokens_used / token_budget)
+
+    if run.readiness == "drafting":
+        if progress >= 0.8 and tokens_pct >= 0.5:
+            return "under_20s"
+        return "under_1m"
+    if run.readiness == "evidence_gathering":
+        if progress >= 0.5:
+            return "under_1m"
+        return "working"
+    # queued, grounding.
+    return "maturing"
+
+
+def is_adoptable(prompt: PredictedPrompt) -> bool:
+    """A prediction is adoptable when it has something material to hand off.
+
+    The rules: readiness is drafting or ready (so artifacts exist), a
+    non-empty briefing or draft is present, and the prediction hasn't
+    been spent by a previous adoption. Freshness is enforced upstream via
+    invalidation.py; this check only looks at the prompt's intrinsic
+    state.
+    """
+    run = prompt.run
+    if run.spent:
+        return False
+    if run.readiness not in ("drafting", "ready"):
+        return False
+    artifacts = prompt.artifacts
+    has_material = bool(
+        (artifacts.prepared_briefing and artifacts.prepared_briefing.strip()) or (artifacts.draft_answer and artifacts.draft_answer.strip())
+    )
+    return has_material
+
+
+def suppression_reason(prompt: PredictedPrompt) -> str | None:
+    """Why the UI should disable Adopt on this prompt. ``None`` → adoptable."""
+    if prompt.run.spent:
+        return "already_adopted"
+    if prompt.run.readiness == "stale":
+        return "stale"
+    if prompt.run.readiness not in ("drafting", "ready"):
+        return "not_ready_yet"
+    if not is_adoptable(prompt):
+        return "no_prepared_material"
+    return None

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -904,6 +904,46 @@ def build_server(
             if not query:
                 await _record("error")
                 return _json_result({"code": "invalid_input", "message": "query is required"}, is_error=True)
+
+            # 0.8.5 WS4: a fresh adopted-package handoff on disk short-circuits
+            # resolution — the user already picked a prepared prediction on
+            # the desktop (or equivalent UI) and we should return that
+            # resolution verbatim rather than spending model budget on a
+            # fresh resolve. Consume (read+delete) so subsequent turns don't
+            # keep reusing the same package.
+            try:
+                from vaner.integrations.injection.handoff import consume_handoff
+
+                ttl = int(config.integrations.context_injection.ttl_seconds)
+                handoff = consume_handoff(ttl_seconds=ttl)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("handoff probe skipped: %s", exc)
+                handoff = None
+            if handoff is not None and handoff.intent is not None:
+                logger.info(
+                    "vaner.resolve suppressed by adopt handoff: pred=%s age=%.1fs",
+                    handoff.adopted_from_prediction_id,
+                    handoff.age_seconds,
+                )
+                await metrics_store.increment_counter("resolves_total")
+                await metrics_store.increment_counter("tool_call_redundancy_suppressed")
+                append_log(
+                    repo_root,
+                    tool=name,
+                    label=(handoff.intent or "")[:60],
+                    decision_id=None,
+                    provenance_mode="handoff_hit",
+                    memory_state=None,
+                )
+                await _record("ok", tool_name="vaner.resolve.handoff")
+                payload = dict(handoff.raw)
+                payload.setdefault("provenance", {})
+                if isinstance(payload["provenance"], dict):
+                    payload["provenance"].setdefault("mode", "handoff_hit")
+                    payload["provenance"].setdefault("cache", "warm")
+                    payload["provenance"].setdefault("freshness", "fresh")
+                payload["suppressed_reason"] = "fresh_adopted_package_handoff"
+                return _json_result(payload)
             suggestion_id = str(args.get("suggestion_id", "")).strip()
             context_arg = args.get("context") or {}
             if suggestion_id and suggestion_id in suggestion_cache:

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -295,8 +295,29 @@ def build_server(
         while len(suggestion_cache) > _SUGGESTION_CACHE_CAPACITY:
             suggestion_cache.popitem(last=False)
 
+    def _detect_and_record_tier() -> None:
+        """Lazy capability detection on first tool/resource call per session.
+
+        The low-level MCP Server does not expose an ``on_initialize`` hook,
+        so we piggyback on the first handler call. Safe to call repeatedly —
+        :func:`record_tier` replaces any prior cache entry for the session.
+        """
+        try:
+            from vaner.integrations.capability import detect_tier, record_tier
+
+            ctx = getattr(server, "request_context", None)
+            session = getattr(ctx, "session", None) if ctx is not None else None
+            client_params = getattr(session, "client_params", None) if session is not None else None
+            if session is None or client_params is None:
+                return
+            detection = detect_tier(client_params)
+            record_tier(session, detection)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("capability detection skipped: %s", exc)
+
     @server.list_tools()
     async def list_tools() -> ListToolsResult:
+        _detect_and_record_tier()
         return ListToolsResult(
             tools=[
                 Tool(

--- a/tests/test_integrations/test_capability.py
+++ b/tests/test_integrations/test_capability.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from vaner.integrations.capability import (
+    ClientCapabilityTier,
+    current_tier,
+    detect_tier,
+    record_tier,
+    reset_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_between_tests() -> None:
+    reset_cache()
+    yield
+    reset_cache()
+
+
+def _params(
+    *,
+    experimental: dict | None = None,
+    roots: object | None = None,
+    sampling: object | None = None,
+    client_name: str | None = "test-client",
+    client_version: str | None = "0.0.0",
+):
+    caps = SimpleNamespace(
+        experimental=experimental,
+        roots=roots,
+        sampling=sampling,
+    )
+    info = SimpleNamespace(name=client_name, version=client_version)
+    return SimpleNamespace(clientInfo=info, capabilities=caps)
+
+
+def test_unknown_when_params_missing() -> None:
+    assert detect_tier(None).tier is ClientCapabilityTier.UNKNOWN
+
+
+def test_tier_1_when_capabilities_absent() -> None:
+    params = SimpleNamespace(
+        clientInfo=SimpleNamespace(name="x", version="1"),
+        capabilities=None,
+    )
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_1
+
+
+def test_tier_1_when_no_markers() -> None:
+    params = _params(experimental={})
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_1
+
+
+def test_tier_2_when_roots_present() -> None:
+    params = _params(roots=SimpleNamespace(listChanged=True))
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_2
+
+
+def test_tier_2_when_sampling_present() -> None:
+    params = _params(sampling=SimpleNamespace())
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_2
+
+
+def test_tier_3_when_injection_extension_present() -> None:
+    params = _params(experimental={"vaner.context_injection": {"version": 1}})
+    detection = detect_tier(params)
+    assert detection.tier is ClientCapabilityTier.TIER_3
+    assert detection.reason == "vaner_injection_extension_advertised"
+
+
+def test_tier_4_when_ui_extension_present() -> None:
+    params = _params(experimental={"io.modelcontextprotocol/ui": {}})
+    detection = detect_tier(params)
+    assert detection.tier is ClientCapabilityTier.TIER_4
+
+
+def test_tier_4_wins_over_tier_2_markers() -> None:
+    params = _params(
+        experimental={"io.modelcontextprotocol/ui": {}},
+        roots=SimpleNamespace(),
+        sampling=SimpleNamespace(),
+    )
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_4
+
+
+def test_detection_carries_client_name() -> None:
+    params = _params(
+        experimental={"io.modelcontextprotocol/ui": {}},
+        client_name="Claude Desktop",
+        client_version="0.9.0",
+    )
+    d = detect_tier(params)
+    assert d.client_name == "Claude Desktop"
+    assert d.client_version == "0.9.0"
+
+
+def test_session_cache_round_trip() -> None:
+    class _Session:
+        pass
+
+    s = _Session()
+    assert current_tier(s) is ClientCapabilityTier.UNKNOWN
+    record_tier(s, detect_tier(_params(experimental={"io.modelcontextprotocol/ui": {}})))
+    assert current_tier(s) is ClientCapabilityTier.TIER_4
+
+
+def test_session_cache_is_per_instance() -> None:
+    class _Session:
+        pass
+
+    s1 = _Session()
+    s2 = _Session()
+    record_tier(s1, detect_tier(_params(roots=SimpleNamespace())))
+    assert current_tier(s1) is ClientCapabilityTier.TIER_2
+    assert current_tier(s2) is ClientCapabilityTier.UNKNOWN

--- a/tests/test_integrations/test_handoff.py
+++ b/tests/test_integrations/test_handoff.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from vaner.integrations.injection.handoff import (
+    DEFAULT_TTL_SECONDS,
+    consume_handoff,
+    handoff_path,
+    read_handoff,
+)
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _fresh_payload(stashed_at: float = 1_777_000_000.0) -> dict:
+    return {
+        "intent": "Draft the project update",
+        "resolution_id": "adopt-pred-xyz",
+        "adopted_from_prediction_id": "pred-xyz",
+        "prepared_briefing": "The team finished evidence gathering yesterday.",
+        "predicted_response": "Here's a draft you asked for.",
+        "provenance": {"mode": "predictive_hit"},
+        "stashed_at": stashed_at,
+    }
+
+
+def test_read_returns_none_when_file_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "pending-adopt.json"
+    assert read_handoff(path=missing) is None
+
+
+def test_read_happy_path(tmp_path: Path) -> None:
+    target = tmp_path / "pending-adopt.json"
+    _write(target, _fresh_payload(stashed_at=1_777_000_000.0))
+
+    res = read_handoff(path=target, now=1_777_000_030.0)
+    assert res is not None
+    assert res.intent == "Draft the project update"
+    assert res.adopted_from_prediction_id == "pred-xyz"
+    assert res.age_seconds == pytest.approx(30.0)
+    assert res.path == target
+
+
+def test_stale_drop_ignored(tmp_path: Path) -> None:
+    target = tmp_path / "pending-adopt.json"
+    _write(target, _fresh_payload(stashed_at=1_777_000_000.0))
+
+    # 10 min + 1s older than the drop → over default TTL.
+    res = read_handoff(
+        path=target,
+        now=1_777_000_000.0 + DEFAULT_TTL_SECONDS + 1.0,
+    )
+    assert res is None
+
+
+def test_custom_ttl_extends_freshness(tmp_path: Path) -> None:
+    target = tmp_path / "pending-adopt.json"
+    _write(target, _fresh_payload(stashed_at=1_777_000_000.0))
+
+    res = read_handoff(
+        path=target,
+        now=1_777_000_000.0 + 1_000.0,
+        ttl_seconds=2_000,
+    )
+    assert res is not None
+
+
+def test_missing_stashed_at_ignored(tmp_path: Path) -> None:
+    target = tmp_path / "pending-adopt.json"
+    payload = _fresh_payload()
+    del payload["stashed_at"]
+    _write(target, payload)
+
+    assert read_handoff(path=target) is None
+
+
+def test_malformed_json_ignored(tmp_path: Path) -> None:
+    target = tmp_path / "pending-adopt.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("{not json", encoding="utf-8")
+
+    assert read_handoff(path=target) is None
+
+
+def test_non_object_payload_ignored(tmp_path: Path) -> None:
+    target = tmp_path / "pending-adopt.json"
+    _write(target.parent / "x.json", {"foo": "bar"})
+    target.write_text("[1, 2, 3]", encoding="utf-8")
+
+    assert read_handoff(path=target) is None
+
+
+def test_consume_deletes_file(tmp_path: Path) -> None:
+    target = tmp_path / "pending-adopt.json"
+    _write(target, _fresh_payload(stashed_at=1_777_000_000.0))
+
+    res = consume_handoff(path=target, now=1_777_000_030.0)
+    assert res is not None
+    assert not target.exists(), "consume should remove the handoff file after read"
+
+
+def test_consume_leaves_stale_file_alone(tmp_path: Path) -> None:
+    target = tmp_path / "pending-adopt.json"
+    _write(target, _fresh_payload(stashed_at=1_777_000_000.0))
+
+    res = consume_handoff(
+        path=target,
+        now=1_777_000_000.0 + DEFAULT_TTL_SECONDS + 1.0,
+    )
+    assert res is None
+    # Stale file is not our business to sweep — the desktop may rotate it.
+    assert target.exists()
+
+
+def test_handoff_path_platform_is_absolute() -> None:
+    # We can't portably check the full path, but it must be absolute and
+    # end with `pending-adopt.json` on every supported platform.
+    p = handoff_path()
+    assert p.is_absolute()
+    assert p.name == "pending-adopt.json"
+
+
+def test_linux_respects_xdg_state_home(monkeypatch) -> None:
+    if not os.sys.platform.startswith("linux"):
+        pytest.skip("XDG_STATE_HOME applies on Linux only")
+    monkeypatch.setenv("XDG_STATE_HOME", "/tmp/xdg-state")
+    p = handoff_path()
+    assert str(p).startswith("/tmp/xdg-state/vaner/")

--- a/tests/test_integrations/test_integrations_doctor.py
+++ b/tests/test_integrations/test_integrations_doctor.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.integrations import integrations_app
+
+runner = CliRunner()
+
+
+def test_doctor_json_reports_guidance_version(tmp_path: Path) -> None:
+    result = runner.invoke(
+        integrations_app,
+        [
+            "doctor",
+            "--repo-root",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--daemon-url",
+            "http://127.0.0.1:1",  # unreachable on purpose
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["guidance"]["version"] == 1
+    assert data["integrations_config"]["context_injection"]["mode"] == "policy_hybrid"
+    assert data["daemon"]["reachable"] is False
+    assert data["handoff"]["present"] is False
+
+
+def test_doctor_pretty_output_renders(tmp_path: Path) -> None:
+    result = runner.invoke(
+        integrations_app,
+        [
+            "doctor",
+            "--repo-root",
+            str(tmp_path),
+            "--daemon-url",
+            "http://127.0.0.1:1",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Vaner integrations doctor" in result.output
+    assert "Integrations config" in result.output
+
+
+def test_doctor_detects_pending_handoff(tmp_path: Path) -> None:
+    vaner_dir = tmp_path / ".vaner"
+    vaner_dir.mkdir()
+    payload = {
+        "adopted_from_prediction_id": "pred-xyz",
+        "resolution_id": "adopt-pred-xyz",
+        "adopted_at": "2026-04-25T12:00:00Z",
+    }
+    (vaner_dir / "pending-adopt.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    result = runner.invoke(
+        integrations_app,
+        [
+            "doctor",
+            "--repo-root",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--daemon-url",
+            "http://127.0.0.1:1",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data["handoff"]["present"] is True
+    assert data["handoff"]["adopted_from_prediction_id"] == "pred-xyz"
+
+
+def test_tier_command_prints_guidance_version() -> None:
+    result = runner.invoke(integrations_app, ["tier"])
+    assert result.exit_code == 0
+    assert "guidance_version=1" in result.output

--- a/tests/test_intent/test_prediction_card.py
+++ b/tests/test_intent/test_prediction_card.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from vaner.intent.prediction import (
+    PredictedPrompt,
+    PredictionArtifacts,
+    PredictionRun,
+    PredictionSpec,
+    ReadinessState,
+    prediction_id,
+)
+from vaner.intent.prediction_card import derive_card_fields, rank_cards
+
+
+def _prompt(
+    *,
+    label: str = "Draft the project update",
+    readiness: ReadinessState = "ready",
+    source: str = "arc",
+    briefing: str | None = "prepared summary",
+    draft: str | None = None,
+    confidence: float = 0.7,
+    spent: bool = False,
+    description: str | None = None,
+) -> PredictedPrompt:
+    spec = PredictionSpec(
+        id=prediction_id(source, "anchor", label),
+        label=label,
+        description=description or label,
+        source=source,  # type: ignore[arg-type]
+        anchor="anchor",
+        confidence=confidence,
+        hypothesis_type="likely_next",
+        specificity="concrete",
+        created_at=0.0,
+    )
+    run = PredictionRun(
+        weight=0.5,
+        token_budget=2048,
+        tokens_used=500,
+        scenarios_spawned=4,
+        scenarios_complete=2,
+        readiness=readiness,
+        updated_at=0.0,
+        spent=spent,
+    )
+    artifacts = PredictionArtifacts(
+        prepared_briefing=briefing,
+        draft_answer=draft,
+    )
+    return PredictedPrompt(spec=spec, run=run, artifacts=artifacts)
+
+
+def test_derive_includes_readiness_eta_and_adoptability() -> None:
+    card = derive_card_fields(_prompt(readiness="ready"))
+    assert card.readiness_label == "Ready"
+    assert card.eta_bucket == "ready_now"
+    assert card.eta_bucket_label == "Ready now"
+    assert card.adoptable is True
+    assert card.suppression_reason is None
+    assert card.has_briefing is True
+
+
+def test_derive_unknown_source_falls_back() -> None:
+    # PredictionSpec.source uses a Literal type, but the derivation must be
+    # tolerant of values not in _SOURCE_LABELS to avoid KeyErrors at runtime.
+    spec = PredictionSpec(
+        id=prediction_id("arc", "anchor", "label"),
+        label="x",
+        description="x",
+        source="arc",  # Safe canonical value for the constructor.
+        anchor="anchor",
+        confidence=0.5,
+        hypothesis_type="likely_next",
+        specificity="concrete",
+        created_at=0.0,
+    )
+    run = PredictionRun(weight=0.5, token_budget=1, readiness="ready", updated_at=0.0)
+    artifacts = PredictionArtifacts(prepared_briefing="stuff")
+    prompt = PredictedPrompt(spec=spec, run=run, artifacts=artifacts)
+    card = derive_card_fields(prompt)
+    assert card.source_label == "Recent work"
+
+
+def test_ui_summary_trims_long_descriptions() -> None:
+    long_desc = "lorem " * 40
+    card = derive_card_fields(_prompt(readiness="ready", description=long_desc))
+    assert len(card.ui_summary) <= 140
+
+
+def test_as_dict_is_json_ready() -> None:
+    import json
+
+    card = derive_card_fields(_prompt(readiness="drafting", draft="something"))
+    payload = card.as_dict()
+    # Must be JSON-serializable without custom encoder.
+    json.dumps(payload)
+    assert payload["adoptable"] is True
+    assert payload["eta_bucket"] in ("under_20s", "under_1m")
+
+
+def test_rank_adoptable_first() -> None:
+    not_ready = _prompt(label="queued one", readiness="queued")
+    adoptable = _prompt(label="ready one", readiness="ready", briefing="x")
+    ordered = rank_cards([not_ready, adoptable])
+    assert ordered[0] is adoptable
+    assert ordered[1] is not_ready
+
+
+def test_rank_ready_before_drafting() -> None:
+    drafting = _prompt(label="drafting one", readiness="drafting", draft="d")
+    ready = _prompt(label="ready one", readiness="ready", briefing="r")
+    ordered = rank_cards([drafting, ready])
+    assert ordered[0] is ready
+
+
+def test_rank_higher_confidence_wins_within_tier() -> None:
+    low = _prompt(label="low", readiness="ready", briefing="x", confidence=0.4)
+    high = _prompt(label="high", readiness="ready", briefing="x", confidence=0.9)
+    ordered = rank_cards([low, high])
+    assert ordered[0] is high

--- a/tests/test_intent/test_readiness.py
+++ b/tests/test_intent/test_readiness.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from vaner.intent.prediction import (
+    PredictedPrompt,
+    PredictionArtifacts,
+    PredictionRun,
+    PredictionSpec,
+    ReadinessState,
+    prediction_id,
+)
+from vaner.intent.readiness import (
+    eta_bucket,
+    eta_bucket_label,
+    is_adoptable,
+    readiness_label,
+    suppression_reason,
+)
+
+
+def _prompt(
+    *,
+    readiness: ReadinessState = "queued",
+    scenarios_complete: int = 0,
+    scenarios_spawned: int = 0,
+    tokens_used: int = 0,
+    token_budget: int = 2048,
+    briefing: str | None = None,
+    draft: str | None = None,
+    spent: bool = False,
+) -> PredictedPrompt:
+    spec = PredictionSpec(
+        id=prediction_id("arc", "anchor", "label"),
+        label="Draft the project update",
+        description="Suspected next move",
+        source="arc",
+        anchor="anchor",
+        confidence=0.72,
+        hypothesis_type="likely_next",
+        specificity="concrete",
+        created_at=0.0,
+    )
+    run = PredictionRun(
+        weight=0.5,
+        token_budget=token_budget,
+        tokens_used=tokens_used,
+        scenarios_spawned=scenarios_spawned,
+        scenarios_complete=scenarios_complete,
+        readiness=readiness,
+        updated_at=0.0,
+        spent=spent,
+    )
+    artifacts = PredictionArtifacts(
+        prepared_briefing=briefing,
+        draft_answer=draft,
+    )
+    return PredictedPrompt(spec=spec, run=run, artifacts=artifacts)
+
+
+# ---------- readiness_label -------------------------------------------------
+
+
+def test_readiness_labels_are_title_case_strings() -> None:
+    assert readiness_label("queued") == "Queued"
+    assert readiness_label("grounding") == "Grounding"
+    assert readiness_label("evidence_gathering") == "Gathering evidence"
+    assert readiness_label("drafting") == "Drafting"
+    assert readiness_label("ready") == "Ready"
+    assert readiness_label("stale") == "Stale"
+
+
+# ---------- eta_bucket ------------------------------------------------------
+
+
+def test_ready_state_returns_ready_now() -> None:
+    assert eta_bucket(_prompt(readiness="ready")) == "ready_now"
+
+
+def test_stale_returns_none() -> None:
+    assert eta_bucket(_prompt(readiness="stale")) is None
+
+
+def test_drafting_with_high_progress_returns_under_20s() -> None:
+    p = _prompt(
+        readiness="drafting",
+        scenarios_spawned=5,
+        scenarios_complete=4,
+        tokens_used=1200,
+        token_budget=2048,
+    )
+    assert eta_bucket(p) == "under_20s"
+
+
+def test_drafting_with_low_progress_returns_under_1m() -> None:
+    p = _prompt(
+        readiness="drafting",
+        scenarios_spawned=5,
+        scenarios_complete=1,
+        tokens_used=50,
+    )
+    assert eta_bucket(p) == "under_1m"
+
+
+def test_evidence_gathering_progress_50pct_returns_under_1m() -> None:
+    p = _prompt(
+        readiness="evidence_gathering",
+        scenarios_spawned=4,
+        scenarios_complete=2,
+    )
+    assert eta_bucket(p) == "under_1m"
+
+
+def test_evidence_gathering_early_returns_working() -> None:
+    p = _prompt(
+        readiness="evidence_gathering",
+        scenarios_spawned=4,
+        scenarios_complete=0,
+    )
+    assert eta_bucket(p) == "working"
+
+
+def test_queued_and_grounding_return_maturing() -> None:
+    assert eta_bucket(_prompt(readiness="queued")) == "maturing"
+    assert eta_bucket(_prompt(readiness="grounding")) == "maturing"
+
+
+def test_eta_bucket_label_maps_through() -> None:
+    assert eta_bucket_label("ready_now") == "Ready now"
+    assert eta_bucket_label("under_20s") == "~10–20s"
+    assert eta_bucket_label(None) is None
+
+
+def test_eta_ignores_out_of_bounds_counts() -> None:
+    # scenarios_complete > scenarios_spawned shouldn't crash or produce garbage
+    p = _prompt(
+        readiness="evidence_gathering",
+        scenarios_spawned=2,
+        scenarios_complete=99,
+    )
+    bucket = eta_bucket(p)
+    assert bucket in ("under_1m", "working", "maturing")
+
+
+# ---------- is_adoptable ----------------------------------------------------
+
+
+def test_adoptable_when_ready_with_briefing() -> None:
+    assert is_adoptable(_prompt(readiness="ready", briefing="prepared summary goes here"))
+
+
+def test_adoptable_when_drafting_with_draft() -> None:
+    assert is_adoptable(_prompt(readiness="drafting", draft="draft content"))
+
+
+def test_not_adoptable_when_no_material() -> None:
+    assert not is_adoptable(_prompt(readiness="ready"))
+
+
+def test_not_adoptable_when_spent() -> None:
+    assert not is_adoptable(_prompt(readiness="ready", briefing="material", spent=True))
+
+
+def test_not_adoptable_when_queued() -> None:
+    assert not is_adoptable(_prompt(readiness="queued", briefing="irrelevant"))
+
+
+def test_not_adoptable_when_blank_briefing_only() -> None:
+    assert not is_adoptable(_prompt(readiness="ready", briefing="   "))
+
+
+# ---------- suppression_reason ---------------------------------------------
+
+
+def test_suppression_none_when_adoptable() -> None:
+    p = _prompt(readiness="ready", briefing="material")
+    assert suppression_reason(p) is None
+
+
+def test_suppression_stale() -> None:
+    assert suppression_reason(_prompt(readiness="stale")) == "stale"
+
+
+def test_suppression_already_adopted() -> None:
+    p = _prompt(readiness="ready", briefing="material", spent=True)
+    assert suppression_reason(p) == "already_adopted"
+
+
+def test_suppression_not_ready_yet() -> None:
+    assert suppression_reason(_prompt(readiness="queued")) == "not_ready_yet"
+
+
+def test_suppression_no_prepared_material() -> None:
+    assert suppression_reason(_prompt(readiness="ready")) == "no_prepared_material"


### PR DESCRIPTION
Stacks on #160 (WS4). Server-side derivation of UI card fields (readiness_label, eta_bucket, adoptable, suppression_reason, source_label, ui_summary) that WS5 (dashboard tool) and WS9 (Rust/Swift/TS mirrors) both consume. 28 tests. 🤖 Generated with Claude Code