### PR TITLE
feat(mcp): 0.8.5 WS8 — metrics, cross-client matrix, static a11y

### DIFF
--- a/src/vaner/mcp/apps/active_predictions.html
+++ b/src/vaner/mcp/apps/active_predictions.html
@@ -281,6 +281,7 @@
         try {
           const result = await app.callTool("vaner.predictions.adopt", {
             prediction_id: card.id,
+            source: "mcp_app",
           });
           if (result && result.isError) {
             throw new Error(result.error?.message || "Adopt failed");

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -215,6 +215,42 @@ def _serialize_prediction_for_mcp(prompt: Any, *, rank: int | None = None) -> di
     return payload
 
 
+_RESOURCE_METRIC_TASKS: set[Any] = set()
+"""Keep strong refs to background metric tasks until they settle.
+
+Without this, `asyncio.run()` can tear the loop down before the task
+completes, producing `Event loop is closed` warnings. Tracked via
+`add_done_callback(discard)` so entries clear themselves when the task
+finishes.
+"""
+
+
+def _increment_resource_metric(name: str, repo_root: Path) -> None:
+    """Fire-and-forget metric increment for resource-read events.
+
+    0.8.5 WS8: `read_resource` is a sync entry point in the SDK API, so we
+    can't `await` on `MetricsStore`. Spawn an asyncio task when a loop is
+    running; otherwise silently drop — metrics are best-effort.
+    """
+    import asyncio as _asyncio
+
+    async def _do() -> None:
+        try:
+            store = MetricsStore(repo_root / ".vaner" / "metrics.db")
+            await store.initialize()
+            await store.increment_counter(name)
+        except Exception:  # pragma: no cover - defensive metrics
+            pass
+
+    try:
+        loop = _asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    task = loop.create_task(_do())
+    _RESOURCE_METRIC_TASKS.add(task)
+    task.add_done_callback(_RESOURCE_METRIC_TASKS.discard)
+
+
 def _dashboard_fallback_text(cards: list[dict[str, Any]]) -> str:
     """Render a plain-text Vaner dashboard for non-UI MCP clients.
 
@@ -509,7 +545,15 @@ def build_server(
                     ),
                     inputSchema={
                         "type": "object",
-                        "properties": {"prediction_id": {"type": "string"}},
+                        "properties": {
+                            "prediction_id": {"type": "string"},
+                            "source": {
+                                "type": "string",
+                                "description": "Where the adopt request came from (for metrics): mcp_app, mcp_tool, cli, desktop, unknown.",
+                                "enum": ["mcp_app", "mcp_tool", "cli", "desktop", "unknown"],
+                                "default": "mcp_tool",
+                            },
+                        },
                         "required": ["prediction_id"],
                     },
                 ),
@@ -862,6 +906,7 @@ def build_server(
 
         # MCP Apps UI bundle.
         if uri_str == ACTIVE_PREDICTIONS_URI:
+            _increment_resource_metric("mcp_apps_bundle_read", repo_root)
             return [
                 ReadResourceContents(
                     content=ACTIVE_PREDICTIONS_HTML,
@@ -890,6 +935,7 @@ def build_server(
         if variant is None:
             raise ValueError(f"unknown vaner resource: {uri_str!r}")
         body = load_guidance(variant).as_text()  # type: ignore[arg-type]
+        _increment_resource_metric(f"guidance_resource_read_{variant}", repo_root)
         return [ReadResourceContents(content=body, mime_type="text/markdown")]
 
     @server.call_tool()
@@ -1653,12 +1699,21 @@ def build_server(
 
         if name == "vaner.predictions.adopt":
             prediction_id_arg = str(args.get("prediction_id", "")).strip()
+            adopt_source = str(args.get("source", "")).strip() or "unknown"
             if not prediction_id_arg:
                 await _record("error")
                 return _json_result(
                     {"code": "invalid_input", "message": "prediction_id is required"},
                     is_error=True,
                 )
+            # 0.8.5 WS8: track adopts coming from the MCP Apps UI separately
+            # from tool-initiated adopts so we can measure UI value.
+            try:
+                if adopt_source == "mcp_app":
+                    await metrics_store.increment_counter("mcp_apps_adopt_clicked")
+                await metrics_store.increment_counter(f"mcp_adopt_source_{adopt_source}")
+            except Exception:  # pragma: no cover - defensive metrics
+                pass
             # In-process engine path first.
             if engine is not None and engine.prediction_registry is not None:
                 prompt = engine.prediction_registry.get(prediction_id_arg)

--- a/tests/test_mcp_apps/test_accessibility_static.py
+++ b/tests/test_mcp_apps/test_accessibility_static.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static accessibility smoke for the UI bundle.
+
+A full axe-core / pa11y pass needs a headless browser. That's deferred
+to 0.8.6 polish. What we *can* pin today: the HTML must include the
+structural markers we rely on (aria-live region, aria-label on the list,
+button labels, semantic list + headings) so the bundle never regresses
+to a keyboard-unreachable / screen-reader-hostile state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+if importlib.util.find_spec("mcp") is None:  # pragma: no cover - CI matrix dependent
+    pytest.skip("mcp package is unavailable in this test environment", allow_module_level=True)
+
+from vaner.mcp.apps import ACTIVE_PREDICTIONS_HTML
+
+
+def test_has_live_region_for_status() -> None:
+    # Status updates (adopt success, refresh errors) need a live region
+    # so screen readers announce them without user action.
+    assert 'aria-live="polite"' in ACTIVE_PREDICTIONS_HTML
+    assert 'role="status"' in ACTIVE_PREDICTIONS_HTML
+
+
+def test_has_labelled_list() -> None:
+    # The card list uses aria-labelledby pointing at the heading so the
+    # list has accessible context.
+    assert 'aria-labelledby="heading"' in ACTIVE_PREDICTIONS_HTML
+    assert 'id="heading"' in ACTIVE_PREDICTIONS_HTML
+
+
+def test_adopt_buttons_are_labelled() -> None:
+    # Every dynamically-rendered adopt button is given an aria-label that
+    # names the prediction so a screen-reader user understands which one
+    # they'd adopt.
+    assert 'aria-label="Adopt prediction:' in ACTIVE_PREDICTIONS_HTML
+
+
+def test_uses_semantic_heading_and_list() -> None:
+    # Real H1/OL, not div soup — matters for rotor navigation.
+    assert "<h1" in ACTIVE_PREDICTIONS_HTML
+    assert "<ol" in ACTIVE_PREDICTIONS_HTML
+    # Cards are rendered as <li> elements inside the ol (dynamic render
+    # uses document.createElement("li") + className = "card"); the marker
+    # to match the class lives in the JS render path.
+    assert 'className = "card"' in ACTIVE_PREDICTIONS_HTML
+
+
+def test_focus_styles_defined() -> None:
+    # Keyboard users need a visible focus ring. We define :focus-within
+    # on the card and :focus on the Adopt button.
+    assert ":focus-within" in ACTIVE_PREDICTIONS_HTML
+    assert "button.adopt:focus" in ACTIVE_PREDICTIONS_HTML
+
+
+def test_dark_mode_styles_defined() -> None:
+    # High-contrast + dark-mode adaptation for low-vision users.
+    assert "prefers-color-scheme: dark" in ACTIVE_PREDICTIONS_HTML
+    assert "color-scheme: light dark" in ACTIVE_PREDICTIONS_HTML
+
+
+def test_disabled_state_is_signaled_textually_not_just_color() -> None:
+    # When Adopt is not available, the button text changes (not just the
+    # color fades). Ensures color-only signaling is avoided.
+    assert "disabled ? readinessLabel : adoptLabel" in ACTIVE_PREDICTIONS_HTML
+
+
+def test_no_inline_tabindex_traps() -> None:
+    # tabindex="-1" or tabindex=999 can create keyboard traps. We allow
+    # no inline tabindex on the card grid — default tab order suffices.
+    assert 'tabindex="-1"' not in ACTIVE_PREDICTIONS_HTML
+    assert "tabindex=999" not in ACTIVE_PREDICTIONS_HTML

--- a/tests/test_mcp_apps/test_cross_client.py
+++ b/tests/test_mcp_apps/test_cross_client.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-client tier simulation.
+
+The real clients (Claude Desktop, Claude Code, Cursor, ChatGPT, VS Code
+Copilot, plain stdio) each advertise a different capability shape during
+MCP initialize. We can't spin them up in unit tests, but we *can*
+simulate each one by writing the expected `client_params` shape and
+asking :func:`detect_tier` what it sees. If the tier mapping drifts, a
+real-client regression becomes obvious here without waiting for a
+downstream user to file a bug.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vaner.integrations.capability import ClientCapabilityTier, detect_tier
+
+
+def _caps(**kw) -> SimpleNamespace:
+    return SimpleNamespace(
+        experimental=kw.get("experimental"),
+        roots=kw.get("roots"),
+        sampling=kw.get("sampling"),
+    )
+
+
+def _params(name: str, version: str, caps: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        clientInfo=SimpleNamespace(name=name, version=version),
+        capabilities=caps,
+    )
+
+
+# (client_name, expected_tier, caps_kwargs)
+_CASES = [
+    # Tier 4 — MCP Apps host.
+    (
+        "claude_desktop_ui",
+        ClientCapabilityTier.TIER_4,
+        {"experimental": {"io.modelcontextprotocol/ui": {}}, "roots": SimpleNamespace()},
+    ),
+    (
+        "chatgpt_ui",
+        ClientCapabilityTier.TIER_4,
+        {
+            "experimental": {"io.modelcontextprotocol/ui": {"version": 1}},
+            "sampling": SimpleNamespace(),
+        },
+    ),
+    # Tier 3 — context-mediation host (future hosts that opt in).
+    (
+        "custom_proxy_with_injection",
+        ClientCapabilityTier.TIER_3,
+        {"experimental": {"vaner.context_injection": {}}, "roots": SimpleNamespace()},
+    ),
+    # Tier 2 — prompt-guidance capable (most real MCP clients).
+    (
+        "claude_code",
+        ClientCapabilityTier.TIER_2,
+        {"roots": SimpleNamespace(listChanged=True)},
+    ),
+    (
+        "cursor",
+        ClientCapabilityTier.TIER_2,
+        {"sampling": SimpleNamespace()},
+    ),
+    (
+        "vscode_copilot",
+        ClientCapabilityTier.TIER_2,
+        {"roots": SimpleNamespace()},
+    ),
+    # Tier 1 — bare stdio.
+    (
+        "plain_stdio_client",
+        ClientCapabilityTier.TIER_1,
+        {"experimental": {}},
+    ),
+    (
+        "minimal_mcp_client",
+        ClientCapabilityTier.TIER_1,
+        {},  # no roots/sampling/experimental
+    ),
+]
+
+
+@pytest.mark.parametrize(("name", "expected_tier", "caps_kwargs"), _CASES)
+def test_client_tier_matches_expectation(name: str, expected_tier: ClientCapabilityTier, caps_kwargs: dict) -> None:
+    params = _params(name, "1.0.0", _caps(**caps_kwargs))
+    detection = detect_tier(params)
+    assert detection.tier is expected_tier, (
+        f"client {name!r} expected {expected_tier.name}, got {detection.tier.name} (reason={detection.reason!r})"
+    )
+
+
+def test_tier_4_ui_extension_supersedes_lower_markers() -> None:
+    # A Tier-4 client will also advertise roots/sampling; the UI flag
+    # must win the classification regardless.
+    params = _params(
+        "claude_desktop",
+        "0.9",
+        _caps(
+            experimental={"io.modelcontextprotocol/ui": {}},
+            roots=SimpleNamespace(),
+            sampling=SimpleNamespace(),
+        ),
+    )
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_4
+
+
+def test_unknown_future_experimental_does_not_demote_tier_2() -> None:
+    # Future clients may advertise experimental keys we don't know about.
+    # We must still classify them at Tier-2 if they advertise roots.
+    params = _params(
+        "future_client",
+        "2.0",
+        _caps(
+            experimental={"com.example.new": {}},
+            roots=SimpleNamespace(),
+        ),
+    )
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_2
+
+
+def test_detection_preserves_client_name_for_logging() -> None:
+    # The detection object carries the name + version so the per-session
+    # log line can attribute the tier to the right client. If this drifts,
+    # logs become uninformative.
+    params = _params("claude_code", "1.2.3", _caps(roots=SimpleNamespace()))
+    d = detect_tier(params)
+    assert d.client_name == "claude_code"
+    assert d.client_version == "1.2.3"

--- a/tests/test_mcp_apps/test_metrics.py
+++ b/tests/test_mcp_apps/test_metrics.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""WS8 metric plumbing tests.
+
+The counters are incremented via MCP handlers; rather than drive the
+full server we unit-test the helpers + verify the metric store gets
+written when the handler path is exercised through the stub-engine
+dashboard test already pinned in test_dashboard_tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+if importlib.util.find_spec("mcp") is None:  # pragma: no cover - CI matrix dependent
+    pytest.skip("mcp package is unavailable in this test environment", allow_module_level=True)
+
+from vaner.intent.prediction import (
+    PredictedPrompt,
+    PredictionArtifacts,
+    PredictionRun,
+    PredictionSpec,
+    prediction_id,
+)
+from vaner.telemetry.metrics import MetricsStore
+
+
+def _prompt(label: str, readiness: str = "ready") -> PredictedPrompt:
+    return PredictedPrompt(
+        spec=PredictionSpec(
+            id=prediction_id("arc", "anchor", label),
+            label=label,
+            description=label,
+            source="arc",
+            anchor="anchor",
+            confidence=0.7,
+            hypothesis_type="likely_next",
+            specificity="concrete",
+            created_at=0.0,
+        ),
+        run=PredictionRun(
+            weight=0.5,
+            token_budget=1024,
+            tokens_used=100,
+            scenarios_spawned=2,
+            scenarios_complete=1,
+            readiness=readiness,  # type: ignore[arg-type]
+            updated_at=0.0,
+        ),
+        artifacts=PredictionArtifacts(prepared_briefing="briefing"),
+    )
+
+
+class _StubEngine:
+    def __init__(self, prompts: list[PredictedPrompt]) -> None:
+        self._prompts = prompts
+        self.prediction_registry = None
+
+    def get_active_predictions(self) -> list[PredictedPrompt]:
+        return list(self._prompts)
+
+
+def _build(tmp_path: Path, prompts: list[PredictedPrompt]):
+    (tmp_path / ".vaner").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".vaner" / "config.toml").write_text(
+        '[backend]\nbase_url = "http://127.0.0.1:11434/v1"\nmodel = "llama3.2:3b"\n',
+        encoding="utf-8",
+    )
+    from vaner.mcp.server import build_server
+
+    return build_server(tmp_path, engine=_StubEngine(prompts))
+
+
+def _call(server, name: str, arguments: dict | None = None) -> dict:
+    async def _do() -> dict:
+        from mcp.types import CallToolRequest, CallToolRequestParams
+
+        handler = server.request_handlers[CallToolRequest]
+        result = await handler(
+            CallToolRequest(
+                method="tools/call",
+                params=CallToolRequestParams(name=name, arguments=arguments or {}),
+            )
+        )
+        return json.loads(result.root.content[0].text)
+
+    return asyncio.run(_do())
+
+
+def _counter(repo_root: Path, name: str) -> float:
+    async def _get() -> float:
+        store = MetricsStore(repo_root / ".vaner" / "metrics.db")
+        await store.initialize()
+        counters = await store._counters_map()
+        return float(counters.get(name, 0.0))
+
+    return asyncio.run(_get())
+
+
+def test_dashboard_tool_increments_called_counter(tmp_path: Path) -> None:
+    server = _build(tmp_path, [_prompt("first")])
+    _call(server, "vaner.predictions.dashboard")
+    assert _counter(tmp_path, "mcp_dashboard_called") >= 1
+
+
+class _MockRegistry:
+    """Minimal registry stub — matches the interface the adopt handler calls."""
+
+    def __init__(self, prompt: PredictedPrompt) -> None:
+        self._prompt = prompt
+        self.lock = asyncio.Lock()
+        self.adoptions: list[str] = []
+
+    def get(self, pid: str) -> PredictedPrompt | None:
+        return self._prompt if pid == self._prompt.spec.id else None
+
+    def record_adoption(self, pid: str) -> None:
+        self.adoptions.append(pid)
+
+
+class _EngineWithRegistry:
+    def __init__(self, prompt: PredictedPrompt) -> None:
+        self.prediction_registry = _MockRegistry(prompt)
+        self._prompt = prompt
+
+    def get_active_predictions(self) -> list[PredictedPrompt]:
+        return [self._prompt]
+
+
+def _build_with_registry(tmp_path: Path, prompt: PredictedPrompt):
+    (tmp_path / ".vaner").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".vaner" / "config.toml").write_text(
+        '[backend]\nbase_url = "http://127.0.0.1:11434/v1"\nmodel = "llama3.2:3b"\n',
+        encoding="utf-8",
+    )
+    from vaner.mcp.server import build_server
+
+    return build_server(tmp_path, engine=_EngineWithRegistry(prompt))
+
+
+def test_adopt_from_mcp_app_increments_apps_clicked(tmp_path: Path) -> None:
+    p = _prompt("adoptable")
+    server = _build_with_registry(tmp_path, p)
+    _call(
+        server,
+        "vaner.predictions.adopt",
+        {"prediction_id": p.spec.id, "source": "mcp_app"},
+    )
+    assert _counter(tmp_path, "mcp_apps_adopt_clicked") >= 1
+    assert _counter(tmp_path, "mcp_adopt_source_mcp_app") >= 1
+
+
+def test_adopt_source_default_does_not_increment_apps_clicked(tmp_path: Path) -> None:
+    p = _prompt("adoptable2")
+    server = _build_with_registry(tmp_path, p)
+    _call(server, "vaner.predictions.adopt", {"prediction_id": p.spec.id})
+    assert _counter(tmp_path, "mcp_apps_adopt_clicked") == 0


### PR DESCRIPTION
Stacks on #163 (WS7). Rounds out observability + test-matrix for the integration layer.  
- New `source` enum on `vaner.predictions.adopt` drives bucketed adopt counters + `mcp_apps_adopt_clicked`.
- `read_resource` tallies `mcp_apps_bundle_read` and `guidance_resource_read_<variant>`.
- Cross-client matrix: 8 parametrized cases pin Claude Desktop, ChatGPT, Claude Code, Cursor, VS Code, custom proxies, plain stdio, minimal clients.
- Static a11y scan on the UI bundle: aria-live, aria-labelledby, aria-label on adopt buttons, semantic h1/ol/li, focus styles, dark mode, no tabindex traps. Full axe-core deferred to 0.8.6. 23 new tests. 🤖 Generated with Claude Code