### PR TITLE
feat(clients): 0.8.5 WS12-A — vaner clients CLI sub-app + Cursor 2.6 matrix

### DIFF
--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -32,6 +32,7 @@ from rich.table import Table
 
 from vaner import __version__, api
 from vaner.cli.commands import mcp_clients
+from vaner.cli.commands.clients import clients_app
 from vaner.cli.commands.config import load_config, set_compute_value, set_config_value
 from vaner.cli.commands.daemon import (
     COCKPIT_PROCESS,
@@ -107,32 +108,6 @@ def _fail(message: str, *, hint: str | None = None, code: int = 1) -> None:
     raise typer.Exit(code=code)
 
 
-def _remove_vaner_from_json_config(path: Path, *, container_key: str = "mcpServers") -> bool:
-    if not path.exists():
-        return False
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return False
-    if not isinstance(payload, dict):
-        return False
-    container = payload.get(container_key)
-    if not isinstance(container, dict):
-        return False
-    keys_to_remove = [key for key in container if str(key) == "vaner" or str(key).startswith("vaner-")]
-    if not keys_to_remove:
-        return False
-    for key in keys_to_remove:
-        container.pop(key, None)
-    if not container:
-        payload.pop(container_key, None)
-    if payload:
-        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    else:
-        path.unlink(missing_ok=True)
-    return True
-
-
 def _remove_managed_skill(path: Path) -> bool:
     if not path.exists():
         return False
@@ -148,33 +123,29 @@ def _remove_managed_skill(path: Path) -> bool:
 
 
 def _remove_mcp_config_entries(repo_root: Path) -> int:
+    """Strip every vaner entry from every detected client's config.
+
+    0.8.5 WS12: delegated to :func:`mcp_clients.remove_client` so the
+    same logic backs both `vaner uninstall` and `vaner clients uninstall`.
+    Includes the per-repo `.cursor/mcp.json` not covered by `detect_all`.
+    """
     updated = 0
     updated_paths: set[Path] = set()
 
     repo_cursor = repo_root / ".cursor" / "mcp.json"
-    if _remove_vaner_from_json_config(repo_cursor, container_key="mcpServers"):
+    if mcp_clients._remove_vaner_from_json(repo_cursor, container_key="mcpServers"):
         updated += 1
         updated_paths.add(repo_cursor)
 
     for detected in mcp_clients.detect_all(repo_root):
         config_path = detected.path
-        if config_path is None:
-            continue
         if config_path in updated_paths:
             continue
-        if detected.spec.kind == "json-mcpServers":
-            if _remove_vaner_from_json_config(config_path, container_key="mcpServers"):
-                updated += 1
-        elif detected.spec.kind == "json-servers":
-            if _remove_vaner_from_json_config(config_path, container_key="servers"):
-                updated += 1
-        elif detected.spec.kind == "json-context_servers":
-            if _remove_vaner_from_json_config(config_path, container_key="context_servers"):
-                updated += 1
-        elif detected.spec.kind == "yaml-continue":
-            if config_path.exists() and "name: vaner" in config_path.read_text(encoding="utf-8"):
-                config_path.unlink(missing_ok=True)
-                updated += 1
+        result = mcp_clients.remove_client(detected)
+        if result.action == "updated":
+            updated += 1
+            if config_path is not None:
+                updated_paths.add(config_path)
     return updated
 
 
@@ -2145,6 +2116,7 @@ app.add_typer(scenarios_app, name="scenarios", rich_help_panel="Use with an agen
 app.add_typer(deep_run_app, name="deep-run", rich_help_panel="Background and local")
 app.add_typer(guidance_app, name="guidance", rich_help_panel="Use with an agent")
 app.add_typer(integrations_app, name="integrations", rich_help_panel="Inspect and debug")
+app.add_typer(clients_app, name="clients", rich_help_panel="Connect MCP clients")
 
 
 def run() -> None:

--- a/src/vaner/cli/commands/clients.py
+++ b/src/vaner/cli/commands/clients.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+"""`vaner clients` CLI — install Vaner into MCP clients.
+
+0.8.5 WS12: thin non-interactive surface over :mod:`vaner.cli.commands.mcp_clients`,
+so desktop apps and CI pipelines can drive install/uninstall/status/doctor
+through a stable contract instead of the interactive `vaner init` wizard.
+
+The per-client adapter knowledge (config paths, JSON vs YAML vs CLI shell-out,
+backup rotation, atomic writes) all lives in `mcp_clients`. This module is
+just the typer-shaped entry point.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from vaner.cli.commands import mcp_clients
+
+clients_app = typer.Typer(
+    help=(
+        "Install Vaner into MCP clients (Cursor, Claude Desktop, Claude Code, "
+        "Cline, Continue, Zed, Windsurf, VS Code, Codex CLI, Roo). Idempotent; "
+        "safe to re-run after Vaner upgrades."
+    ),
+    no_args_is_help=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+_STATUS_GLYPH = {
+    mcp_clients.ClientStatus.CONFIGURED: ("[green]✓[/green]", "Configured"),
+    mcp_clients.ClientStatus.INSTALLED: ("[yellow]·[/yellow]", "Detected"),
+    mcp_clients.ClientStatus.MISSING: ("[dim]✗[/dim]", "Missing"),
+}
+
+
+def _detected_to_dict(detected: mcp_clients.DetectedClient) -> dict[str, object]:
+    return {
+        "id": detected.spec.id,
+        "label": detected.spec.label,
+        "kind": detected.spec.kind,
+        "status": detected.status.value,
+        "detected": detected.status != mcp_clients.ClientStatus.MISSING,
+        "configured": detected.status == mcp_clients.ClientStatus.CONFIGURED,
+        "config_path": str(detected.path) if detected.path is not None else None,
+        "detail": detected.detail,
+    }
+
+
+def _result_to_dict(result: mcp_clients.WriteResult) -> dict[str, object]:
+    return {
+        "client_id": result.client_id,
+        "path": str(result.path) if result.path is not None else None,
+        "action": result.action,
+        "backup": str(result.backup) if result.backup is not None else None,
+        "error": result.error,
+        "manual_snippet": result.manual_snippet,
+    }
+
+
+def _drift_to_dict(report: mcp_clients.LauncherDrift) -> dict[str, object]:
+    return {
+        "client_id": report.client_id,
+        "label": report.label,
+        "config_path": str(report.config_path) if report.config_path is not None else None,
+        "drift": report.drift,
+        "current_in_config": report.current_in_config,
+        "expected": report.expected,
+        "detail": report.detail,
+    }
+
+
+def _print_detect_table(detected_list: list[mcp_clients.DetectedClient]) -> None:
+    console = Console()
+    table = Table(title="MCP clients", show_lines=False)
+    table.add_column("Client")
+    table.add_column("Status")
+    table.add_column("Path")
+    for detected in detected_list:
+        glyph, label = _STATUS_GLYPH[detected.status]
+        path = str(detected.path) if detected.path is not None else "-"
+        table.add_row(detected.spec.label, f"{glyph} {label}", path)
+    console.print(table)
+
+
+def _print_install_results(results: list[mcp_clients.WriteResult]) -> None:
+    console = Console()
+    for r in results:
+        if r.action == "added":
+            console.print(f"[green]✓[/green] {r.client_id}: added at {r.path}")
+        elif r.action == "updated":
+            console.print(f"[green]✓[/green] {r.client_id}: updated at {r.path}")
+        elif r.action == "skipped":
+            note = f" ({r.error})" if r.error else ""
+            console.print(f"[yellow]·[/yellow] {r.client_id}: skipped{note}")
+        elif r.action == "failed":
+            console.print(f"[red]✗[/red] {r.client_id}: failed — {r.error or 'unknown error'}")
+
+
+def _resolve_repo_root(repo_root: Path | None) -> Path:
+    return repo_root if repo_root is not None else Path.cwd()
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+@clients_app.command("detect", help="List MCP clients found on this machine and their config status.")
+def detect_cmd(
+    repo_root: Annotated[
+        Path | None,
+        typer.Option("--repo-root", "-C", help="Repo root for per-repo detection (default: cwd)."),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: pretty (default), json."),
+    ] = "pretty",
+) -> None:
+    root = _resolve_repo_root(repo_root)
+    detected_list = mcp_clients.detect_all(root)
+    if format == "json":
+        typer.echo(json.dumps({"clients": [_detected_to_dict(d) for d in detected_list]}, indent=2))
+        return
+    if format != "pretty":
+        raise typer.BadParameter(f"unknown format {format!r}. Choose from: pretty, json")
+    _print_detect_table(detected_list)
+
+
+@clients_app.command("install", help="Install Vaner into one or all MCP clients.")
+def install_cmd(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Client id (e.g. cursor, claude-desktop). Omit when using --all."),
+    ] = None,
+    install_all: Annotated[
+        bool,
+        typer.Option("--all", help="Install Vaner for every detected MCP client."),
+    ] = False,
+    server_key: Annotated[
+        str,
+        typer.Option(
+            "--server-key",
+            help="Override the JSON `mcpServers` key (Claude Desktop uses `vaner-<reponame>` by default).",
+        ),
+    ] = "vaner",
+    repo_root: Annotated[
+        Path | None,
+        typer.Option("--repo-root", "-C", help="Repo root (default: cwd)."),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show what would change; do not write any files."),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Re-write the entry even when it already matches."),
+    ] = False,
+    format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: pretty (default), json."),
+    ] = "pretty",
+) -> None:
+    if not install_all and name is None:
+        raise typer.BadParameter("specify a client id or pass --all")
+    if install_all and name is not None:
+        raise typer.BadParameter("--all and a client name are mutually exclusive")
+
+    root = _resolve_repo_root(repo_root)
+    detected_list = mcp_clients.detect_all(root)
+    launcher_cmd, launcher_args = mcp_clients.resolve_launcher(root)
+
+    if install_all:
+        targets = [d for d in detected_list if d.status != mcp_clients.ClientStatus.MISSING]
+    else:
+        targets = [d for d in detected_list if d.spec.id == name]
+        if not targets:
+            ids = ", ".join(d.spec.id for d in detected_list)
+            raise typer.BadParameter(f"unknown client id {name!r}. Known: {ids}")
+        if targets[0].status == mcp_clients.ClientStatus.MISSING:
+            typer.secho(
+                f"warning: {name} not detected on this machine — writing config anyway",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+
+    results: list[mcp_clients.WriteResult] = []
+    for detected in targets:
+        # Per the existing wizard convention, Claude Desktop uses
+        # `vaner-<reponame>` so multiple repos can register independently.
+        key = server_key
+        if key == "vaner" and detected.spec.id == "claude-desktop":
+            key = f"vaner-{root.name}"
+        result = mcp_clients.write_client(
+            detected,
+            launcher_cmd=launcher_cmd,
+            launcher_args=launcher_args,
+            server_key=key,
+            dry_run=dry_run,
+            force=force,
+        )
+        results.append(result)
+
+    if format == "json":
+        typer.echo(json.dumps({"results": [_result_to_dict(r) for r in results]}, indent=2))
+        return
+    if format != "pretty":
+        raise typer.BadParameter(f"unknown format {format!r}. Choose from: pretty, json")
+    _print_install_results(results)
+    if any(r.action == "failed" for r in results):
+        raise typer.Exit(code=1)
+
+
+@clients_app.command("uninstall", help="Remove the Vaner entry from one or all MCP clients.")
+def uninstall_cmd(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Client id; omit with --all."),
+    ] = None,
+    uninstall_all: Annotated[
+        bool,
+        typer.Option("--all", help="Remove Vaner from every configured MCP client."),
+    ] = False,
+    repo_root: Annotated[
+        Path | None,
+        typer.Option("--repo-root", "-C", help="Repo root (default: cwd)."),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show what would change; do not delete."),
+    ] = False,
+    format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: pretty (default), json."),
+    ] = "pretty",
+) -> None:
+    if not uninstall_all and name is None:
+        raise typer.BadParameter("specify a client id or pass --all")
+    if uninstall_all and name is not None:
+        raise typer.BadParameter("--all and a client name are mutually exclusive")
+
+    root = _resolve_repo_root(repo_root)
+    detected_list = mcp_clients.detect_all(root)
+    if uninstall_all:
+        targets = [d for d in detected_list if d.status == mcp_clients.ClientStatus.CONFIGURED]
+    else:
+        targets = [d for d in detected_list if d.spec.id == name]
+        if not targets:
+            ids = ", ".join(d.spec.id for d in detected_list)
+            raise typer.BadParameter(f"unknown client id {name!r}. Known: {ids}")
+
+    results = [mcp_clients.remove_client(d, dry_run=dry_run) for d in targets]
+    if format == "json":
+        typer.echo(json.dumps({"results": [_result_to_dict(r) for r in results]}, indent=2))
+        return
+    if format != "pretty":
+        raise typer.BadParameter(f"unknown format {format!r}. Choose from: pretty, json")
+    for r in results:
+        if r.action == "updated":
+            typer.echo(f"✓ {r.client_id}: removed from {r.path}")
+        elif r.action == "skipped":
+            typer.echo(f"· {r.client_id}: nothing to remove" + (f" ({r.error})" if r.error else ""))
+        else:
+            typer.secho(f"✗ {r.client_id}: {r.error or 'failed'}", fg=typer.colors.RED, err=True)
+
+
+@clients_app.command("status", help="Show install/configured matrix for every supported MCP client.")
+def status_cmd(
+    repo_root: Annotated[
+        Path | None,
+        typer.Option("--repo-root", "-C"),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: pretty (default), json."),
+    ] = "pretty",
+) -> None:
+    detect_cmd(repo_root=repo_root, format=format)
+
+
+@clients_app.command(
+    "doctor",
+    help="Detect launcher path drift after Vaner is reinstalled / moved.",
+)
+def doctor_cmd(
+    repo_root: Annotated[
+        Path | None,
+        typer.Option("--repo-root", "-C"),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: pretty (default), json."),
+    ] = "pretty",
+) -> None:
+    root = _resolve_repo_root(repo_root)
+    detected_list = mcp_clients.detect_all(root)
+    reports = [mcp_clients.launcher_drift(d) for d in detected_list]
+    drifted = [r for r in reports if r.drift]
+
+    if format == "json":
+        typer.echo(
+            json.dumps(
+                {
+                    "drift": [_drift_to_dict(r) for r in reports],
+                    "drift_count": len(drifted),
+                    "fix_command": "vaner clients install --all --force",
+                },
+                indent=2,
+            )
+        )
+        if drifted:
+            sys.exit(1)
+        return
+
+    if format != "pretty":
+        raise typer.BadParameter(f"unknown format {format!r}. Choose from: pretty, json")
+
+    console = Console()
+    if not drifted:
+        console.print("[green]All configured MCP clients use the current `vaner` binary.[/green]")
+        return
+    table = Table(title="Launcher drift", show_lines=False)
+    table.add_column("Client")
+    table.add_column("Configured")
+    table.add_column("Expected")
+    for r in drifted:
+        table.add_row(r.label, r.current_in_config or "-", r.expected)
+    console.print(table)
+    console.print()
+    console.print("[yellow]Fix:[/yellow] run `vaner clients install --all --force`")
+    raise typer.Exit(code=1)

--- a/src/vaner/cli/commands/mcp_clients.py
+++ b/src/vaner/cli/commands/mcp_clients.py
@@ -495,6 +495,202 @@ def write_client(
     return WriteResult(client_id=spec.id, path=target_path, action="failed", error=f"Unsupported kind: {spec.kind}")
 
 
+def _remove_vaner_from_json(path: Path, *, container_key: str) -> bool:
+    """Strip `vaner` and `vaner-*` entries from a json client config.
+
+    Returns True when the file was modified or deleted, False otherwise.
+    Used by both `vaner uninstall` and `vaner clients uninstall`.
+    """
+    if not path.exists():
+        return False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    container = payload.get(container_key)
+    if not isinstance(container, dict):
+        return False
+    keys_to_remove = [key for key in container if str(key) == "vaner" or str(key).startswith("vaner-")]
+    if not keys_to_remove:
+        return False
+    for key in keys_to_remove:
+        container.pop(key, None)
+    if not container:
+        payload.pop(container_key, None)
+    if payload:
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    else:
+        path.unlink(missing_ok=True)
+    return True
+
+
+def remove_client(detected: DetectedClient, *, dry_run: bool = False) -> WriteResult:
+    """Remove the Vaner entry from a single detected client's config.
+
+    Symmetric to :func:`write_client`. Returns the same `WriteResult` shape
+    (`action="updated"` when an entry was removed, `"skipped"` when nothing
+    matched). For CLI-driven clients (Claude Code, Codex CLI) we shell out
+    to their respective `mcp remove` command.
+    """
+    spec = detected.spec
+    target_path = detected.path
+
+    if spec.kind in ("json-mcpServers", "json-servers", "json-context_servers"):
+        if target_path is None:
+            return WriteResult(client_id=spec.id, path=None, action="skipped", error="no config path")
+        container_key = {
+            "json-mcpServers": "mcpServers",
+            "json-servers": "servers",
+            "json-context_servers": "context_servers",
+        }[spec.kind]
+        if dry_run:
+            return WriteResult(client_id=spec.id, path=target_path, action="skipped", error="dry-run")
+        changed = _remove_vaner_from_json(target_path, container_key=container_key)
+        return WriteResult(
+            client_id=spec.id,
+            path=target_path,
+            action="updated" if changed else "skipped",
+        )
+
+    if spec.kind == "yaml-continue":
+        if target_path is None or not target_path.exists():
+            return WriteResult(client_id=spec.id, path=target_path, action="skipped")
+        try:
+            text = target_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            return WriteResult(client_id=spec.id, path=target_path, action="failed", error=str(exc))
+        if "name: vaner" not in text:
+            return WriteResult(client_id=spec.id, path=target_path, action="skipped")
+        if dry_run:
+            return WriteResult(client_id=spec.id, path=target_path, action="skipped", error="dry-run")
+        target_path.unlink(missing_ok=True)
+        return WriteResult(client_id=spec.id, path=target_path, action="updated")
+
+    if spec.kind == "cli-claude":
+        argv = ["claude", "mcp", "remove", "--scope", "user", "vaner"]
+        return _run_cli_remove(spec.id, "claude", argv, dry_run=dry_run)
+    if spec.kind == "cli-codex":
+        argv = ["codex", "mcp", "remove", "vaner"]
+        return _run_cli_remove(spec.id, "codex", argv, dry_run=dry_run)
+    return WriteResult(client_id=spec.id, path=target_path, action="skipped")
+
+
+def _run_cli_remove(client_id: str, executable: str, argv: list[str], *, dry_run: bool) -> WriteResult:
+    if dry_run:
+        return WriteResult(client_id=client_id, path=None, action="skipped", error="dry-run")
+    if not shutil.which(executable):
+        return WriteResult(
+            client_id=client_id,
+            path=None,
+            action="skipped",
+            error=f"{executable} binary not found",
+        )
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True, check=False, timeout=30)
+    except Exception as exc:  # pragma: no cover
+        return WriteResult(client_id=client_id, path=None, action="failed", error=str(exc))
+    if result.returncode == 0:
+        return WriteResult(client_id=client_id, path=None, action="updated")
+    return WriteResult(
+        client_id=client_id,
+        path=None,
+        action="failed",
+        error=(result.stderr or result.stdout).strip()[:500],
+    )
+
+
+@dataclass(slots=True)
+class LauncherDrift:
+    """Single client's view of `vaner` binary path drift."""
+
+    client_id: str
+    label: str
+    config_path: Path | None
+    drift: bool
+    current_in_config: str | None
+    expected: str
+    detail: str = ""
+
+
+def _load_configured_command(detected: DetectedClient) -> str | None:
+    """Read the `command` (or `command.path` for Zed) the client uses for vaner.
+
+    Returns None when the config file doesn't exist, isn't valid JSON, or
+    doesn't carry a vaner entry. CLI-managed clients (claude/codex) don't
+    expose their config to us this way and return None — they need to be
+    re-run to pick up new launcher paths.
+    """
+    spec = detected.spec
+    if spec.kind not in ("json-mcpServers", "json-servers", "json-context_servers"):
+        return None
+    if detected.path is None or not detected.path.exists():
+        return None
+    container_key = {
+        "json-mcpServers": "mcpServers",
+        "json-servers": "servers",
+        "json-context_servers": "context_servers",
+    }[spec.kind]
+    try:
+        payload = json.loads(detected.path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    container = payload.get(container_key)
+    if not isinstance(container, dict):
+        return None
+    for key, entry in container.items():
+        if not (str(key) == "vaner" or str(key).startswith("vaner-")):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        cmd = entry.get("command")
+        if isinstance(cmd, dict):
+            # Zed uses `{"command": {"path": "...", "args": [...]}}`.
+            inner = cmd.get("path")
+            if isinstance(inner, str):
+                return inner
+        elif isinstance(cmd, str):
+            return cmd
+    return None
+
+
+def launcher_drift(detected: DetectedClient) -> LauncherDrift:
+    """Report whether *detected*'s configured launcher matches the current `vaner` binary."""
+    expected = shutil.which("vaner") or "vaner"
+    if detected.status != ClientStatus.CONFIGURED:
+        return LauncherDrift(
+            client_id=detected.spec.id,
+            label=detected.spec.label,
+            config_path=detected.path,
+            drift=False,
+            current_in_config=None,
+            expected=expected,
+            detail="not configured",
+        )
+    current = _load_configured_command(detected)
+    if current is None:
+        return LauncherDrift(
+            client_id=detected.spec.id,
+            label=detected.spec.label,
+            config_path=detected.path,
+            drift=False,
+            current_in_config=None,
+            expected=expected,
+            detail="cli-managed; cannot inspect",
+        )
+    drifted = current != expected
+    return LauncherDrift(
+        client_id=detected.spec.id,
+        label=detected.spec.label,
+        config_path=detected.path,
+        drift=drifted,
+        current_in_config=current,
+        expected=expected,
+        detail="drift detected" if drifted else "in sync",
+    )
+
+
 def print_other_client_help(launcher_cmd: str, launcher_args: list[str]) -> str:
     snippet = generic_snippet(launcher_cmd, launcher_args)
     lines = [

--- a/tests/test_cli/test_clients_subcommand.py
+++ b/tests/test_cli/test_clients_subcommand.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `vaner clients` CLI (0.8.5 WS12)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+from vaner.cli.commands.clients import clients_app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin HOME / Path.home() / shutil.which / APPDATA so clients are
+    detectable under tmp_path with no leakage to the real machine.
+
+    Mirrors the pattern from `tests/test_cli/test_init.py`.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.setenv("APPDATA", str(home / "AppData"))
+    # Make `vaner` look installed at a stable absolute path so the launcher
+    # ends up deterministic across platforms.
+    monkeypatch.setattr(
+        "vaner.cli.commands.mcp_clients.shutil.which",
+        lambda name: f"/fake/bin/{name}" if name == "vaner" else None,
+    )
+    return home
+
+
+def _seed_cursor(home: Path, repo_root: Path) -> None:
+    # Cursor's user dir is what `_detect_cursor` looks for; create it.
+    (home / ".cursor").mkdir(parents=True, exist_ok=True)
+
+
+def _seed_claude_desktop(home: Path) -> None:
+    # Linux path on the fake home.
+    (home / ".config" / "Claude").mkdir(parents=True, exist_ok=True)
+
+
+def _seed_continue(home: Path) -> None:
+    (home / ".continue").mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# detect
+# ---------------------------------------------------------------------------
+
+
+def test_detect_returns_every_known_client(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        clients_app,
+        ["detect", "--repo-root", str(repo), "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ids = {c["id"] for c in payload["clients"]}
+    expected = {
+        "cursor",
+        "claude-desktop",
+        "claude-code",
+        "vscode-copilot",
+        "codex-cli",
+        "windsurf",
+        "zed",
+        "continue",
+        "cline",
+        "roo",
+    }
+    assert expected.issubset(ids)
+
+
+def test_detect_marks_seeded_clients_as_installed(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    _seed_claude_desktop(fake_home)
+    _seed_continue(fake_home)
+    result = runner.invoke(clients_app, ["detect", "--repo-root", str(repo), "--format", "json"])
+    payload = json.loads(result.output)
+    by_id = {c["id"]: c for c in payload["clients"]}
+    assert by_id["cursor"]["detected"] is True
+    assert by_id["claude-desktop"]["detected"] is True
+    assert by_id["continue"]["detected"] is True
+    # Unseeded clients remain missing.
+    assert by_id["zed"]["detected"] is False
+    assert by_id["windsurf"]["detected"] is False
+
+
+def test_detect_pretty_format_renders_table(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    result = runner.invoke(clients_app, ["detect", "--repo-root", str(repo)])
+    assert result.exit_code == 0
+    assert "MCP clients" in result.output
+    assert "Cursor" in result.output
+
+
+# ---------------------------------------------------------------------------
+# install
+# ---------------------------------------------------------------------------
+
+
+def test_install_writes_to_cursor(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    result = runner.invoke(
+        clients_app,
+        ["install", "cursor", "--repo-root", str(repo), "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["results"][0]["client_id"] == "cursor"
+    assert payload["results"][0]["action"] in ("added", "updated")
+    config_path = Path(payload["results"][0]["path"])
+    assert config_path.exists()
+    blob = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "vaner" in blob["mcpServers"]
+    assert blob["mcpServers"]["vaner"]["command"] == "/fake/bin/vaner"
+
+
+def test_install_all_writes_to_every_detected(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    _seed_claude_desktop(fake_home)
+    result = runner.invoke(
+        clients_app,
+        ["install", "--all", "--repo-root", str(repo), "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ids = [r["client_id"] for r in payload["results"]]
+    assert "cursor" in ids
+    assert "claude-desktop" in ids
+
+
+def test_install_idempotent_when_entry_present(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    runner.invoke(clients_app, ["install", "cursor", "--repo-root", str(repo)])
+    second = runner.invoke(
+        clients_app,
+        ["install", "cursor", "--repo-root", str(repo), "--format", "json"],
+    )
+    payload = json.loads(second.output)
+    assert payload["results"][0]["action"] == "skipped"
+
+
+def test_install_preserves_user_other_servers(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    cursor_cfg = fake_home / ".cursor" / "mcp.json"
+    cursor_cfg.write_text(
+        json.dumps({"mcpServers": {"github": {"command": "/usr/local/bin/gh-mcp", "args": []}}}, indent=2),
+        encoding="utf-8",
+    )
+    result = runner.invoke(clients_app, ["install", "cursor", "--repo-root", str(repo)])
+    assert result.exit_code == 0
+    blob = json.loads(cursor_cfg.read_text(encoding="utf-8"))
+    assert "github" in blob["mcpServers"], "user's other MCP servers must survive install"
+    assert "vaner" in blob["mcpServers"]
+
+
+def test_install_dry_run_does_not_write(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    config_path = fake_home / ".cursor" / "mcp.json"
+    assert not config_path.exists()
+    result = runner.invoke(
+        clients_app,
+        ["install", "cursor", "--repo-root", str(repo), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    # The config file must NOT exist after a dry-run.
+    assert not config_path.exists(), "dry-run must not write any files"
+
+
+def test_install_unknown_client_errors(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(clients_app, ["install", "nonsense", "--repo-root", str(repo)])
+    assert result.exit_code != 0
+    assert "unknown client" in result.output.lower() or "Known:" in result.output
+
+
+def test_install_requires_name_or_all(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(clients_app, ["install", "--repo-root", str(repo)])
+    assert result.exit_code != 0
+
+
+def test_install_claude_desktop_uses_repo_scoped_server_key(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _seed_claude_desktop(fake_home)
+    result = runner.invoke(
+        clients_app,
+        ["install", "claude-desktop", "--repo-root", str(repo)],
+    )
+    assert result.exit_code == 0
+    cfg = fake_home / ".config" / "Claude" / "claude_desktop_config.json"
+    blob = json.loads(cfg.read_text(encoding="utf-8"))
+    # Wizard convention: vaner-<reponame> so multiple repos coexist.
+    assert "vaner-myrepo" in blob["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# uninstall
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_removes_only_vaner_entries(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    cursor_cfg = fake_home / ".cursor" / "mcp.json"
+    cursor_cfg.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "github": {"command": "/usr/local/bin/gh-mcp", "args": []},
+                    "vaner": {"command": "/fake/bin/vaner", "args": ["mcp", "--path", "."]},
+                }
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        clients_app,
+        ["uninstall", "cursor", "--repo-root", str(repo)],
+    )
+    assert result.exit_code == 0
+    blob = json.loads(cursor_cfg.read_text(encoding="utf-8"))
+    assert "vaner" not in blob["mcpServers"]
+    assert "github" in blob["mcpServers"]
+
+
+def test_uninstall_when_no_entry_skips_cleanly(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    # No vaner entry; just an empty config.
+    cfg = fake_home / ".cursor" / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {}}, indent=2), encoding="utf-8")
+    result = runner.invoke(
+        clients_app,
+        ["uninstall", "cursor", "--repo-root", str(repo), "--format", "json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["results"][0]["action"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# doctor — launcher drift
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_clean_when_no_drift(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    runner.invoke(clients_app, ["install", "cursor", "--repo-root", str(repo)])
+    result = runner.invoke(
+        clients_app,
+        ["doctor", "--repo-root", str(repo), "--format", "json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["drift_count"] == 0
+
+
+def test_doctor_detects_launcher_drift(fake_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_cursor(fake_home, repo)
+    runner.invoke(clients_app, ["install", "cursor", "--repo-root", str(repo)])
+    # Now simulate `vaner` moving (e.g. uv → pipx reinstall).
+    monkeypatch.setattr(
+        "vaner.cli.commands.mcp_clients.shutil.which",
+        lambda name: "/new/bin/vaner" if name == "vaner" else None,
+    )
+    result = runner.invoke(
+        clients_app,
+        ["doctor", "--repo-root", str(repo), "--format", "json"],
+    )
+    assert result.exit_code != 0  # non-zero exit signals drift to CI
+    payload = json.loads(result.output)
+    assert payload["drift_count"] >= 1
+    cursor_drift = next(d for d in payload["drift"] if d["client_id"] == "cursor")
+    assert cursor_drift["drift"] is True
+    assert cursor_drift["current_in_config"] == "/fake/bin/vaner"
+    assert cursor_drift["expected"] == "/new/bin/vaner"
+
+
+# ---------------------------------------------------------------------------
+# Top-level command registration
+# ---------------------------------------------------------------------------
+
+
+def test_clients_subapp_registered_on_top_level_app() -> None:
+    result = runner.invoke(app, ["clients", "--help"])
+    assert result.exit_code == 0
+    assert "MCP clients" in result.output or "mcp clients" in result.output.lower()

--- a/tests/test_cli/test_clients_subcommand.py
+++ b/tests/test_cli/test_clients_subcommand.py
@@ -43,8 +43,16 @@ def _seed_cursor(home: Path, repo_root: Path) -> None:
 
 
 def _seed_claude_desktop(home: Path) -> None:
-    # Linux path on the fake home.
-    (home / ".config" / "Claude").mkdir(parents=True, exist_ok=True)
+    """Seed Claude Desktop's config dir at whatever path the detection
+    helper looks at on the current OS — `~/Library/Application
+    Support/Claude` on macOS, `~/.config/Claude` on Linux,
+    `%APPDATA%\\Claude` on Windows. Without this dispatch the test would
+    pass on Linux runners and fail on macOS.
+    """
+    from vaner.cli.commands import mcp_clients
+
+    target_dir = mcp_clients._claude_desktop_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
 
 
 def _seed_continue(home: Path) -> None:
@@ -208,6 +216,8 @@ def test_install_requires_name_or_all(fake_home: Path, tmp_path: Path) -> None:
 
 
 def test_install_claude_desktop_uses_repo_scoped_server_key(fake_home: Path, tmp_path: Path) -> None:
+    from vaner.cli.commands import mcp_clients
+
     repo = tmp_path / "myrepo"
     repo.mkdir()
     _seed_claude_desktop(fake_home)
@@ -216,7 +226,9 @@ def test_install_claude_desktop_uses_repo_scoped_server_key(fake_home: Path, tmp
         ["install", "claude-desktop", "--repo-root", str(repo)],
     )
     assert result.exit_code == 0
-    cfg = fake_home / ".config" / "Claude" / "claude_desktop_config.json"
+    # Resolve the platform-canonical config path the same way the daemon
+    # does, so this test passes on macOS + Linux + Windows runners alike.
+    cfg = mcp_clients._claude_desktop_dir() / "claude_desktop_config.json"
     blob = json.loads(cfg.read_text(encoding="utf-8"))
     # Wizard convention: vaner-<reponame> so multiple repos coexist.
     assert "vaner-myrepo" in blob["mcpServers"]

--- a/tests/test_mcp_apps/test_cross_client.py
+++ b/tests/test_mcp_apps/test_cross_client.py
@@ -63,10 +63,23 @@ _CASES = [
         ClientCapabilityTier.TIER_2,
         {"roots": SimpleNamespace(listChanged=True)},
     ),
+    # Cursor pre-2.6 — MCP-aware but no UI extension. Tier 2.
     (
-        "cursor",
+        "cursor_pre_2_6",
         ClientCapabilityTier.TIER_2,
         {"sampling": SimpleNamespace()},
+    ),
+    # Cursor 2.6+ ships MCP Apps support. Detection is value-driven (we
+    # match on the experimental UI key, not the client name) so the same
+    # capability-detection code automatically promotes Cursor to Tier-4
+    # the moment it advertises the extension. This case pins the contract.
+    (
+        "cursor_2_6_ui",
+        ClientCapabilityTier.TIER_4,
+        {
+            "experimental": {"io.modelcontextprotocol/ui": {"version": 1}},
+            "sampling": SimpleNamespace(),
+        },
     ),
     (
         "vscode_copilot",


### PR DESCRIPTION
Stacks on #167. New `vaner clients {detect, install, uninstall, status, doctor}` sub-app exposes the existing 10-client mcp_clients registry as a non-interactive surface for desktop apps + CI. Idempotent, JSON-format contract for tooling, launcher-drift detection. Plus Cursor 2.6 matrix split (now Tier-4 when it advertises MCP Apps UI). 16 new tests; existing init/mcp_clients regressions clean. Foundation for WS12-B (docs), WS12-C (macOS pane), WS12-D (Linux pane). 🤖 Generated with Claude Code