### PR TITLE
feat(setup): 0.8.6 WS1 — setup primitives + config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+#### Setup primitives + config schema (0.8.6 WS1)
+- **`src/vaner/setup/` module** — outcome-level configuration surface for the 0.8.6 Simple Mode wizard. Five `Literal` type aliases — `WorkStyle`, `Priority`, `ComputePosture`, `CloudPosture`, `BackgroundPosture` — plus a shared `HardwareTier` alias declared here for WS2 to populate via `tier_for()`.
+- **`SetupAnswers`** frozen dataclass (`src/vaner/setup/answers.py`) — immutable record of one wizard run, with `__post_init__` validation that rejects empty `work_styles` (the engine has no priors to average without at least one selection).
+- **`VanerPolicyBundle`** frozen dataclass (`src/vaner/setup/policy.py`) — outcome-level policy archetype. Carries cloud posture, runtime profile, spend profile, latency profile, privacy profile, four-key prediction-horizon-bias mapping, drafting aggressiveness, exploration ratio, persistence strength, goal weighting, context-injection default, and Deep-Run profile. Mapping keys are validated and frozen into a `MappingProxyType` view at construction time.
+- **`PROFILE_CATALOG`** (`src/vaner/setup/catalog.py`) — the seven shipped bundles per spec §9: `local_lightweight`, `local_balanced`, `local_heavy`, `hybrid_balanced`, `hybrid_quality`, `cost_saver`, `deep_research`. Plus `bundle_by_id()` lookup helper that raises `KeyError` (not a swallowed `None`) on unknown ids.
+- **`SetupConfig` and `PolicyConfig` Pydantic models** (`src/vaner/models/config.py`) — added to `VanerConfig` with default factories. `setup` carries the wizard answers + `mode` + `completed_at` first-run marker + schema `version`. `policy` carries `selected_bundle_id` (default `"hybrid_balanced"`), `bundle_overrides`, and `auto_select`.
+
+### Removed
+- **`IntentConfig.domain`** field — the unused `Literal["coding","research","writing","ops"]` field is removed outright (zero callers; no external users to migrate). Superseded by the multi-select `setup.work_styles` field on `SetupConfig`. CHANGELOG is the only record needed.
+
 ## [0.8.4] - 2026-04-24
 
 ### Added

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    Priority,
+    WorkStyle,
+)
 
 
 class PrivacyConfig(BaseModel):
@@ -171,7 +180,11 @@ class IntentConfig(BaseModel):
     lookback_turns: int = 8
     skills_loop_enabled: bool = True
     max_feedback_events_per_cycle: int = 5
-    domain: Literal["coding", "research", "writing", "ops"] = "coding"
+    # 0.8.6 WS1 — the previous ``domain`` field
+    # (``Literal["coding","research","writing","ops"]``) is removed.
+    # It had zero callers and is superseded by the multi-select
+    # ``setup.work_styles`` field on :class:`SetupConfig`. See the
+    # 0.8.6 CHANGELOG entry under "Removed".
     embedding_classifier_enabled: bool = True
     cross_workspace_profile: bool = False
 
@@ -616,6 +629,67 @@ class RefinementConfig(BaseModel):
     adoption_pending_confirm_seconds: float = Field(default=600.0, ge=0.0)
 
 
+class SetupConfig(BaseModel):
+    """``[setup]`` — Simple-Mode wizard state (0.8.6 WS1).
+
+    Holds the answers from one completed wizard run plus a few
+    bookkeeping fields. ``mode`` distinguishes the Simple-Mode
+    (outcome-level questions) surface from the Advanced-Mode (full
+    knob-level config) surface; both are simultaneously valid (the
+    user can flip back and forth from the desktop UI). ``completed_at``
+    marks first-run state — when ``None``, the engine treats this as a
+    fresh install and triggers the wizard on first interaction.
+
+    Configs without a ``[setup]`` section get all defaults at load
+    time, which means ``mode="simple"`` and the no-op ``["mixed"]``
+    work-style. There is no migration path from a legacy
+    ``IntentConfig.domain`` field — that field is removed outright in
+    0.8.6 (see CHANGELOG entry).
+    """
+
+    mode: Literal["simple", "advanced"] = "simple"
+    work_styles: list[WorkStyle] = Field(default_factory=lambda: ["mixed"])  # type: ignore[arg-type]
+    # ^ mypy can't see through the Literal narrowing inside the lambda;
+    # the runtime list ["mixed"] is a perfectly valid list[WorkStyle].
+    priority: Priority = "balanced"
+    compute_posture: ComputePosture = "balanced"
+    cloud_posture: CloudPosture = "ask_first"
+    background_posture: BackgroundPosture = "normal"
+    completed_at: datetime | None = None
+    """ISO timestamp of the most recent wizard completion. ``None``
+    means the wizard has never been run on this config; first-run
+    surfaces use this to decide whether to prompt."""
+    version: int = 1
+    """Schema-migration anchor for future ``[setup]`` extensions.
+    Bumped only when a backwards-incompatible field change lands."""
+
+
+class PolicyConfig(BaseModel):
+    """``[policy]`` — selected policy bundle and per-knob overrides
+    (0.8.6 WS1).
+
+    ``selected_bundle_id`` is the foreign key into
+    :data:`vaner.setup.catalog.PROFILE_CATALOG`. The default
+    ``"hybrid_balanced"`` is the safe middle path used when the
+    wizard has not run yet.
+
+    ``bundle_overrides`` is a free-form dict for per-knob user
+    overrides on top of the selected bundle. Keys are bundle field
+    names; values are the override values. WS5's ``apply_policy_bundle``
+    composes bundle defaults → user overrides → Deep-Run session
+    deltas.
+
+    ``auto_select`` controls whether the engine re-runs WS3's
+    selection algorithm when hardware changes (e.g. desktop → battery,
+    GPU added/removed). When ``False`` (user pinned the bundle), the
+    engine emits a warning but does not re-select.
+    """
+
+    selected_bundle_id: str = "hybrid_balanced"
+    bundle_overrides: dict[str, Any] = Field(default_factory=dict)
+    auto_select: bool = True
+
+
 class VanerConfig(BaseModel):
     repo_root: Path
     store_path: Path
