### PR TITLE
feat(contract): 0.8.5 WS9 — Rust contract bump + card-model fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 members = ["crates/vaner-contract"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/vaner-contract/src/enums.rs
+++ b/crates/vaner-contract/src/enums.rs
@@ -90,6 +90,57 @@ impl Readiness {
     }
 }
 
+/// 0.8.5 WS6: Coarse ETA bucket for a prediction.
+///
+/// User-facing labels only — we deliberately avoid wall-clock promises.
+/// The daemon populates this alongside readiness; when the prompt is
+/// `Stale` no bucket is surfaced at all (the field is `None`).
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(TS), ts(export))]
+#[serde(rename_all = "snake_case")]
+pub enum EtaBucket {
+    /// Prediction is ready right now — click Adopt to use it.
+    ReadyNow,
+    /// Drafting almost done; usable within ~10–20s.
+    Under20s,
+    /// Evidence half-gathered; expect roughly a minute.
+    Under1m,
+    /// Work is underway but no crisp ETA yet.
+    #[default]
+    Working,
+    /// Early in the lifecycle — grounding or queued.
+    Maturing,
+    /// Unknown / future server value.
+    #[serde(other)]
+    Unknown,
+}
+
+#[cfg(test)]
+mod eta_bucket_tests {
+    use super::*;
+
+    #[test]
+    fn decodes_known_eta_buckets() {
+        let cases = [
+            (r#""ready_now""#, EtaBucket::ReadyNow),
+            (r#""under_20s""#, EtaBucket::Under20s),
+            (r#""under_1m""#, EtaBucket::Under1m),
+            (r#""working""#, EtaBucket::Working),
+            (r#""maturing""#, EtaBucket::Maturing),
+        ];
+        for (raw, expected) in cases {
+            let decoded: EtaBucket = serde_json::from_str(raw).unwrap();
+            assert_eq!(decoded, expected, "decoding {raw}");
+        }
+    }
+
+    #[test]
+    fn unknown_eta_bucket_does_not_error() {
+        let decoded: EtaBucket = serde_json::from_str(r#""eons""#).unwrap();
+        assert_eq!(decoded, EtaBucket::Unknown);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/vaner-contract/src/models.rs
+++ b/crates/vaner-contract/src/models.rs
@@ -13,7 +13,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::enums::{HypothesisType, PredictionSource, Readiness, Specificity};
+use crate::enums::{EtaBucket, HypothesisType, PredictionSource, Readiness, Specificity};
 
 #[cfg(feature = "ts-rs")]
 use ts_rs::TS;
@@ -24,6 +24,13 @@ use ts_rs::TS;
 
 /// A single in-flight predicted prompt. The top-level shape returned by
 /// `GET /predictions/active` (wrapped in `{"predictions": [...]}`).
+///
+/// 0.8.5 WS9: the daemon now emits optional card-model derivations
+/// (`readiness_label`, `eta_bucket`, `adoptable`, `rank`, `ui_summary`,
+/// `suppression_reason`, `source_label`, `eta_bucket_label`) alongside
+/// the raw fields. All new fields are `Option<T>` with `skip_serializing_if`
+/// so older daemons keep round-tripping and newer fields are available
+/// to UIs without a contract-version bump coordination step.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts-rs", derive(TS), ts(export))]
 pub struct PredictedPrompt {
@@ -31,6 +38,24 @@ pub struct PredictedPrompt {
     pub spec: PredictionSpec,
     pub run: PredictionRun,
     pub artifacts: PredictionArtifacts,
+
+    // 0.8.5 WS9 — UI card-model derivations. Server-computed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub readiness_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eta_bucket: Option<EtaBucket>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eta_bucket_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adoptable: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rank: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ui_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suppression_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_label: Option<String>,
 }
 
 /// Immutable identity + hypothesis of a predicted prompt.

--- a/crates/vaner-contract/src/reducer.rs
+++ b/crates/vaner-contract/src/reducer.rs
@@ -146,6 +146,14 @@ mod tests {
                 updated_at: 0.0,
             },
             artifacts: PredictionArtifacts::default(),
+            readiness_label: None,
+            eta_bucket: None,
+            eta_bucket_label: None,
+            adoptable: None,
+            rank: None,
+            ui_summary: None,
+            suppression_reason: None,
+            source_label: None,
         }
     }
 

--- a/src/vaner/mcp/apps/active_predictions.html
+++ b/src/vaner/mcp/apps/active_predictions.html
@@ -281,6 +281,7 @@
         try {
           const result = await app.callTool("vaner.predictions.adopt", {
             prediction_id: card.id,
+            source: "mcp_app",
           });
           if (result && result.isError) {
             throw new Error(result.error?.message || "Adopt failed");

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -215,6 +215,42 @@ def _serialize_prediction_for_mcp(prompt: Any, *, rank: int | None = None) -> di
     return payload
 
 
+_RESOURCE_METRIC_TASKS: set[Any] = set()
+"""Keep strong refs to background metric tasks until they settle.
+
+Without this, `asyncio.run()` can tear the loop down before the task
+completes, producing `Event loop is closed` warnings. Tracked via
+`add_done_callback(discard)` so entries clear themselves when the task
+finishes.
+"""
+
+
+def _increment_resource_metric(name: str, repo_root: Path) -> None:
+    """Fire-and-forget metric increment for resource-read events.
+
+    0.8.5 WS8: `read_resource` is a sync entry point in the SDK API, so we
+    can't `await` on `MetricsStore`. Spawn an asyncio task when a loop is
+    running; otherwise silently drop — metrics are best-effort.
+    """
+    import asyncio as _asyncio
+
+    async def _do() -> None:
+        try:
+            store = MetricsStore(repo_root / ".vaner" / "metrics.db")
+            await store.initialize()
+            await store.increment_counter(name)
+        except Exception:  # pragma: no cover - defensive metrics
+            pass
+
+    try:
+        loop = _asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    task = loop.create_task(_do())
+    _RESOURCE_METRIC_TASKS.add(task)
+    task.add_done_callback(_RESOURCE_METRIC_TASKS.discard)
+
+
 def _dashboard_fallback_text(cards: list[dict[str, Any]]) -> str:
     """Render a plain-text Vaner dashboard for non-UI MCP clients.
 
@@ -509,7 +545,15 @@ def build_server(
                     ),
                     inputSchema={
                         "type": "object",
-                        "properties": {"prediction_id": {"type": "string"}},
+                        "properties": {
+                            "prediction_id": {"type": "string"},
+                            "source": {
+                                "type": "string",
+                                "description": "Where the adopt request came from (for metrics): mcp_app, mcp_tool, cli, desktop, unknown.",
+                                "enum": ["mcp_app", "mcp_tool", "cli", "desktop", "unknown"],
+                                "default": "mcp_tool",
+                            },
+                        },
                         "required": ["prediction_id"],
                     },
                 ),
@@ -862,6 +906,7 @@ def build_server(
 
         # MCP Apps UI bundle.
         if uri_str == ACTIVE_PREDICTIONS_URI:
+            _increment_resource_metric("mcp_apps_bundle_read", repo_root)
             return [
                 ReadResourceContents(
                     content=ACTIVE_PREDICTIONS_HTML,
@@ -890,6 +935,7 @@ def build_server(
         if variant is None:
             raise ValueError(f"unknown vaner resource: {uri_str!r}")
         body = load_guidance(variant).as_text()  # type: ignore[arg-type]
+        _increment_resource_metric(f"guidance_resource_read_{variant}", repo_root)
         return [ReadResourceContents(content=body, mime_type="text/markdown")]
 
     @server.call_tool()
@@ -1653,12 +1699,21 @@ def build_server(
 
         if name == "vaner.predictions.adopt":
             prediction_id_arg = str(args.get("prediction_id", "")).strip()
+            adopt_source = str(args.get("source", "")).strip() or "unknown"
             if not prediction_id_arg:
                 await _record("error")
                 return _json_result(
                     {"code": "invalid_input", "message": "prediction_id is required"},
                     is_error=True,
                 )
+            # 0.8.5 WS8: track adopts coming from the MCP Apps UI separately
+            # from tool-initiated adopts so we can measure UI value.
+            try:
+                if adopt_source == "mcp_app":
+                    await metrics_store.increment_counter("mcp_apps_adopt_clicked")
+                await metrics_store.increment_counter(f"mcp_adopt_source_{adopt_source}")
+            except Exception:  # pragma: no cover - defensive metrics
+                pass
             # In-process engine path first.
             if engine is not None and engine.prediction_registry is not None:
                 prompt = engine.prediction_registry.get(prediction_id_arg)

--- a/tests/test_mcp/test_protocol_roundtrip.py
+++ b/tests/test_mcp/test_protocol_roundtrip.py
@@ -60,6 +60,8 @@ def test_mcp_protocol_roundtrip(temp_repo: Path, monkeypatch: pytest.MonkeyPatch
                 "vaner.debug.trace",
                 "vaner.predictions.active",
                 "vaner.predictions.adopt",
+                # 0.8.5 WS5: interactive MCP Apps dashboard.
+                "vaner.predictions.dashboard",
                 # WS7: workspace goals.
                 "vaner.goals.list",
                 "vaner.goals.declare",

--- a/tests/test_mcp/test_scenario_tools.py
+++ b/tests/test_mcp/test_scenario_tools.py
@@ -62,6 +62,8 @@ def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
             "vaner.debug.trace",
             "vaner.predictions.active",
             "vaner.predictions.adopt",
+            # 0.8.5 WS5: interactive MCP Apps dashboard.
+            "vaner.predictions.dashboard",
             # WS7: workspace goals.
             "vaner.goals.list",
             "vaner.goals.declare",

--- a/tests/test_mcp/test_server_boot.py
+++ b/tests/test_mcp/test_server_boot.py
@@ -20,12 +20,13 @@ def test_server_boot_initialize_lists_tools_and_status(temp_repo) -> None:
             names = [tool.name for tool in listed.tools]
             # WS7 added 4 goal tools → 16. 0.8.2 WS1 adds 4 artefact
             # tools + 1 sources.status → 21. 0.8.3 WS4 adds 5 deep_run
-            # tools → 26 total. Exact set is asserted in
-            # test_protocol_roundtrip; here we just check smoke.
-            assert len(names) == 26
+            # tools → 26. 0.8.5 WS5 adds vaner.predictions.dashboard → 27.
+            # Exact set is asserted in test_protocol_roundtrip.
+            assert len(names) == 27
             assert "vaner.status" in names
             assert "vaner.predictions.active" in names
             assert "vaner.predictions.adopt" in names
+            assert "vaner.predictions.dashboard" in names
             assert "vaner.goals.declare" in names
             assert "vaner.artefacts.list" in names
             assert "vaner.artefacts.influence" in names

--- a/tests/test_mcp_apps/test_accessibility_static.py
+++ b/tests/test_mcp_apps/test_accessibility_static.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static accessibility smoke for the UI bundle.
+
+A full axe-core / pa11y pass needs a headless browser. That's deferred
+to 0.8.6 polish. What we *can* pin today: the HTML must include the
+structural markers we rely on (aria-live region, aria-label on the list,
+button labels, semantic list + headings) so the bundle never regresses
+to a keyboard-unreachable / screen-reader-hostile state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+if importlib.util.find_spec("mcp") is None:  # pragma: no cover - CI matrix dependent
+    pytest.skip("mcp package is unavailable in this test environment", allow_module_level=True)
+
+from vaner.mcp.apps import ACTIVE_PREDICTIONS_HTML
+
+
+def test_has_live_region_for_status() -> None:
+    # Status updates (adopt success, refresh errors) need a live region
+    # so screen readers announce them without user action.
+    assert 'aria-live="polite"' in ACTIVE_PREDICTIONS_HTML
+    assert 'role="status"' in ACTIVE_PREDICTIONS_HTML
+
+
+def test_has_labelled_list() -> None:
+    # The card list uses aria-labelledby pointing at the heading so the
+    # list has accessible context.
+    assert 'aria-labelledby="heading"' in ACTIVE_PREDICTIONS_HTML
+    assert 'id="heading"' in ACTIVE_PREDICTIONS_HTML
+
+
+def test_adopt_buttons_are_labelled() -> None:
+    # Every dynamically-rendered adopt button is given an aria-label that
+    # names the prediction so a screen-reader user understands which one
+    # they'd adopt.
+    assert 'aria-label="Adopt prediction:' in ACTIVE_PREDICTIONS_HTML
+
+
+def test_uses_semantic_heading_and_list() -> None:
+    # Real H1/OL, not div soup — matters for rotor navigation.
+    assert "<h1" in ACTIVE_PREDICTIONS_HTML
+    assert "<ol" in ACTIVE_PREDICTIONS_HTML
+    # Cards are rendered as <li> elements inside the ol (dynamic render
+    # uses document.createElement("li") + className = "card"); the marker
+    # to match the class lives in the JS render path.
+    assert 'className = "card"' in ACTIVE_PREDICTIONS_HTML
+
+
+def test_focus_styles_defined() -> None:
+    # Keyboard users need a visible focus ring. We define :focus-within
+    # on the card and :focus on the Adopt button.
+    assert ":focus-within" in ACTIVE_PREDICTIONS_HTML
+    assert "button.adopt:focus" in ACTIVE_PREDICTIONS_HTML
+
+
+def test_dark_mode_styles_defined() -> None:
+    # High-contrast + dark-mode adaptation for low-vision users.
+    assert "prefers-color-scheme: dark" in ACTIVE_PREDICTIONS_HTML
+    assert "color-scheme: light dark" in ACTIVE_PREDICTIONS_HTML
+
+
+def test_disabled_state_is_signaled_textually_not_just_color() -> None:
+    # When Adopt is not available, the button text changes (not just the
+    # color fades). Ensures color-only signaling is avoided.
+    assert "disabled ? readinessLabel : adoptLabel" in ACTIVE_PREDICTIONS_HTML
+
+
+def test_no_inline_tabindex_traps() -> None:
+    # tabindex="-1" or tabindex=999 can create keyboard traps. We allow
+    # no inline tabindex on the card grid — default tab order suffices.
+    assert 'tabindex="-1"' not in ACTIVE_PREDICTIONS_HTML
+    assert "tabindex=999" not in ACTIVE_PREDICTIONS_HTML

--- a/tests/test_mcp_apps/test_cross_client.py
+++ b/tests/test_mcp_apps/test_cross_client.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-client tier simulation.
+
+The real clients (Claude Desktop, Claude Code, Cursor, ChatGPT, VS Code
+Copilot, plain stdio) each advertise a different capability shape during
+MCP initialize. We can't spin them up in unit tests, but we *can*
+simulate each one by writing the expected `client_params` shape and
+asking :func:`detect_tier` what it sees. If the tier mapping drifts, a
+real-client regression becomes obvious here without waiting for a
+downstream user to file a bug.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vaner.integrations.capability import ClientCapabilityTier, detect_tier
+
+
+def _caps(**kw) -> SimpleNamespace:
+    return SimpleNamespace(
+        experimental=kw.get("experimental"),
+        roots=kw.get("roots"),
+        sampling=kw.get("sampling"),
+    )
+
+
+def _params(name: str, version: str, caps: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        clientInfo=SimpleNamespace(name=name, version=version),
+        capabilities=caps,
+    )
+
+
+# (client_name, expected_tier, caps_kwargs)
+_CASES = [
+    # Tier 4 — MCP Apps host.
+    (
+        "claude_desktop_ui",
+        ClientCapabilityTier.TIER_4,
+        {"experimental": {"io.modelcontextprotocol/ui": {}}, "roots": SimpleNamespace()},
+    ),
+    (
+        "chatgpt_ui",
+        ClientCapabilityTier.TIER_4,
+        {
+            "experimental": {"io.modelcontextprotocol/ui": {"version": 1}},
+            "sampling": SimpleNamespace(),
+        },
+    ),
+    # Tier 3 — context-mediation host (future hosts that opt in).
+    (
+        "custom_proxy_with_injection",
+        ClientCapabilityTier.TIER_3,
+        {"experimental": {"vaner.context_injection": {}}, "roots": SimpleNamespace()},
+    ),
+    # Tier 2 — prompt-guidance capable (most real MCP clients).
+    (
+        "claude_code",
+        ClientCapabilityTier.TIER_2,
+        {"roots": SimpleNamespace(listChanged=True)},
+    ),
+    (
+        "cursor",
+        ClientCapabilityTier.TIER_2,
+        {"sampling": SimpleNamespace()},
+    ),
+    (
+        "vscode_copilot",
+        ClientCapabilityTier.TIER_2,
+        {"roots": SimpleNamespace()},
+    ),
+    # Tier 1 — bare stdio.
+    (
+        "plain_stdio_client",
+        ClientCapabilityTier.TIER_1,
+        {"experimental": {}},
+    ),
+    (
+        "minimal_mcp_client",
+        ClientCapabilityTier.TIER_1,
+        {},  # no roots/sampling/experimental
+    ),
+]
+
+
+@pytest.mark.parametrize(("name", "expected_tier", "caps_kwargs"), _CASES)
+def test_client_tier_matches_expectation(name: str, expected_tier: ClientCapabilityTier, caps_kwargs: dict) -> None:
+    params = _params(name, "1.0.0", _caps(**caps_kwargs))
+    detection = detect_tier(params)
+    assert detection.tier is expected_tier, (
+        f"client {name!r} expected {expected_tier.name}, got {detection.tier.name} (reason={detection.reason!r})"
+    )
+
+
+def test_tier_4_ui_extension_supersedes_lower_markers() -> None:
+    # A Tier-4 client will also advertise roots/sampling; the UI flag
+    # must win the classification regardless.
+    params = _params(
+        "claude_desktop",
+        "0.9",
+        _caps(
+            experimental={"io.modelcontextprotocol/ui": {}},
+            roots=SimpleNamespace(),
+            sampling=SimpleNamespace(),
+        ),
+    )
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_4
+
+
+def test_unknown_future_experimental_does_not_demote_tier_2() -> None:
+    # Future clients may advertise experimental keys we don't know about.
+    # We must still classify them at Tier-2 if they advertise roots.
+    params = _params(
+        "future_client",
+        "2.0",
+        _caps(
+            experimental={"com.example.new": {}},
+            roots=SimpleNamespace(),
+        ),
+    )
+    assert detect_tier(params).tier is ClientCapabilityTier.TIER_2
+
+
+def test_detection_preserves_client_name_for_logging() -> None:
+    # The detection object carries the name + version so the per-session
+    # log line can attribute the tier to the right client. If this drifts,
+    # logs become uninformative.
+    params = _params("claude_code", "1.2.3", _caps(roots=SimpleNamespace()))
+    d = detect_tier(params)
+    assert d.client_name == "claude_code"
+    assert d.client_version == "1.2.3"

--- a/tests/test_mcp_apps/test_metrics.py
+++ b/tests/test_mcp_apps/test_metrics.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""WS8 metric plumbing tests.
+
+The counters are incremented via MCP handlers; rather than drive the
+full server we unit-test the helpers + verify the metric store gets
+written when the handler path is exercised through the stub-engine
+dashboard test already pinned in test_dashboard_tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+if importlib.util.find_spec("mcp") is None:  # pragma: no cover - CI matrix dependent
+    pytest.skip("mcp package is unavailable in this test environment", allow_module_level=True)
+
+from vaner.intent.prediction import (
+    PredictedPrompt,
+    PredictionArtifacts,
+    PredictionRun,
+    PredictionSpec,
+    prediction_id,
+)
+from vaner.telemetry.metrics import MetricsStore
+
+
+def _prompt(label: str, readiness: str = "ready") -> PredictedPrompt:
+    return PredictedPrompt(
+        spec=PredictionSpec(
+            id=prediction_id("arc", "anchor", label),
+            label=label,
+            description=label,
+            source="arc",
+            anchor="anchor",
+            confidence=0.7,
+            hypothesis_type="likely_next",
+            specificity="concrete",
+            created_at=0.0,
+        ),
+        run=PredictionRun(
+            weight=0.5,
+            token_budget=1024,
+            tokens_used=100,
+            scenarios_spawned=2,
+            scenarios_complete=1,
+            readiness=readiness,  # type: ignore[arg-type]
+            updated_at=0.0,
+        ),
+        artifacts=PredictionArtifacts(prepared_briefing="briefing"),
+    )
+
+
+class _StubEngine:
+    def __init__(self, prompts: list[PredictedPrompt]) -> None:
+        self._prompts = prompts
+        self.prediction_registry = None
+
+    def get_active_predictions(self) -> list[PredictedPrompt]:
+        return list(self._prompts)
+
+
+def _build(tmp_path: Path, prompts: list[PredictedPrompt]):
+    (tmp_path / ".vaner").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".vaner" / "config.toml").write_text(
+        '[backend]\nbase_url = "http://127.0.0.1:11434/v1"\nmodel = "llama3.2:3b"\n',
+        encoding="utf-8",
+    )
+    from vaner.mcp.server import build_server
+
+    return build_server(tmp_path, engine=_StubEngine(prompts))
+
+
+def _call(server, name: str, arguments: dict | None = None) -> dict:
+    async def _do() -> dict:
+        from mcp.types import CallToolRequest, CallToolRequestParams
+
+        handler = server.request_handlers[CallToolRequest]
+        result = await handler(
+            CallToolRequest(
+                method="tools/call",
+                params=CallToolRequestParams(name=name, arguments=arguments or {}),
+            )
+        )
+        return json.loads(result.root.content[0].text)
+
+    return asyncio.run(_do())
+
+
+def _counter(repo_root: Path, name: str) -> float:
+    async def _get() -> float:
+        store = MetricsStore(repo_root / ".vaner" / "metrics.db")
+        await store.initialize()
+        counters = await store._counters_map()
+        return float(counters.get(name, 0.0))
+
+    return asyncio.run(_get())
+
+
+def test_dashboard_tool_increments_called_counter(tmp_path: Path) -> None:
+    server = _build(tmp_path, [_prompt("first")])
+    _call(server, "vaner.predictions.dashboard")
+    assert _counter(tmp_path, "mcp_dashboard_called") >= 1
+
+
+class _MockRegistry:
+    """Minimal registry stub — matches the interface the adopt handler calls."""
+
+    def __init__(self, prompt: PredictedPrompt) -> None:
+        self._prompt = prompt
+        self.lock = asyncio.Lock()
+        self.adoptions: list[str] = []
+
+    def get(self, pid: str) -> PredictedPrompt | None:
+        return self._prompt if pid == self._prompt.spec.id else None
+
+    def record_adoption(self, pid: str) -> None:
+        self.adoptions.append(pid)
+
+
+class _EngineWithRegistry:
+    def __init__(self, prompt: PredictedPrompt) -> None:
+        self.prediction_registry = _MockRegistry(prompt)
+        self._prompt = prompt
+
+    def get_active_predictions(self) -> list[PredictedPrompt]:
+        return [self._prompt]
+
+
+def _build_with_registry(tmp_path: Path, prompt: PredictedPrompt):
+    (tmp_path / ".vaner").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".vaner" / "config.toml").write_text(
+        '[backend]\nbase_url = "http://127.0.0.1:11434/v1"\nmodel = "llama3.2:3b"\n',
+        encoding="utf-8",
+    )
+    from vaner.mcp.server import build_server
+
+    return build_server(tmp_path, engine=_EngineWithRegistry(prompt))
+
+
+def test_adopt_from_mcp_app_increments_apps_clicked(tmp_path: Path) -> None:
+    p = _prompt("adoptable")
+    server = _build_with_registry(tmp_path, p)
+    _call(
+        server,
+        "vaner.predictions.adopt",
+        {"prediction_id": p.spec.id, "source": "mcp_app"},
+    )
+    assert _counter(tmp_path, "mcp_apps_adopt_clicked") >= 1
+    assert _counter(tmp_path, "mcp_adopt_source_mcp_app") >= 1
+
+
+def test_adopt_source_default_does_not_increment_apps_clicked(tmp_path: Path) -> None:
+    p = _prompt("adoptable2")
+    server = _build_with_registry(tmp_path, p)
+    _call(server, "vaner.predictions.adopt", {"prediction_id": p.spec.id})
+    assert _counter(tmp_path, "mcp_apps_adopt_clicked") == 0


### PR DESCRIPTION
Stacks on #164 (WS8). Additive wire change: PredictedPrompt gets optional UI card-model fields + a new unknown-tolerant EtaBucket enum. Workspace version bumped 0.1.0 → 0.2.0. Sibling mirrors (vaner-desktop Swift, vaner-linux TS) are updated in separate PRs in their respective repos. 🤖 Generated with Claude Code