### PR TITLE
fix(release): call SLSA generator by tag, not SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,12 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # slsa-github-generator REQUIRES a tag-form ref here — it verifies its own
+    # provenance against the tag at runtime and exits with `Invalid ref: <sha>`
+    # when called by SHA. This is the only reusable-workflow uses: line in the
+    # repo that intentionally bypasses the SHA-pin policy. See the project's
+    # SECURITY.md / RELEASE.md for the rationale.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.publish.outputs.slsa_subjects }}
       upload-assets: true


### PR DESCRIPTION
## Summary

- The `slsa-github-generator` reusable workflow refuses to run when called by SHA — it verifies its own provenance against the tag at runtime and fails with `Invalid ref: <sha>. Expected ref of the form refs/tags/vX.Y.Z`.
- The SHA pin (zizmor/actionlint compliance) was actively breaking every release since v0.8.3.
- Switched the one offending `uses:` line to `@v2.1.0`. Every other reusable workflow in the repo stays SHA-pinned. The exception is documented inline.

## Refs

- https://github.com/slsa-framework/slsa-github-generator/blob/main/RELEASE.md ("calling by SHA is not supported")

## Impact on v0.8.5

v0.8.5 IS published with cosign + `attest-build-provenance@v3` + `attest-sbom` attestations on every artifact (the publish job succeeded; only the supplementary SLSA-3 reusable workflow failed). After this lands, v0.8.6+ will additionally produce the SLSA-3 `.intoto.jsonl` provenance file.

## Test plan

- [x] `actionlint` passes locally on the diff (only line touched is the `uses:` directive).
- [ ] Next tag push triggers `Release` workflow to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)