@@ -634,3 +708,5 @@ class VanerConfig(BaseModel):
     sources: SourcesConfig = Field(default_factory=SourcesConfig)
     refinement: RefinementConfig = Field(default_factory=RefinementConfig)
     integrations: IntegrationsConfig = Field(default_factory=IntegrationsConfig)
+    setup: SetupConfig = Field(default_factory=SetupConfig)
+    policy: PolicyConfig = Field(default_factory=PolicyConfig)

--- a/src/vaner/setup/__init__.py
+++ b/src/vaner/setup/__init__.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vaner setup primitives — Simple-Mode wizard data model (0.8.6).
+
+This package owns the outcome-level configuration surface introduced in
+0.8.6:
+
+- :mod:`vaner.setup.enums` — ``WorkStyle`` / ``Priority`` /
+  ``ComputePosture`` / ``CloudPosture`` / ``BackgroundPosture`` /
+  ``HardwareTier`` literal aliases.
+- :mod:`vaner.setup.answers` — :class:`SetupAnswers` dataclass, the
+  immutable record of one wizard run.
+- :mod:`vaner.setup.policy` — :class:`VanerPolicyBundle` dataclass.
+- :mod:`vaner.setup.catalog` — :data:`PROFILE_CATALOG` (the seven
+  shipped bundles) and the ``bundle_by_id()`` lookup helper.
+
+Hardware detection (:mod:`vaner.setup.hardware`), the selection
+algorithm (:mod:`vaner.setup.select`), and the policy applicator
+(:mod:`vaner.setup.apply`) land in subsequent 0.8.6 work streams.
+
+Note: this ``__init__`` deliberately re-exports *only* the leaf modules
+that have no dependency on the engine stack (``enums``, ``answers``).
+Importing :class:`VanerPolicyBundle` or the catalogue requires
+explicit submodule imports — ``from vaner.setup.policy import …`` —
+because :mod:`vaner.setup.policy` depends transitively on
+:mod:`vaner.intent.deep_run` and would create an import cycle if
+re-exported from here while :mod:`vaner.models.config` also imports
+from this package.
+"""
+
+from __future__ import annotations
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    HardwareTier,
+    Priority,
+    WorkStyle,
+)
+
+__all__ = [
+    "BackgroundPosture",
+    "CloudPosture",
+    "ComputePosture",
+    "HardwareTier",
+    "Priority",
+    "SetupAnswers",
+    "WorkStyle",
+]

--- a/src/vaner/setup/answers.py
+++ b/src/vaner/setup/answers.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: SetupAnswers dataclass (0.8.6).
+
+``SetupAnswers`` is the immutable record of one completed Simple-Mode
+wizard run. It is the input to WS3's ``select_policy_bundle()`` and is
+persisted (in normal-form, on the ``[setup]`` section of
+``.vaner/config.toml``) so the engine can re-run selection on hardware
+changes without re-prompting the user.
+
+Validation in ``__post_init__`` enforces the *only* invariant Simple Mode
+cannot recover from: empty ``work_styles``. The engine has no priors to
+average if no work styles were selected; UI surfaces are responsible for
+forcing at least one selection (defaulting to ``"mixed"`` when the user
+has no preference). All other fields are scalar enums and validated by
+their ``Literal`` types when loaded through Pydantic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    Priority,
+    WorkStyle,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SetupAnswers:
+    """Immutable record of one completed Simple-Mode wizard run.
+
+    ``work_styles`` is a tuple (not a list) so the dataclass remains
+    hashable and properly frozen. The wizard surface accepts a list and
+    converts at the boundary.
+    """
+
+    work_styles: tuple[WorkStyle, ...]
+    priority: Priority
+    compute_posture: ComputePosture
+    cloud_posture: CloudPosture
+    background_posture: BackgroundPosture
+
+    def __post_init__(self) -> None:
+        if not self.work_styles:
+            raise ValueError(
+                "SetupAnswers.work_styles must contain at least one WorkStyle; "
+                "the engine has no priors to average if no work styles are selected. "
+                'Pass ("mixed",) when the user has no preference.'
+            )
+
+
+__all__ = ["SetupAnswers"]

--- a/src/vaner/setup/catalog.py
+++ b/src/vaner/setup/catalog.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: PROFILE_CATALOG (0.8.6).
+
+The seven shipped policy bundles per spec §9. This is the single source
+of truth — desktop apps, the CLI wizard, the cockpit summary card, and
+the MCP/HTTP setup tools all read from this tuple.
+
+Numeric values for the per-bundle multipliers (drafting_aggressiveness,
+exploration_ratio, persistence_strength, goal_weighting,
+prediction_horizon_bias) are calibrated against the Deep-Run preset
+table (see :mod:`vaner.intent.deep_run_policy`) so that bundle defaults
+compose multiplicatively with any Deep-Run session deltas without
+double-application.
+
+Bundle scale:
+
+- ``drafting_aggressiveness``: ``0.7`` (cautious) → ``1.3`` (eager).
+  Multiplier on the drafter evidence threshold.
+- ``exploration_ratio``: ``-0.10`` (exploit-leaning) → ``+0.15``
+  (explore-leaning). Additive bias on top of base exploration weights.
+- ``persistence_strength``: ``0.6`` (decay fast) → ``1.5`` (decay
+  slow). Multiplier on memory retention.
+- ``goal_weighting``: ``0.8`` → ``1.4``. Multiplier on goal-aligned
+  prediction scoring.
+- ``prediction_horizon_bias``: weights sum *roughly* to 4.0 across the
+  four buckets; the engine normalises before applying.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from vaner.setup.policy import VanerPolicyBundle
+
+# ---------------------------------------------------------------------------
+# Bundle definitions. Order matches spec §9 narrative; ids are the
+# stable foreign key persisted to ``PolicyConfig.selected_bundle_id``.
+# ---------------------------------------------------------------------------
+
+
+_LOCAL_LIGHTWEIGHT = VanerPolicyBundle(
+    # Target user: laptop on battery, integrated GPU, wants Vaner to
+    # not heat the room. Local-only by default; minimal background.
+    id="local_lightweight",
+    label="Local Lightweight",
+    description=("Run entirely on this device with a small local model. Best for older laptops, battery, and privacy-first users."),
+    local_cloud_posture="local_only",
+    runtime_profile="small",
+    spend_profile="zero",
+    latency_profile="snappy",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.4,
+        "long_horizon": 0.8,
+        "finish_partials": 1.2,
+        "balanced": 0.6,
+    },
+    drafting_aggressiveness=0.8,
+    exploration_ratio=-0.05,
+    persistence_strength=0.7,
+    goal_weighting=1.0,
+    context_injection_default="digest_only",
+    deep_run_profile="conservative",
+)
+
+
+_LOCAL_BALANCED = VanerPolicyBundle(
+    # Target user: capable laptop or desktop, mid-tier local model
+    # (e.g. 7-13B). Local-first but willing to ponder more in the
+    # background. Default for the "Capable" hardware tier.
+    id="local_balanced",
+    label="Local Balanced",
+    description=("Local-first with a mid-sized model. Solid default for a capable laptop or desktop with no cloud reliance."),
+    local_cloud_posture="local_preferred",
+    runtime_profile="medium",
+    spend_profile="zero",
+    latency_profile="balanced",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.0,
+        "finish_partials": 1.0,
+        "balanced": 1.0,
+    },
+    drafting_aggressiveness=1.0,
+    exploration_ratio=0.0,
+    persistence_strength=1.0,
+    goal_weighting=1.0,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="balanced",
+)
+
+
+_LOCAL_HEAVY = VanerPolicyBundle(
+    # Target user: workstation or homelab with a large local model
+    # (e.g. 30-70B at Q4+). Local-only, but Vaner is allowed to ponder
+    # aggressively because the box can take it.
+    id="local_heavy",
+    label="Local Heavy",
+    description=("All-local with a large model and aggressive background pondering. Built for workstations and homelab GPUs."),
+    local_cloud_posture="local_only",
+    runtime_profile="large",
+    spend_profile="zero",
+    latency_profile="quality",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.4,
+        "finish_partials": 1.0,
+        "balanced": 1.2,
+    },
+    drafting_aggressiveness=1.1,
+    exploration_ratio=0.10,
+    persistence_strength=1.3,
+    goal_weighting=1.2,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="aggressive",
+)
+
+
+_HYBRID_BALANCED = VanerPolicyBundle(
+    # Target user: anyone who's fine with the engine reaching for a
+    # cloud model when local is genuinely insufficient. The default
+    # bundle for first-run when hardware tier is unknown — safe
+    # middle path.
+    id="hybrid_balanced",
+    label="Hybrid Balanced",
+    description=("Local for everyday work, cloud only when it's clearly worth it. Recommended default for most users."),
+    local_cloud_posture="hybrid",
+    runtime_profile="medium",
+    spend_profile="low",
+    latency_profile="balanced",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.1,
+        "finish_partials": 1.0,
+        "balanced": 1.0,
+    },
+    drafting_aggressiveness=1.0,
+    exploration_ratio=0.05,
+    persistence_strength=1.0,
+    goal_weighting=1.0,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="balanced",
+)
+
+
+_HYBRID_QUALITY = VanerPolicyBundle(
+    # Target user: serious work where the user is willing to spend on
+    # cloud capacity to get the best result. Still hybrid, but the
+    # cloud bias is set higher and the latency profile prioritises
+    # quality over snappiness.
+    id="hybrid_quality",
+    label="Hybrid Quality",
+    description=("Reach for the best available model — local or cloud — and trade some snappiness and budget for higher answer quality."),
+    local_cloud_posture="cloud_preferred",
+    runtime_profile="large",
+    spend_profile="medium",
+    latency_profile="quality",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 0.9,
+        "long_horizon": 1.4,
+        "finish_partials": 1.0,
+        "balanced": 1.1,
+    },
+    drafting_aggressiveness=1.2,
+    exploration_ratio=0.10,
+    persistence_strength=1.2,
+    goal_weighting=1.2,
+    context_injection_default="top_match_auto_include",
+    deep_run_profile="balanced",
+)
+
+
+_COST_SAVER = VanerPolicyBundle(
+    # Target user: cost-conscious user who still wants some hybrid
+    # capacity. Tightens spend cap and prefers the cheapest endpoint
+    # that meets the latency / context floor.
+    id="cost_saver",
+    label="Cost Saver",
+    description=("Hybrid setup with tight cloud spend caps. Prefers the cheapest endpoint that still meets the bar."),
+    local_cloud_posture="local_preferred",
+    runtime_profile="small",
+    spend_profile="low",
+    latency_profile="balanced",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 1.2,
+        "long_horizon": 0.9,
+        "finish_partials": 1.1,
+        "balanced": 0.8,
+    },
+    drafting_aggressiveness=0.9,
+    exploration_ratio=-0.05,
+    persistence_strength=0.9,
+    goal_weighting=1.0,
+    context_injection_default="adopted_package_only",
+    deep_run_profile="conservative",
+)
+
+
+_DEEP_RESEARCH = VanerPolicyBundle(
+    # Target user: long-horizon research / writing work where Vaner
+    # should ponder broadly and persistently. Overnight Deep-Run is the
+    # natural mode; daytime use composes the bundle's bias with the
+    # active session's preset.
+    id="deep_research",
+    label="Deep Research",
+    description=("Long-horizon, broad exploration for research and writing. Persists predictions longer and prefers depth over speed."),
+    local_cloud_posture="hybrid",
+    runtime_profile="large",
+    spend_profile="medium",
+    latency_profile="quality",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 0.7,
+        "long_horizon": 1.6,
+        "finish_partials": 1.1,
+        "balanced": 1.2,
+    },
+    drafting_aggressiveness=1.1,
+    exploration_ratio=0.15,
+    persistence_strength=1.5,
+    goal_weighting=1.4,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="aggressive",
+)
+
+
+PROFILE_CATALOG: Final[tuple[VanerPolicyBundle, ...]] = (
+    _LOCAL_LIGHTWEIGHT,
+    _LOCAL_BALANCED,
+    _LOCAL_HEAVY,
+    _HYBRID_BALANCED,
+    _HYBRID_QUALITY,
+    _COST_SAVER,
+    _DEEP_RESEARCH,
+)
+
+
+# Internal id-keyed lookup map. Built once at import time so
+# ``bundle_by_id`` is O(1). Not exported — callers should use the
+# helper, which gives a clearer error message on miss.
+_BY_ID: Final[dict[str, VanerPolicyBundle]] = {bundle.id: bundle for bundle in PROFILE_CATALOG}
+
+
+def bundle_by_id(bundle_id: str) -> VanerPolicyBundle:
+    """Return the bundle with the given id.
+
+    Raises :class:`KeyError` (with a helpful message) if no bundle in
+    :data:`PROFILE_CATALOG` matches. The engine should never silently
+    fall back to a default for an unknown id — that would mask a
+    config-shape bug or a corrupted ``.vaner/config.toml``.
+    """
+
+    try:
+        return _BY_ID[bundle_id]
+    except KeyError as exc:
+        known = ", ".join(sorted(_BY_ID))
+        raise KeyError(f"unknown bundle id {bundle_id!r}; known ids: {known}") from exc
+
+
+__all__ = [
+    "PROFILE_CATALOG",
+    "bundle_by_id",
+]

--- a/src/vaner/setup/enums.py
+++ b/src/vaner/setup/enums.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: enums (0.8.6).
+
+These ``Literal`` type aliases are the single source of truth for the
+outcome-level question vocabulary surfaced by Simple Mode (CLI wizard,
+desktop apps, MCP/HTTP setup tools). Each alias matches one question in
+the five-step Simple-Mode flow described in the 0.8.6 spec §5:
+
+- ``WorkStyle`` — multi-select. What kind of work do you want help with?
+  ("writing", "research", "planning", "support", "learning", "coding",
+  "general", "mixed", "unsure"). The engine averages priors when more
+  than one work style is selected.
+- ``Priority`` — single-select. What matters most? ("balanced", "speed",
+  "quality", "privacy", "cost", "low_resource").
+- ``ComputePosture`` — single-select. How hard should this machine work
+  for you? ("light", "balanced", "available_power").
+- ``CloudPosture`` — single-select. How do you feel about cloud LLMs?
+  ("local_only", "ask_first", "hybrid_when_worth_it",
+  "best_available").
+- ``BackgroundPosture`` — single-select. How aggressive should
+  background pondering be? ("minimal", "normal", "idle_more",
+  "deep_run_aggressive").
+- ``HardwareTier`` — output of WS2's ``tier_for()`` mapping. Declared
+  here so all of WS1+WS2+WS3 share one definition.
+
+We use ``Literal`` aliases rather than ``enum.Enum`` classes to match the
+existing codebase pattern (see ``DeepRunPreset`` / ``DeepRunFocus`` /
+``DeepRunHorizonBias`` in :mod:`vaner.intent.deep_run`). The aliases
+participate naturally in Pydantic validation, JSON serialisation, and
+``ts-rs`` codegen on the ``vaner-contract`` side.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+WorkStyle = Literal[
+    "writing",
+    "research",
+    "planning",
+    "support",
+    "learning",
+    "coding",
+    "general",
+    "mixed",
+    "unsure",
+]
+
+Priority = Literal[
+    "balanced",
+    "speed",
+    "quality",
+    "privacy",
+    "cost",
+    "low_resource",
+]
+
+ComputePosture = Literal[
+    "light",
+    "balanced",
+    "available_power",
+]
+
+CloudPosture = Literal[
+    "local_only",
+    "ask_first",
+    "hybrid_when_worth_it",
+    "best_available",
+]
+
+BackgroundPosture = Literal[
+    "minimal",
+    "normal",
+    "idle_more",
+    "deep_run_aggressive",
+]
+
+# Declared here for shared use across WS1 (config schema) and WS2
+# (hardware detection / tier_for()). WS2 owns the mapping logic.
+HardwareTier = Literal[
+    "light",
+    "capable",
+    "high_performance",
+    "unknown",
+]
+
+
+__all__ = [
+    "BackgroundPosture",
+    "CloudPosture",
+    "ComputePosture",
+    "HardwareTier",
+    "Priority",
+    "WorkStyle",
+]

--- a/src/vaner/setup/policy.py
+++ b/src/vaner/setup/policy.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: VanerPolicyBundle dataclass (0.8.6).
+
+A *policy bundle* is the intermediate layer between Simple-Mode wizard
+answers and the engine's existing knobs. Each bundle:
+
+- Names an outcome-level archetype (e.g. *"Local Balanced"*, *"Hybrid
+  Quality"*) that a non-technical user can recognise.
+- Carries the seven dimensions the engine actually consults
+  (cloud posture, runtime profile, spend profile, latency profile,
+  privacy profile, prediction-horizon bias, drafting aggressiveness,
+  exploration ratio, persistence strength, goal weighting,
+  context-injection default, deep-run profile).
+- Composes additively with Deep-Run preset overrides at session start
+  (see :mod:`vaner.intent.deep_run_policy`); bundles set the *baseline*,
+  Deep-Run sessions layer additive overrides on top.
+
+The single source of truth for the seven shipped bundles is
+:data:`vaner.setup.catalog.PROFILE_CATALOG`. WS3's selection algorithm
+filters and scores that catalogue against the user's
+:class:`SetupAnswers` and :class:`HardwareProfile`.
+
+The bundle dataclass is **frozen**: bundles are pure data, never mutated.
+``PolicyConfig.bundle_overrides`` (a free-form dict on the config
+schema) carries the user's per-knob deviations from the selected
+bundle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+from vaner.intent.deep_run import DeepRunPreset
+
+# Mirror of ``ContextInjectionConfig.mode`` (see
+# :mod:`vaner.models.config`). Repeated here verbatim because the source
+# Literal is declared inline on the field rather than as a named alias.
+# Keep these two lists in sync; a mismatch surfaces as a Pydantic
+# validation error when the bundle's value flows into the integration
+# config.
+ContextInjectionMode = Literal[
+    "none",
+    "digest_only",
+    "adopted_package_only",
+    "top_match_auto_include",
+    "policy_hybrid",
+    "client_controlled",
+]
+
+# The four horizon-bias buckets surfaced to the engine's frontier
+# scoring. These are the same four values used by Deep-Run's
+# ``HorizonBiasSpec`` (see :mod:`vaner.intent.deep_run_policy`); the
+# bundle's ``prediction_horizon_bias`` mapping is a per-bundle weight
+# distribution over these buckets, *not* a single chosen mode. The
+# engine multiplies these weights into its frontier scoring at cycle
+# time.
+PredictionHorizonKey = Literal[
+    "likely_next",
+    "long_horizon",
+    "finish_partials",
+    "balanced",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class VanerPolicyBundle:
+    """One outcome-level policy bundle.
+
+    Field meanings (spec §8):
+
+    - ``id`` — stable kebab-case identifier; used as the foreign key in
+      ``PolicyConfig.selected_bundle_id``. Never displayed to users.
+    - ``label`` — short human-readable name (Title Case). Shown in the
+      desktop summary card and the CLI ``vaner setup show`` output.
+    - ``description`` — one-sentence explanation of who the bundle is
+      for. Shown under the label in any surface that has the room.
+    - ``local_cloud_posture`` — flows into ``BackendConfig.prefer_local``,
+      the ``ExplorationConfig.endpoints`` cloud filter, and the
+      Deep-Run default ``locality``.
+    - ``runtime_profile`` — selects the local-runtime preference band
+      (``"small"`` / ``"medium"`` / ``"large"``) the exploration pool
+      consults when more than one local model is detected.
+    - ``spend_profile`` — drives ``BackendConfig.remote_budget_per_hour``
+      and the Deep-Run default ``cost_cap_usd``.
+    - ``latency_profile`` — informs the exploration pool's
+      latency-vs-quality tie-break.
+    - ``privacy_profile`` — interacts with cloud_posture; sets the
+      strictness floor that the user cannot accidentally relax via a
+      bundle re-selection (see WS5 invariant test).
+    - ``prediction_horizon_bias`` — frozen mapping over the four
+      horizon-bias keys; weights compose multiplicatively with
+      Deep-Run's ``HorizonBiasSpec`` at session time.
+    - ``drafting_aggressiveness`` — multiplier on the drafter's
+      evidence threshold. ``1.0`` is neutral; ``< 1.0`` requires more
+      evidence (conservative drafts), ``> 1.0`` is more permissive.
+    - ``exploration_ratio`` — added to ``ExplorationConfig`` invest /
+      exploit balance.
+    - ``persistence_strength`` — multiplier on memory-decay resistance;
+      higher values keep predictions warm longer.
+    - ``goal_weighting`` — multiplier on goal-aligned prediction
+      scoring (see ``IntentConfig`` goal-weighting in 0.8.2+).
+    - ``context_injection_default`` — per-tier default for
+      ``IntegrationsConfig.context_injection.mode``. Capability tiers
+      may downgrade this floor at run time.
+    - ``deep_run_profile`` — default Deep-Run preset when the user
+      opens "Start Deep-Run".
+    """
+
+    id: str
+    label: str
+    description: str
+    local_cloud_posture: Literal[
+        "local_only",
+        "local_preferred",
+        "hybrid",
+        "cloud_preferred",
+    ]
+    runtime_profile: Literal["small", "medium", "large", "auto"]
+    spend_profile: Literal["zero", "low", "medium", "high"]
+    latency_profile: Literal["snappy", "balanced", "quality"]
+    privacy_profile: Literal["strict", "standard", "relaxed"]
+    prediction_horizon_bias: Mapping[PredictionHorizonKey, float]
+    drafting_aggressiveness: float
+    exploration_ratio: float
+    persistence_strength: float
+    goal_weighting: float
+    context_injection_default: ContextInjectionMode
+    deep_run_profile: DeepRunPreset
+
+    # Internal: bundles are intended to be defined as module-level
+    # constants. The ``__post_init__`` freeze step ensures any
+    # ``prediction_horizon_bias`` passed as a plain ``dict`` is wrapped
+    # in a ``MappingProxyType`` so the bundle remains structurally
+    # immutable (the dataclass itself is already frozen against
+    # attribute reassignment).
+    def __post_init__(self) -> None:
+        # Use object.__setattr__ because the dataclass is frozen.
+        if not isinstance(self.prediction_horizon_bias, MappingProxyType):
+            object.__setattr__(
+                self,
+                "prediction_horizon_bias",
+                MappingProxyType(dict(self.prediction_horizon_bias)),
+            )
+        # Validate the mapping keys match exactly the four expected
+        # literals — guards against typos in catalogue entries.
+        expected_keys = {"likely_next", "long_horizon", "finish_partials", "balanced"}
+        actual_keys = set(self.prediction_horizon_bias.keys())
+        if actual_keys != expected_keys:
+            missing = expected_keys - actual_keys
+            extra = actual_keys - expected_keys
+            raise ValueError(
+                f"VanerPolicyBundle.prediction_horizon_bias keys must be exactly "
+                f"{sorted(expected_keys)}; missing={sorted(missing)} extra={sorted(extra)}"
+            )
+
+
+# Re-export for convenience; downstream modules can import everything
+# they need from ``vaner.setup.policy``.
+__all__ = [
+    "ContextInjectionMode",
+    "PredictionHorizonKey",
+    "VanerPolicyBundle",
+]

--- a/tests/test_setup/test_answers.py
+++ b/tests/test_setup/test_answers.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — SetupAnswers dataclass tests (0.8.6)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from vaner.setup.answers import SetupAnswers
+
+
+def _valid_answers() -> SetupAnswers:
+    return SetupAnswers(
+        work_styles=("writing", "research"),
+        priority="quality",
+        compute_posture="balanced",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="idle_more",
+    )
+
+
+def test_round_trip_preserves_fields() -> None:
+    answers = _valid_answers()
+    assert answers.work_styles == ("writing", "research")
+    assert answers.priority == "quality"
+    assert answers.compute_posture == "balanced"
+    assert answers.cloud_posture == "hybrid_when_worth_it"
+    assert answers.background_posture == "idle_more"
+
+
+def test_empty_work_styles_raises() -> None:
+    with pytest.raises(ValueError, match="work_styles must contain"):
+        SetupAnswers(
+            work_styles=(),
+            priority="balanced",
+            compute_posture="balanced",
+            cloud_posture="ask_first",
+            background_posture="normal",
+        )
+
+
+def test_dataclass_is_frozen() -> None:
+    answers = _valid_answers()
+    with pytest.raises(FrozenInstanceError):
+        answers.priority = "speed"  # type: ignore[misc]
+
+
+def test_single_work_style_is_valid() -> None:
+    answers = SetupAnswers(
+        work_styles=("mixed",),
+        priority="balanced",
+        compute_posture="balanced",
+        cloud_posture="ask_first",
+        background_posture="normal",
+    )
+    assert answers.work_styles == ("mixed",)
+
+
+def test_setup_answers_is_hashable() -> None:
+    # Frozen + tuple work_styles means SetupAnswers is hashable.
+    # Important for cache keys in the selection algorithm.
+    a1 = _valid_answers()
+    a2 = _valid_answers()
+    assert hash(a1) == hash(a2)
+    assert a1 == a2

--- a/tests/test_setup/test_catalog.py
+++ b/tests/test_setup/test_catalog.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — PROFILE_CATALOG tests (0.8.6)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vaner.setup.catalog import PROFILE_CATALOG, bundle_by_id
+from vaner.setup.policy import VanerPolicyBundle
+
+
+def test_catalog_has_seven_bundles() -> None:
+    assert len(PROFILE_CATALOG) == 7
+
+
+def test_catalog_ids_are_unique() -> None:
+    ids = [bundle.id for bundle in PROFILE_CATALOG]
+    assert len(ids) == len(set(ids))
+
+
+def test_catalog_ids_match_spec() -> None:
+    expected = {
+        "local_lightweight",
+        "local_balanced",
+        "local_heavy",
+        "hybrid_balanced",
+        "hybrid_quality",
+        "cost_saver",
+        "deep_research",
+    }
+    actual = {bundle.id for bundle in PROFILE_CATALOG}
+    assert actual == expected
+
+
+def test_bundle_by_id_returns_correct_bundle() -> None:
+    bundle = bundle_by_id("hybrid_balanced")
+    assert isinstance(bundle, VanerPolicyBundle)
+    assert bundle.id == "hybrid_balanced"
+    assert bundle.label == "Hybrid Balanced"
+
+
+def test_bundle_by_id_unknown_raises_keyerror() -> None:
+    with pytest.raises(KeyError, match="unknown bundle id"):
+        bundle_by_id("nonexistent")
+
+
+def test_every_bundle_has_complete_horizon_bias_mapping() -> None:
+    for bundle in PROFILE_CATALOG:
+        assert set(bundle.prediction_horizon_bias.keys()) == {
+            "likely_next",
+            "long_horizon",
+            "finish_partials",
+            "balanced",
+        }, f"bundle {bundle.id} has incomplete horizon-bias mapping"
+
+
+def test_every_bundle_has_nonempty_label_and_description() -> None:
+    for bundle in PROFILE_CATALOG:
+        assert bundle.label, f"bundle {bundle.id} has empty label"
+        assert bundle.description, f"bundle {bundle.id} has empty description"

--- a/tests/test_setup/test_config_schema.py
+++ b/tests/test_setup/test_config_schema.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — VanerConfig schema tests (0.8.6).
+
+Confirms the new ``[setup]`` and ``[policy]`` sections exist on
+:class:`VanerConfig`, round-trip through Pydantic JSON, and that the
+``IntentConfig.domain`` field is removed outright (no compat shim).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaner.models.config import (
+    IntentConfig,
+    PolicyConfig,
+    SetupConfig,
+    VanerConfig,
+)
+
+
+def _make_config(tmp_path: Path) -> VanerConfig:
+    return VanerConfig(
+        repo_root=tmp_path,
+        store_path=tmp_path / "store.db",
+        telemetry_path=tmp_path / "telemetry.db",
+    )
+
+
+def test_vaner_config_includes_setup_and_policy_sections(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert isinstance(cfg.setup, SetupConfig)
+    assert isinstance(cfg.policy, PolicyConfig)
+
+
+def test_setup_defaults(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert cfg.setup.mode == "simple"
+    assert cfg.setup.work_styles == ["mixed"]
+    assert cfg.setup.priority == "balanced"
+    assert cfg.setup.compute_posture == "balanced"
+    assert cfg.setup.cloud_posture == "ask_first"
+    assert cfg.setup.background_posture == "normal"
+    assert cfg.setup.completed_at is None
+    assert cfg.setup.version == 1
+
+
+def test_policy_defaults(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert cfg.policy.selected_bundle_id == "hybrid_balanced"
+    assert cfg.policy.bundle_overrides == {}
+    assert cfg.policy.auto_select is True
+
+
+def test_intent_config_no_longer_has_domain_field() -> None:
+    # The 0.8.6 WS1 removal — verify the field is gone outright.
+    assert "domain" not in IntentConfig.model_fields
+
+
+def test_config_round_trips_through_json(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    payload = cfg.model_dump_json()
+    parsed = json.loads(payload)
+    assert "setup" in parsed
+    assert "policy" in parsed
+    # Reconstruct from the dumped JSON and verify equivalence.
+    cfg2 = VanerConfig.model_validate_json(payload)
+    assert cfg2.setup.mode == cfg.setup.mode
+    assert cfg2.policy.selected_bundle_id == cfg.policy.selected_bundle_id
+
+
+def test_setup_config_completed_at_accepts_datetime(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    when = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    cfg = SetupConfig(completed_at=when)
+    payload = cfg.model_dump_json()
+    parsed = SetupConfig.model_validate_json(payload)
+    assert parsed.completed_at == when

--- a/tests/test_setup/test_enums.py
+++ b/tests/test_setup/test_enums.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — enum literal alias tests (0.8.6).
+
+The aliases themselves are ``Literal`` types and have no runtime
+behaviour to test directly. We exercise their interaction with the
+``SetupConfig`` Pydantic model: every valid value round-trips, and an
+invalid value raises :class:`pydantic.ValidationError`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from vaner.models.config import SetupConfig
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    HardwareTier,
+    Priority,
+    WorkStyle,
+)
+
+# ---------------------------------------------------------------------------
+# Literal-membership checks. ``Literal`` doesn't expose its args via a
+# stable public API; we use ``typing.get_args`` which is documented and
+# stable across 3.11+.
+# ---------------------------------------------------------------------------
+
+
+def _literal_values(alias: object) -> tuple[str, ...]:
+    from typing import get_args
+
+    return tuple(get_args(alias))
+
+
+def test_work_style_values() -> None:
+    assert set(_literal_values(WorkStyle)) == {
+        "writing",
+        "research",
+        "planning",
+        "support",
+        "learning",
+        "coding",
+        "general",
+        "mixed",
+        "unsure",
+    }
+
+
+def test_priority_values() -> None:
+    assert set(_literal_values(Priority)) == {
+        "balanced",
+        "speed",
+        "quality",
+        "privacy",
+        "cost",
+        "low_resource",
+    }
+
+
+def test_compute_posture_values() -> None:
+    assert set(_literal_values(ComputePosture)) == {"light", "balanced", "available_power"}
+
+
+def test_cloud_posture_values() -> None:
+    assert set(_literal_values(CloudPosture)) == {
+        "local_only",
+        "ask_first",
+        "hybrid_when_worth_it",
+        "best_available",
+    }
+
+
+def test_background_posture_values() -> None:
+    assert set(_literal_values(BackgroundPosture)) == {
+        "minimal",
+        "normal",
+        "idle_more",
+        "deep_run_aggressive",
+    }
+
+
+def test_hardware_tier_values() -> None:
+    assert set(_literal_values(HardwareTier)) == {
+        "light",
+        "capable",
+        "high_performance",
+        "unknown",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pydantic validation: each enum value works as a SetupConfig field
+# value; invalid values raise ValidationError.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", _literal_values(WorkStyle))
+def test_setup_config_accepts_each_work_style(value: str) -> None:
+    cfg = SetupConfig(work_styles=[value])  # type: ignore[list-item]
+    assert cfg.work_styles == [value]
+
+
+@pytest.mark.parametrize("value", _literal_values(Priority))
+def test_setup_config_accepts_each_priority(value: str) -> None:
+    cfg = SetupConfig(priority=value)  # type: ignore[arg-type]
+    assert cfg.priority == value
+
+
+def test_setup_config_rejects_invalid_priority() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(priority="not-a-priority")  # type: ignore[arg-type]
+
+
+def test_setup_config_rejects_invalid_work_style() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(work_styles=["not-a-work-style"])  # type: ignore[list-item]
+
+
+def test_setup_config_rejects_invalid_cloud_posture() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(cloud_posture="not-a-cloud-posture")  # type: ignore[arg-type]
+
+
+def test_setup_config_rejects_invalid_background_posture() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(background_posture="not-a-background-posture")  # type: ignore[arg-type]

--- a/tests/test_setup/test_policy.py
+++ b/tests/test_setup/test_policy.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — VanerPolicyBundle dataclass tests (0.8.6)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from types import MappingProxyType
+
+import pytest
+
+from vaner.setup.policy import VanerPolicyBundle
+
+
+def _valid_bundle() -> VanerPolicyBundle:
+    return VanerPolicyBundle(
+        id="test_bundle",
+        label="Test Bundle",
+        description="for unit tests",
+        local_cloud_posture="local_preferred",
+        runtime_profile="medium",
+        spend_profile="zero",
+        latency_profile="balanced",
+        privacy_profile="standard",
+        prediction_horizon_bias={
+            "likely_next": 1.0,
+            "long_horizon": 1.0,
+            "finish_partials": 1.0,
+            "balanced": 1.0,
+        },
+        drafting_aggressiveness=1.0,
+        exploration_ratio=0.0,
+        persistence_strength=1.0,
+        goal_weighting=1.0,
+        context_injection_default="policy_hybrid",
+        deep_run_profile="balanced",
+    )
+
+
+def test_bundle_is_frozen() -> None:
+    bundle = _valid_bundle()
+    with pytest.raises(FrozenInstanceError):
+        bundle.id = "different_id"  # type: ignore[misc]
+
+
+def test_horizon_bias_keys_must_be_exact() -> None:
+    with pytest.raises(ValueError, match="prediction_horizon_bias"):
+        VanerPolicyBundle(
+            id="x",
+            label="x",
+            description="x",
+            local_cloud_posture="local_preferred",
+            runtime_profile="medium",
+            spend_profile="zero",
+            latency_profile="balanced",
+            privacy_profile="standard",
+            # Missing "balanced" key.
+            prediction_horizon_bias={
+                "likely_next": 1.0,
+                "long_horizon": 1.0,
+                "finish_partials": 1.0,
+            },
+            drafting_aggressiveness=1.0,
+            exploration_ratio=0.0,
+            persistence_strength=1.0,
+            goal_weighting=1.0,
+            context_injection_default="policy_hybrid",
+            deep_run_profile="balanced",
+        )
+
+
+def test_horizon_bias_extra_keys_rejected() -> None:
+    with pytest.raises(ValueError, match="prediction_horizon_bias"):
+        VanerPolicyBundle(
+            id="x",
+            label="x",
+            description="x",
+            local_cloud_posture="local_preferred",
+            runtime_profile="medium",
+            spend_profile="zero",
+            latency_profile="balanced",
+            privacy_profile="standard",
+            prediction_horizon_bias={
+                "likely_next": 1.0,
+                "long_horizon": 1.0,
+                "finish_partials": 1.0,
+                "balanced": 1.0,
+                "unexpected": 1.0,
+            },
+            drafting_aggressiveness=1.0,
+            exploration_ratio=0.0,
+            persistence_strength=1.0,
+            goal_weighting=1.0,
+            context_injection_default="policy_hybrid",
+            deep_run_profile="balanced",
+        )
+
+
+def test_horizon_bias_is_immutable_view() -> None:
+    bundle = _valid_bundle()
+    # The mapping is wrapped as a MappingProxyType and so cannot be
+    # mutated after construction.
+    assert isinstance(bundle.prediction_horizon_bias, MappingProxyType)
+    with pytest.raises(TypeError):
+        bundle.prediction_horizon_bias["likely_next"] = 99.0  # type: ignore[index]
+
+
+def test_horizon_bias_keys_are_exactly_the_four_expected() -> None:
+    bundle = _valid_bundle()
+    assert set(bundle.prediction_horizon_bias.keys()) == {
+        "likely_next",
+        "long_horizon",
+        "finish_partials",
+        "balanced",
+    }


### PR DESCRIPTION
## Summary
First PR in the v0.8.6 stack. Adds the foundational `src/vaner/setup/` module with five `Literal` enums (`WorkStyle`, `Priority`, `ComputePosture`, `CloudPosture`, `BackgroundPosture`, `HardwareTier`), the `SetupAnswers` and `VanerPolicyBundle` frozen dataclasses, the seven-bundle `PROFILE_CATALOG`, and `SetupConfig` + `PolicyConfig` Pydantic models on `VanerConfig`.

`IntentConfig.domain` is removed outright — zero callers, no external users yet.

Stack: WS1 → WS2 → WS3 → WS4 → WS5 → WS6 → WS10 → WS11 → WS7 → WS8 → WS9 → WS12a → WS12b. PRs target the previous WS in the stack.

## Test plan
- [x] `tests/test_setup/` — primitives, enums, answers, policy, catalog, config schema (48 tests added)
- [x] Full Vaner suite green: 1241 → 1289 passing on this WS
- [x] Ruff check + format clean; mypy clean on new modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)