### PR TITLE
feat(intent): 0.8.6 WS4 — work-style intent priors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+#### Setup primitives + config schema (0.8.6 WS1)
+- **`src/vaner/setup/` module** — outcome-level configuration surface for the 0.8.6 Simple Mode wizard. Five `Literal` type aliases — `WorkStyle`, `Priority`, `ComputePosture`, `CloudPosture`, `BackgroundPosture` — plus a shared `HardwareTier` alias declared here for WS2 to populate via `tier_for()`.
+- **`SetupAnswers`** frozen dataclass (`src/vaner/setup/answers.py`) — immutable record of one wizard run, with `__post_init__` validation that rejects empty `work_styles` (the engine has no priors to average without at least one selection).
+- **`VanerPolicyBundle`** frozen dataclass (`src/vaner/setup/policy.py`) — outcome-level policy archetype. Carries cloud posture, runtime profile, spend profile, latency profile, privacy profile, four-key prediction-horizon-bias mapping, drafting aggressiveness, exploration ratio, persistence strength, goal weighting, context-injection default, and Deep-Run profile. Mapping keys are validated and frozen into a `MappingProxyType` view at construction time.
+- **`PROFILE_CATALOG`** (`src/vaner/setup/catalog.py`) — the seven shipped bundles per spec §9: `local_lightweight`, `local_balanced`, `local_heavy`, `hybrid_balanced`, `hybrid_quality`, `cost_saver`, `deep_research`. Plus `bundle_by_id()` lookup helper that raises `KeyError` (not a swallowed `None`) on unknown ids.
+- **`SetupConfig` and `PolicyConfig` Pydantic models** (`src/vaner/models/config.py`) — added to `VanerConfig` with default factories. `setup` carries the wizard answers + `mode` + `completed_at` first-run marker + schema `version`. `policy` carries `selected_bundle_id` (default `"hybrid_balanced"`), `bundle_overrides`, and `auto_select`.
+
+### Removed
+- **`IntentConfig.domain`** field — the unused `Literal["coding","research","writing","ops"]` field is removed outright (zero callers; no external users to migrate). Superseded by the multi-select `setup.work_styles` field on `SetupConfig`. CHANGELOG is the only record needed.
+
 ## [0.8.4] - 2026-04-24
 
 ### Added

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -82,6 +82,15 @@ from vaner.intent.timing import ActivityTimingModel
 from vaner.intent.trainer import IntentTrainer
 from vaner.intent.transfer import bootstrap_transfer_priors
 from vaner.intent.volatility import semantic_volatility_profile
+from vaner.intent.work_style_priors import (
+    IntentPriorAdjustments,
+)
+from vaner.intent.work_style_priors import (
+    adjustments_for as work_style_adjustments_for,
+)
+from vaner.intent.work_style_priors import (
+    default_adjustments as default_work_style_adjustments,
+)
 from vaner.learning.counterfactual import CounterfactualAnalyzer
 from vaner.learning.reward import RewardInput, compute_reward
 from vaner.models.artefact import Artefact, ArtefactKind
@@ -263,6 +272,14 @@ class VanerEngine:
         # later via ``set_briefing_tokenizer`` once the structured LLM client
         # exposes one.
         self._briefing_assembler = BriefingAssembler()
+        # 0.8.6 WS4 — work-style intent priors. Cached per cycle so the
+        # frontier / drafter / briefing assembler all see the same
+        # composed multipliers. Defaults to the ``mixed`` identity so
+        # configs without a populated ``[setup]`` section produce
+        # byte-identical behaviour to pre-WS4. Refreshed at the top of
+        # ``precompute_cycle`` via :meth:`_refresh_work_style_adjustments`.
+        self._cycle_work_style_adjustments: IntentPriorAdjustments = default_work_style_adjustments()
+        self._refresh_work_style_adjustments()
         # WS10: single drafting module. Owns the rewrite + draft LLM
         # templates and the gate arithmetic so arc / pattern / history /
         # future goal-sourced (WS7) predictions all drive through the same
@@ -345,6 +362,23 @@ class VanerEngine:
             "invest_ratio": 0.10,
             "no_regret_ratio": 0.20,
         }
+
+    def _refresh_work_style_adjustments(self) -> None:
+        """Recompute per-cycle work-style adjustments from config.
+
+        0.8.6 WS4. Reads ``config.setup.work_styles`` and caches the
+        averaged :class:`IntentPriorAdjustments` for the cycle. Called
+        from ``__init__`` and again at the top of each ``precompute_cycle``
+        so a hot config edit takes effect on the next cycle without a
+        daemon restart. Default ``["mixed"]`` yields the identity element
+        — the engine produces byte-identical behaviour to pre-WS4.
+        """
+
+        styles = tuple(getattr(self.config.setup, "work_styles", ()) or ())
+        self._cycle_work_style_adjustments = work_style_adjustments_for(styles)
+        # Forward hook for the briefing assembler's artefact-template
+        # tie-break. Empty tuple under the ``mixed`` default → no-op.
+        self._briefing_assembler.set_preferred_templates(self._cycle_work_style_adjustments.preferred_artefact_templates)
 
     async def initialize(self) -> None:
         await self.store.initialize()
@@ -1011,6 +1045,10 @@ class VanerEngine:
         """
         cycle_started = time.monotonic()
         await self.initialize()
+        # 0.8.6 WS4 — refresh work-style adjustments from current config
+        # so a hot edit to ``setup.work_styles`` takes effect on the next
+        # cycle. No-op for the default ``["mixed"]``.
+        self._refresh_work_style_adjustments()
         compute = self.config.compute
         # Keep the binary idle-only gate as an escape hatch: if the load is
         # genuinely saturating, skip the cycle entirely. Between idle and
@@ -1268,7 +1306,12 @@ class VanerEngine:
                         aligned_paths.update(str(p) for p in paths if p)
                 except Exception:
                     continue
-        frontier.set_artefact_aligned_paths(aligned_paths)
+        # 0.8.6 WS4 — compose the default 1.10x artefact-alignment boost with
+        # the work-style multiplier (mixed → 1.0 → no-op). The frontier clamps
+        # to >= 1.0 internally; we still pass a positive value so the contract
+        # holds without WS4 inspecting frontier internals.
+        _ws_boost = 1.10 * self._cycle_work_style_adjustments.artefact_alignment_weight_multiplier
+        frontier.set_artefact_aligned_paths(aligned_paths, boost=_ws_boost)
 
         # Order matters: Jaccard-dedup is first-admitted-wins, and
         # seed_from_workflow_phase produces arc-sourced scenarios whose file
@@ -3206,13 +3249,26 @@ class VanerEngine:
             draft_budget_min_s = float(self._cycle_policy_state.get("draft_budget_min_ms", 2000.0)) / 1000.0
             has_budget = deadline is None or (deadline - time.monotonic()) >= draft_budget_min_s
             # WS10: gates consolidated into the Drafter.
+            # 0.8.6 WS4 — fold work-style intent priors into the gates so a
+            # "coding"/"planning" style demands stronger evidence and a
+            # tighter volatility ceiling, while "writing"/"learning" relax
+            # the bar. ``mixed`` (default) leaves both knobs unchanged.
+            _ws_adj = self._cycle_work_style_adjustments
+            _ws_gates = dict(self._cycle_policy_state)
+            _ws_gates["draft_evidence_threshold"] = max(
+                float(_ws_gates.get("draft_evidence_threshold", 0.45)),
+                _ws_adj.drafting_evidence_floor,
+            )
+            _ws_gates["draft_volatility_ceiling"] = (
+                float(_ws_gates.get("draft_volatility_ceiling", 0.40)) * _ws_adj.drafting_volatility_ceiling_multiplier
+            )
             if not self._drafter.passes_gates(
                 posterior_confidence=posterior_confidence,
                 evidence_quality=evidence_quality,
                 evidence_volatility=evidence_volatility,
                 prior_draft_usefulness=prior_draft_usefulness,
                 has_budget=has_budget,
-                gates=self._cycle_policy_state,
+                gates=_ws_gates,
             ):
                 continue
 

--- a/src/vaner/intent/briefing.py
+++ b/src/vaner/intent/briefing.py
@@ -96,6 +96,32 @@ class BriefingAssembler:
 
     def __init__(self, tokenizer: Callable[[str], int] | None = None) -> None:
         self._tokenizer = tokenizer
+        # 0.8.6 WS4 — preferred artefact-template ids derived from the
+        # active work-style mix. Updated each cycle by the engine via
+        # :meth:`set_preferred_templates`. The assembler ranks registered
+        # templates by this preference when an artefact-template registry
+        # is consulted (forward hook — no-op until the registry lands in
+        # a later WS). Empty tuple is the neutral default.
+        self._preferred_artefact_templates: tuple[str, ...] = ()
+
+    def set_preferred_templates(self, template_ids: tuple[str, ...]) -> None:
+        """Set the preferred artefact-template ids for tie-breaking.
+
+        0.8.6 WS4. Called once per engine cycle with the work-style
+        mix's preferred templates (e.g. ``("decision_memo", "risk_list")``
+        for planning). When the briefing assembler consults an artefact-
+        template registry it should prefer ids in this tuple. Templates
+        that aren't registered are silently ignored — the assembler falls
+        back to its existing template selection.
+        """
+
+        self._preferred_artefact_templates = tuple(template_ids)
+
+    @property
+    def preferred_artefact_templates(self) -> tuple[str, ...]:
+        """The preferred artefact-template ids (0.8.6 WS4 forward hook)."""
+
+        return self._preferred_artefact_templates
 
     def _count_tokens(self, text: str) -> int:
         if not text:

--- a/src/vaner/intent/work_style_priors.py
+++ b/src/vaner/intent/work_style_priors.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS4 — Work-style intent priors (0.8.6).
+
+Maps each :data:`vaner.setup.enums.WorkStyle` Literal value to a small
+bundle of multiplicative nudges that the engine composes with its base
+scoring / drafting knobs. The table lives here as immutable data: no
+side effects, no lazy loading. Engine code calls
+:func:`adjustments_for` once per cycle (or whenever
+``config.setup.work_styles`` changes) and threads the result into the
+existing call sites that already accept multipliers from
+:class:`vaner.intent.deep_run_policy.DeepRunPresetSpec` and
+:class:`vaner.intent.deep_run_policy.HorizonBiasSpec`.
+
+Design notes
+------------
+
+- **Multiplicative + averaged.** Multipliers compose multiplicatively
+  with preset/horizon multipliers (matches the convention in
+  :mod:`vaner.intent.deep_run_policy`). When the user picks more than
+  one work style, the multipliers are averaged arithmetically — explicit
+  and predictable per the 0.8.6 plan, rather than geometrically.
+- **"mixed" is the identity.** Every multiplier is 1.0, the drafting
+  floor is 0.0, and the preferred-template tuple is empty. Engines
+  running on default ``setup.work_styles == ["mixed"]`` configs see
+  byte-identical behaviour to pre-WS4.
+- **Conservative ranges.** Multipliers stay inside ``[0.7, 1.5]`` and
+  the drafting floor inside ``[0.0, 0.6]``. The point is a small,
+  explainable lookup — not a tuning monster. WS6+ benches can iterate
+  on the numbers; the structure is fixed by spec §7.
+- **Templates are a forward hook.** ``preferred_artefact_templates``
+  is consumed by the briefing assembler when an artefact-template
+  registry exists. If the named templates are not registered (current
+  state — the registry lands in a later WS), the engine silently
+  falls back to its existing template selection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final, get_args
+
+from vaner.setup.enums import WorkStyle
+
+
+@dataclass(frozen=True, slots=True)
+class IntentPriorAdjustments:
+    """Multipliers/floors that nudge engine knobs toward a work style.
+
+    All multiplier values are multiplicative on top of the engine's base
+    value (:class:`DeepRunPresetSpec` already uses this convention; we
+    compose with it the same way). The drafting evidence floor is a
+    lower bound — the drafter takes ``max(threshold, floor)`` so a
+    work style that demands stronger evidence can only raise the bar,
+    never lower it.
+
+    ``preferred_artefact_templates`` is a tuple of template ids the
+    briefing assembler should prefer when ranking ties between
+    otherwise-equivalent artefact templates. Templates that aren't
+    registered are ignored silently.
+    """
+
+    artefact_alignment_weight_multiplier: float
+    long_horizon_bonus_multiplier: float
+    possible_branch_bonus_multiplier: float
+    drafting_evidence_floor: float
+    drafting_volatility_ceiling_multiplier: float
+    preferred_artefact_templates: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# The work-style table (spec §7). Immutable; values are the single source
+# of truth for "what does each work style nudge."
+# ---------------------------------------------------------------------------
+
+
+WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
+    "writing": IntentPriorAdjustments(
+        # Writing rewards continuity; let drafts ride on thinner evidence
+        # but boost long-horizon (next-scene / next-chapter) hypotheses.
+        artefact_alignment_weight_multiplier=1.2,
+        long_horizon_bonus_multiplier=1.3,
+        possible_branch_bonus_multiplier=1.0,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.2,
+        preferred_artefact_templates=("next_scene_draft", "outline_continuation"),
+    ),
+    "research": IntentPriorAdjustments(
+        # Research wants broad branch coverage; weight possible-branch
+        # exploration higher, demand stronger artefact alignment, and
+        # keep drafting bar near baseline.
+        artefact_alignment_weight_multiplier=1.4,
+        long_horizon_bonus_multiplier=1.2,
+        possible_branch_bonus_multiplier=1.4,
+        drafting_evidence_floor=0.45,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=("research_brief", "lit_review"),
+    ),
+    "planning": IntentPriorAdjustments(
+        # Planning is artefact-anchored (decision memos, risk lists);
+        # boost alignment hard, keep horizon balanced, demand decent
+        # evidence so plans aren't wishy-washy.
+        artefact_alignment_weight_multiplier=1.5,
+        long_horizon_bonus_multiplier=1.2,
+        possible_branch_bonus_multiplier=1.1,
+        drafting_evidence_floor=0.50,
+        drafting_volatility_ceiling_multiplier=0.9,
+        preferred_artefact_templates=("decision_memo", "risk_list"),
+    ),
+    "support": IntentPriorAdjustments(
+        # Support work wants to finish what's in flight (short horizon,
+        # low branching); demand strong evidence so answers don't mislead.
+        artefact_alignment_weight_multiplier=1.1,
+        long_horizon_bonus_multiplier=0.8,
+        possible_branch_bonus_multiplier=0.8,
+        drafting_evidence_floor=0.55,
+        drafting_volatility_ceiling_multiplier=0.8,
+        preferred_artefact_templates=("ticket_reply", "troubleshooting_brief"),
+    ),
+    "learning": IntentPriorAdjustments(
+        # Learning rewards exposure to adjacent concepts (high possible-
+        # branch); drafting bar stays gentle so partials still surface.
+        artefact_alignment_weight_multiplier=1.0,
+        long_horizon_bonus_multiplier=1.1,
+        possible_branch_bonus_multiplier=1.5,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.3,
+        preferred_artefact_templates=("study_outline", "concept_brief"),
+    ),
+    "coding": IntentPriorAdjustments(
+        # Coding wants clean patches: high evidence floor, tight volatility
+        # ceiling, modest long-horizon (debugging is short-loop).
+        artefact_alignment_weight_multiplier=1.3,
+        long_horizon_bonus_multiplier=0.9,
+        possible_branch_bonus_multiplier=1.1,
+        drafting_evidence_floor=0.55,
+        drafting_volatility_ceiling_multiplier=0.8,
+        preferred_artefact_templates=("debugging_brief", "patch_proposal"),
+    ),
+    "general": IntentPriorAdjustments(
+        # General-purpose: very gentle nudges, no template preference.
+        artefact_alignment_weight_multiplier=1.1,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.1,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=(),
+    ),
+    "mixed": IntentPriorAdjustments(
+        # Identity element. ``setup.work_styles == ["mixed"]`` is the
+        # default for fresh installs; it MUST be a strict no-op so the
+        # engine produces byte-identical behaviour to pre-WS4.
+        artefact_alignment_weight_multiplier=1.0,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.0,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=(),
+    ),
+    "unsure": IntentPriorAdjustments(
+        # Same identity as ``mixed`` — the user opted out of telling us;
+        # we should not gamble on a guess. Functionally equivalent today;
+        # split out so future surfaces can show "unsure" as a distinct
+        # affordance without breaking the table key invariant.
+        artefact_alignment_weight_multiplier=1.0,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.0,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=(),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Lookups + helpers
+# ---------------------------------------------------------------------------
+
+
+def default_adjustments() -> IntentPriorAdjustments:
+    """Return the identity-element adjustments (``mixed``).
+
+    Used when ``setup.work_styles`` is empty or contains only the
+    ``"mixed"`` sentinel. Every multiplier is 1.0, the drafting floor
+    is 0.0, and the preferred-template tuple is empty — composing
+    these with any base value yields the base value unchanged.
+    """
+
+    return WORK_STYLE_PRIORS["mixed"]
+
+
+def adjustments_for(work_styles: Sequence[WorkStyle]) -> IntentPriorAdjustments:
+    """Average the per-style adjustments across a multi-select input.
+
+    Empty input falls back to :func:`default_adjustments` (the
+    ``"mixed"`` identity element). When more than one style is
+    selected, the float multipliers are averaged arithmetically;
+    template tuples are unioned (deduplicated, sorted) so the result
+    is deterministic regardless of input order.
+
+    Unknown style names raise :class:`KeyError` — that would be a
+    schema-migration bug, not a runtime concern.
+    """
+
+    if not work_styles:
+        return default_adjustments()
+
+    specs = [WORK_STYLE_PRIORS[style] for style in work_styles]
+    n = len(specs)
+
+    templates: set[str] = set()
+    for spec in specs:
+        templates.update(spec.preferred_artefact_templates)
+
+    return IntentPriorAdjustments(
+        artefact_alignment_weight_multiplier=sum(s.artefact_alignment_weight_multiplier for s in specs) / n,
+        long_horizon_bonus_multiplier=sum(s.long_horizon_bonus_multiplier for s in specs) / n,
+        possible_branch_bonus_multiplier=sum(s.possible_branch_bonus_multiplier for s in specs) / n,
+        drafting_evidence_floor=sum(s.drafting_evidence_floor for s in specs) / n,
+        drafting_volatility_ceiling_multiplier=sum(s.drafting_volatility_ceiling_multiplier for s in specs) / n,
+        preferred_artefact_templates=tuple(sorted(templates)),
+    )
+
+
+def compose_with_deep_run_preset(
+    work_style: IntentPriorAdjustments,
+    *,
+    base_artefact_alignment: float,
+    base_long_horizon: float,
+    base_possible_branch: float,
+) -> tuple[float, float, float]:
+    """Multiply work-style multipliers onto base scoring weights.
+
+    The composition is multiplicative — the same convention used by
+    :class:`vaner.intent.deep_run_policy.HorizonBiasSpec` so that
+    work-style + Deep-Run preset + horizon bias compose associatively
+    at the call site (any order yields the same product).
+
+    Returns the three adjusted scoring weights as a tuple in the same
+    order as the parameters: artefact-alignment, long-horizon,
+    possible-branch.
+    """
+
+    return (
+        base_artefact_alignment * work_style.artefact_alignment_weight_multiplier,
+        base_long_horizon * work_style.long_horizon_bonus_multiplier,
+        base_possible_branch * work_style.possible_branch_bonus_multiplier,
+    )
+
+
+# Self-check: every WorkStyle Literal value must have an entry in
+# WORK_STYLE_PRIORS. We also expose the literal's args for the test
+# module to consume without re-importing typing internals.
+_WORK_STYLE_VALUES: Final[tuple[WorkStyle, ...]] = get_args(WorkStyle)
+assert set(_WORK_STYLE_VALUES) == set(WORK_STYLE_PRIORS.keys()), (
+    "WORK_STYLE_PRIORS must cover every value in the WorkStyle Literal "
+    f"(missing: {set(_WORK_STYLE_VALUES) - set(WORK_STYLE_PRIORS.keys())}, "
+    f"extra: {set(WORK_STYLE_PRIORS.keys()) - set(_WORK_STYLE_VALUES)})"
+)
+
+
+__all__ = [
+    "WORK_STYLE_PRIORS",
+    "IntentPriorAdjustments",
+    "adjustments_for",
+    "compose_with_deep_run_preset",
+    "default_adjustments",
+]

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    Priority,
+    WorkStyle,
+)
 
 
 class PrivacyConfig(BaseModel):
@@ -171,7 +180,11 @@ class IntentConfig(BaseModel):
     lookback_turns: int = 8
     skills_loop_enabled: bool = True
     max_feedback_events_per_cycle: int = 5
-    domain: Literal["coding", "research", "writing", "ops"] = "coding"
+    # 0.8.6 WS1 — the previous ``domain`` field
+    # (``Literal["coding","research","writing","ops"]``) is removed.
+    # It had zero callers and is superseded by the multi-select
+    # ``setup.work_styles`` field on :class:`SetupConfig`. See the
+    # 0.8.6 CHANGELOG entry under "Removed".
     embedding_classifier_enabled: bool = True
     cross_workspace_profile: bool = False
 
@@ -616,6 +629,67 @@ class RefinementConfig(BaseModel):
     adoption_pending_confirm_seconds: float = Field(default=600.0, ge=0.0)
 
 
+class SetupConfig(BaseModel):
+    """``[setup]`` — Simple-Mode wizard state (0.8.6 WS1).
+
+    Holds the answers from one completed wizard run plus a few
+    bookkeeping fields. ``mode`` distinguishes the Simple-Mode
+    (outcome-level questions) surface from the Advanced-Mode (full
+    knob-level config) surface; both are simultaneously valid (the
+    user can flip back and forth from the desktop UI). ``completed_at``
+    marks first-run state — when ``None``, the engine treats this as a
+    fresh install and triggers the wizard on first interaction.
+
+    Configs without a ``[setup]`` section get all defaults at load
+    time, which means ``mode="simple"`` and the no-op ``["mixed"]``
+    work-style. There is no migration path from a legacy
+    ``IntentConfig.domain`` field — that field is removed outright in
+    0.8.6 (see CHANGELOG entry).
+    """
+
+    mode: Literal["simple", "advanced"] = "simple"
+    work_styles: list[WorkStyle] = Field(default_factory=lambda: ["mixed"])  # type: ignore[arg-type]
+    # ^ mypy can't see through the Literal narrowing inside the lambda;
+    # the runtime list ["mixed"] is a perfectly valid list[WorkStyle].
+    priority: Priority = "balanced"
+    compute_posture: ComputePosture = "balanced"
+    cloud_posture: CloudPosture = "ask_first"
+    background_posture: BackgroundPosture = "normal"
+    completed_at: datetime | None = None
+    """ISO timestamp of the most recent wizard completion. ``None``
+    means the wizard has never been run on this config; first-run
+    surfaces use this to decide whether to prompt."""
+    version: int = 1
+    """Schema-migration anchor for future ``[setup]`` extensions.
+    Bumped only when a backwards-incompatible field change lands."""
+
+
+class PolicyConfig(BaseModel):
+    """``[policy]`` — selected policy bundle and per-knob overrides
+    (0.8.6 WS1).
+
+    ``selected_bundle_id`` is the foreign key into
+    :data:`vaner.setup.catalog.PROFILE_CATALOG`. The default
+    ``"hybrid_balanced"`` is the safe middle path used when the
+    wizard has not run yet.
+
+    ``bundle_overrides`` is a free-form dict for per-knob user
+    overrides on top of the selected bundle. Keys are bundle field
+    names; values are the override values. WS5's ``apply_policy_bundle``
+    composes bundle defaults → user overrides → Deep-Run session
+    deltas.
+
+    ``auto_select`` controls whether the engine re-runs WS3's
+    selection algorithm when hardware changes (e.g. desktop → battery,
+    GPU added/removed). When ``False`` (user pinned the bundle), the
+    engine emits a warning but does not re-select.
+    """
+
+    selected_bundle_id: str = "hybrid_balanced"
+    bundle_overrides: dict[str, Any] = Field(default_factory=dict)
+    auto_select: bool = True
+
+
 class VanerConfig(BaseModel):
     repo_root: Path
     store_path: Path
@@ -634,3 +708,5 @@ class VanerConfig(BaseModel):
     sources: SourcesConfig = Field(default_factory=SourcesConfig)
     refinement: RefinementConfig = Field(default_factory=RefinementConfig)
     integrations: IntegrationsConfig = Field(default_factory=IntegrationsConfig)
+    setup: SetupConfig = Field(default_factory=SetupConfig)
+    policy: PolicyConfig = Field(default_factory=PolicyConfig)

--- a/src/vaner/setup/__init__.py
+++ b/src/vaner/setup/__init__.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vaner setup primitives — Simple-Mode wizard data model (0.8.6).
+
+This package owns the outcome-level configuration surface introduced in
+0.8.6:
+
+- :mod:`vaner.setup.enums` — ``WorkStyle`` / ``Priority`` /
+  ``ComputePosture`` / ``CloudPosture`` / ``BackgroundPosture`` /
+  ``HardwareTier`` literal aliases.
+- :mod:`vaner.setup.answers` — :class:`SetupAnswers` dataclass, the
+  immutable record of one wizard run.
+- :mod:`vaner.setup.policy` — :class:`VanerPolicyBundle` dataclass.
+- :mod:`vaner.setup.catalog` — :data:`PROFILE_CATALOG` (the seven
+  shipped bundles) and the ``bundle_by_id()`` lookup helper.
+
+Hardware detection (:mod:`vaner.setup.hardware`), the selection
+algorithm (:mod:`vaner.setup.select`), and the policy applicator
+(:mod:`vaner.setup.apply`) land in subsequent 0.8.6 work streams.
+
+Note: this ``__init__`` deliberately re-exports *only* the leaf modules
+that have no dependency on the engine stack (``enums``, ``answers``).
+Importing :class:`VanerPolicyBundle` or the catalogue requires
+explicit submodule imports — ``from vaner.setup.policy import …`` —
+because :mod:`vaner.setup.policy` depends transitively on
+:mod:`vaner.intent.deep_run` and would create an import cycle if
+re-exported from here while :mod:`vaner.models.config` also imports
+from this package.
+"""
+
+from __future__ import annotations
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    HardwareTier,
+    Priority,
+    WorkStyle,
+)
+
+__all__ = [
+    "BackgroundPosture",
+    "CloudPosture",
+    "ComputePosture",
+    "HardwareTier",
+    "Priority",
+    "SetupAnswers",
+    "WorkStyle",
+]

--- a/src/vaner/setup/answers.py
+++ b/src/vaner/setup/answers.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: SetupAnswers dataclass (0.8.6).
+
+``SetupAnswers`` is the immutable record of one completed Simple-Mode
+wizard run. It is the input to WS3's ``select_policy_bundle()`` and is
+persisted (in normal-form, on the ``[setup]`` section of
+``.vaner/config.toml``) so the engine can re-run selection on hardware
+changes without re-prompting the user.
+
+Validation in ``__post_init__`` enforces the *only* invariant Simple Mode
+cannot recover from: empty ``work_styles``. The engine has no priors to
+average if no work styles were selected; UI surfaces are responsible for
+forcing at least one selection (defaulting to ``"mixed"`` when the user
+has no preference). All other fields are scalar enums and validated by
+their ``Literal`` types when loaded through Pydantic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    Priority,
+    WorkStyle,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SetupAnswers:
+    """Immutable record of one completed Simple-Mode wizard run.
+
+    ``work_styles`` is a tuple (not a list) so the dataclass remains
+    hashable and properly frozen. The wizard surface accepts a list and
+    converts at the boundary.
+    """
+
+    work_styles: tuple[WorkStyle, ...]
+    priority: Priority
+    compute_posture: ComputePosture
+    cloud_posture: CloudPosture
+    background_posture: BackgroundPosture
+
+    def __post_init__(self) -> None:
+        if not self.work_styles:
+            raise ValueError(
+                "SetupAnswers.work_styles must contain at least one WorkStyle; "
+                "the engine has no priors to average if no work styles are selected. "
+                'Pass ("mixed",) when the user has no preference.'
+            )
+
+
+__all__ = ["SetupAnswers"]

--- a/src/vaner/setup/catalog.py
+++ b/src/vaner/setup/catalog.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: PROFILE_CATALOG (0.8.6).
+
+The seven shipped policy bundles per spec §9. This is the single source
+of truth — desktop apps, the CLI wizard, the cockpit summary card, and
+the MCP/HTTP setup tools all read from this tuple.
+
+Numeric values for the per-bundle multipliers (drafting_aggressiveness,
+exploration_ratio, persistence_strength, goal_weighting,
+prediction_horizon_bias) are calibrated against the Deep-Run preset
+table (see :mod:`vaner.intent.deep_run_policy`) so that bundle defaults
+compose multiplicatively with any Deep-Run session deltas without
+double-application.
+
+Bundle scale:
+
+- ``drafting_aggressiveness``: ``0.7`` (cautious) → ``1.3`` (eager).
+  Multiplier on the drafter evidence threshold.
+- ``exploration_ratio``: ``-0.10`` (exploit-leaning) → ``+0.15``
+  (explore-leaning). Additive bias on top of base exploration weights.
+- ``persistence_strength``: ``0.6`` (decay fast) → ``1.5`` (decay
+  slow). Multiplier on memory retention.
+- ``goal_weighting``: ``0.8`` → ``1.4``. Multiplier on goal-aligned
+  prediction scoring.
+- ``prediction_horizon_bias``: weights sum *roughly* to 4.0 across the
+  four buckets; the engine normalises before applying.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from vaner.setup.policy import VanerPolicyBundle
+
+# ---------------------------------------------------------------------------
+# Bundle definitions. Order matches spec §9 narrative; ids are the
+# stable foreign key persisted to ``PolicyConfig.selected_bundle_id``.
+# ---------------------------------------------------------------------------
+
+
+_LOCAL_LIGHTWEIGHT = VanerPolicyBundle(
+    # Target user: laptop on battery, integrated GPU, wants Vaner to
+    # not heat the room. Local-only by default; minimal background.
+    id="local_lightweight",
+    label="Local Lightweight",
+    description=("Run entirely on this device with a small local model. Best for older laptops, battery, and privacy-first users."),
+    local_cloud_posture="local_only",
+    runtime_profile="small",
+    spend_profile="zero",
+    latency_profile="snappy",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.4,
+        "long_horizon": 0.8,
+        "finish_partials": 1.2,
+        "balanced": 0.6,
+    },
+    drafting_aggressiveness=0.8,
+    exploration_ratio=-0.05,
+    persistence_strength=0.7,
+    goal_weighting=1.0,
+    context_injection_default="digest_only",
+    deep_run_profile="conservative",
+)
+
+
+_LOCAL_BALANCED = VanerPolicyBundle(
+    # Target user: capable laptop or desktop, mid-tier local model
+    # (e.g. 7-13B). Local-first but willing to ponder more in the
+    # background. Default for the "Capable" hardware tier.
+    id="local_balanced",
+    label="Local Balanced",
+    description=("Local-first with a mid-sized model. Solid default for a capable laptop or desktop with no cloud reliance."),
+    local_cloud_posture="local_preferred",
+    runtime_profile="medium",
+    spend_profile="zero",
+    latency_profile="balanced",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.0,
+        "finish_partials": 1.0,
+        "balanced": 1.0,
+    },
+    drafting_aggressiveness=1.0,
+    exploration_ratio=0.0,
+    persistence_strength=1.0,
+    goal_weighting=1.0,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="balanced",
+)
+
+
+_LOCAL_HEAVY = VanerPolicyBundle(
+    # Target user: workstation or homelab with a large local model
+    # (e.g. 30-70B at Q4+). Local-only, but Vaner is allowed to ponder
+    # aggressively because the box can take it.
+    id="local_heavy",
+    label="Local Heavy",
+    description=("All-local with a large model and aggressive background pondering. Built for workstations and homelab GPUs."),
+    local_cloud_posture="local_only",
+    runtime_profile="large",
+    spend_profile="zero",
+    latency_profile="quality",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.4,
+        "finish_partials": 1.0,
+        "balanced": 1.2,
+    },
+    drafting_aggressiveness=1.1,
+    exploration_ratio=0.10,
+    persistence_strength=1.3,
+    goal_weighting=1.2,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="aggressive",
+)
+
+
+_HYBRID_BALANCED = VanerPolicyBundle(
+    # Target user: anyone who's fine with the engine reaching for a
+    # cloud model when local is genuinely insufficient. The default
+    # bundle for first-run when hardware tier is unknown — safe
+    # middle path.
+    id="hybrid_balanced",
+    label="Hybrid Balanced",
+    description=("Local for everyday work, cloud only when it's clearly worth it. Recommended default for most users."),
+    local_cloud_posture="hybrid",
+    runtime_profile="medium",
+    spend_profile="low",
+    latency_profile="balanced",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.1,
+        "finish_partials": 1.0,
+        "balanced": 1.0,
+    },
+    drafting_aggressiveness=1.0,
+    exploration_ratio=0.05,
+    persistence_strength=1.0,
+    goal_weighting=1.0,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="balanced",
+)
+
+
+_HYBRID_QUALITY = VanerPolicyBundle(
+    # Target user: serious work where the user is willing to spend on
+    # cloud capacity to get the best result. Still hybrid, but the
+    # cloud bias is set higher and the latency profile prioritises
+    # quality over snappiness.
+    id="hybrid_quality",
+    label="Hybrid Quality",
+    description=("Reach for the best available model — local or cloud — and trade some snappiness and budget for higher answer quality."),
+    local_cloud_posture="cloud_preferred",
+    runtime_profile="large",
+    spend_profile="medium",
+    latency_profile="quality",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 0.9,
+        "long_horizon": 1.4,
+        "finish_partials": 1.0,
+        "balanced": 1.1,
+    },
+    drafting_aggressiveness=1.2,
+    exploration_ratio=0.10,
+    persistence_strength=1.2,
+    goal_weighting=1.2,
+    context_injection_default="top_match_auto_include",
+    deep_run_profile="balanced",
+)
+
+
+_COST_SAVER = VanerPolicyBundle(
+    # Target user: cost-conscious user who still wants some hybrid
+    # capacity. Tightens spend cap and prefers the cheapest endpoint
+    # that meets the latency / context floor.
+    id="cost_saver",
+    label="Cost Saver",
+    description=("Hybrid setup with tight cloud spend caps. Prefers the cheapest endpoint that still meets the bar."),
+    local_cloud_posture="local_preferred",
+    runtime_profile="small",
+    spend_profile="low",
+    latency_profile="balanced",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 1.2,
+        "long_horizon": 0.9,
+        "finish_partials": 1.1,
+        "balanced": 0.8,
+    },
+    drafting_aggressiveness=0.9,
+    exploration_ratio=-0.05,
+    persistence_strength=0.9,
+    goal_weighting=1.0,
+    context_injection_default="adopted_package_only",
+    deep_run_profile="conservative",
+)
+
+
+_DEEP_RESEARCH = VanerPolicyBundle(
+    # Target user: long-horizon research / writing work where Vaner
+    # should ponder broadly and persistently. Overnight Deep-Run is the
+    # natural mode; daytime use composes the bundle's bias with the
+    # active session's preset.
+    id="deep_research",
+    label="Deep Research",
+    description=("Long-horizon, broad exploration for research and writing. Persists predictions longer and prefers depth over speed."),
+    local_cloud_posture="hybrid",
+    runtime_profile="large",
+    spend_profile="medium",
+    latency_profile="quality",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 0.7,
+        "long_horizon": 1.6,
+        "finish_partials": 1.1,
+        "balanced": 1.2,
+    },
+    drafting_aggressiveness=1.1,
+    exploration_ratio=0.15,
+    persistence_strength=1.5,
+    goal_weighting=1.4,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="aggressive",
+)
+
+
+PROFILE_CATALOG: Final[tuple[VanerPolicyBundle, ...]] = (
+    _LOCAL_LIGHTWEIGHT,
+    _LOCAL_BALANCED,
+    _LOCAL_HEAVY,
+    _HYBRID_BALANCED,
+    _HYBRID_QUALITY,
+    _COST_SAVER,
+    _DEEP_RESEARCH,
+)
+
+
+# Internal id-keyed lookup map. Built once at import time so
+# ``bundle_by_id`` is O(1). Not exported — callers should use the
+# helper, which gives a clearer error message on miss.
+_BY_ID: Final[dict[str, VanerPolicyBundle]] = {bundle.id: bundle for bundle in PROFILE_CATALOG}
+
+
+def bundle_by_id(bundle_id: str) -> VanerPolicyBundle:
+    """Return the bundle with the given id.
+
+    Raises :class:`KeyError` (with a helpful message) if no bundle in
+    :data:`PROFILE_CATALOG` matches. The engine should never silently
+    fall back to a default for an unknown id — that would mask a
+    config-shape bug or a corrupted ``.vaner/config.toml``.
+    """
+
+    try:
+        return _BY_ID[bundle_id]
+    except KeyError as exc:
+        known = ", ".join(sorted(_BY_ID))
+        raise KeyError(f"unknown bundle id {bundle_id!r}; known ids: {known}") from exc
+
+
+__all__ = [
+    "PROFILE_CATALOG",
+    "bundle_by_id",
+]

--- a/src/vaner/setup/enums.py
+++ b/src/vaner/setup/enums.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: enums (0.8.6).
+
+These ``Literal`` type aliases are the single source of truth for the
+outcome-level question vocabulary surfaced by Simple Mode (CLI wizard,
+desktop apps, MCP/HTTP setup tools). Each alias matches one question in
+the five-step Simple-Mode flow described in the 0.8.6 spec §5:
+
+- ``WorkStyle`` — multi-select. What kind of work do you want help with?
+  ("writing", "research", "planning", "support", "learning", "coding",
+  "general", "mixed", "unsure"). The engine averages priors when more
+  than one work style is selected.
+- ``Priority`` — single-select. What matters most? ("balanced", "speed",
+  "quality", "privacy", "cost", "low_resource").
+- ``ComputePosture`` — single-select. How hard should this machine work
+  for you? ("light", "balanced", "available_power").
+- ``CloudPosture`` — single-select. How do you feel about cloud LLMs?
+  ("local_only", "ask_first", "hybrid_when_worth_it",
+  "best_available").
+- ``BackgroundPosture`` — single-select. How aggressive should
+  background pondering be? ("minimal", "normal", "idle_more",
+  "deep_run_aggressive").
+- ``HardwareTier`` — output of WS2's ``tier_for()`` mapping. Declared
+  here so all of WS1+WS2+WS3 share one definition.
+
+We use ``Literal`` aliases rather than ``enum.Enum`` classes to match the
+existing codebase pattern (see ``DeepRunPreset`` / ``DeepRunFocus`` /
+``DeepRunHorizonBias`` in :mod:`vaner.intent.deep_run`). The aliases
+participate naturally in Pydantic validation, JSON serialisation, and
+``ts-rs`` codegen on the ``vaner-contract`` side.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+WorkStyle = Literal[
+    "writing",
+    "research",
+    "planning",
+    "support",
+    "learning",
+    "coding",
+    "general",
+    "mixed",
+    "unsure",
+]
+
+Priority = Literal[
+    "balanced",
+    "speed",
+    "quality",
+    "privacy",
+    "cost",
+    "low_resource",
+]
+
+ComputePosture = Literal[
+    "light",
+    "balanced",
+    "available_power",
+]
+
+CloudPosture = Literal[
+    "local_only",
+    "ask_first",
+    "hybrid_when_worth_it",
+    "best_available",
+]
+
+BackgroundPosture = Literal[
+    "minimal",
+    "normal",
+    "idle_more",
+    "deep_run_aggressive",
+]
+
+# Declared here for shared use across WS1 (config schema) and WS2
+# (hardware detection / tier_for()). WS2 owns the mapping logic.
+HardwareTier = Literal[
+    "light",
+    "capable",
+    "high_performance",
+    "unknown",
+]
+
+
+__all__ = [
+    "BackgroundPosture",
+    "CloudPosture",
+    "ComputePosture",
+    "HardwareTier",
+    "Priority",
+    "WorkStyle",
+]

--- a/src/vaner/setup/hardware.py
+++ b/src/vaner/setup/hardware.py
@@ -1,0 +1,629 @@
+"""Hardware detection for Vaner setup wizard.
+
+Read-only, fail-safe probes that build a :class:`HardwareProfile` snapshot of
+the local machine and map it to a :data:`HardwareTier` for policy-bundle
+selection (spec §6.1).
+
+Every probe is wrapped so that a missing dependency, a non-zero subprocess
+exit, a timeout, or unrecognised output yields a sensible default rather than
+raising. This module must import cleanly on any supported platform.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+from urllib import request as urlrequest
+from urllib.error import URLError
+
+from vaner.setup.enums import HardwareTier
+
+OS = Literal["linux", "darwin", "windows"]
+CPUClass = Literal["low", "mid", "high"]
+GPU = Literal["none", "integrated", "nvidia", "amd", "apple_silicon"]
+Runtime = Literal["ollama", "llama.cpp", "lmstudio", "vllm", "mlx"]
+
+_RUNTIMES: tuple[Runtime, ...] = ("ollama", "llama.cpp", "lmstudio", "vllm", "mlx")
+
+_HTTP_TIMEOUT = 1.0
+_SUBPROCESS_TIMEOUT = 2.0
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class HardwareProfile:
+    """Immutable snapshot of detected hardware capabilities.
+
+    The ``tier`` field is computed once at construction time so consumers do
+    not need to re-derive it.
+    """
+
+    os: OS
+    cpu_class: CPUClass
+    ram_gb: int
+    gpu: GPU
+    gpu_vram_gb: int | None
+    is_battery: bool
+    thermal_constrained: bool
+    detected_runtimes: tuple[Runtime, ...]
+    detected_models: tuple[tuple[str, str, str], ...]
+    tier: HardwareTier = field(default="unknown")
+
+
+# ---------------------------------------------------------------------------
+# OS / CPU / RAM probes
+# ---------------------------------------------------------------------------
+
+
+def _probe_os() -> OS | None:
+    """Return the host OS or ``None`` if it cannot be classified."""
+    try:
+        plat = sys.platform
+        if plat.startswith("linux"):
+            return "linux"
+        if plat == "darwin":
+            return "darwin"
+        if plat in {"win32", "cygwin"}:
+            return "windows"
+        # Fall back to platform.system() spelling.
+        sysname = platform.system().lower()
+        if sysname == "linux":
+            return "linux"
+        if sysname == "darwin":
+            return "darwin"
+        if sysname == "windows":
+            return "windows"
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("os probe failed", exc_info=True)
+    return None
+
+
+def _read_meminfo_gb() -> int | None:
+    """Parse Linux ``/proc/meminfo`` for total RAM in GB. Best-effort."""
+    try:
+        text = Path("/proc/meminfo").read_text()
+        for line in text.splitlines():
+            if line.startswith("MemTotal:"):
+                # MemTotal:       16327208 kB
+                parts = line.split()
+                kb = int(parts[1])
+                return max(1, round(kb / (1024 * 1024)))
+    except Exception:
+        logger.debug("/proc/meminfo probe failed", exc_info=True)
+    return None
+
+
+def _sysctl_memsize_gb() -> int | None:
+    """Run ``sysctl hw.memsize`` (macOS) and convert to GB. Best-effort."""
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        value = int(result.stdout.strip())
+        return max(1, round(value / (1024**3)))
+    except Exception:
+        logger.debug("sysctl hw.memsize failed", exc_info=True)
+        return None
+
+
+def _probe_cpu_and_ram() -> tuple[CPUClass, int]:
+    """Return CPU class + RAM in GB.
+
+    Heuristic for ``cpu_class`` (documented):
+
+    * ``low``  — fewer than 4 logical CPUs **or** less than 8 GB RAM.
+    * ``high`` — 12+ logical CPUs **and** 32+ GB RAM.
+    * ``mid``  — everything in between.
+
+    On total probe failure both return ``"low"`` / ``0``; the tier mapper then
+    treats the resulting profile as ``unknown``.
+    """
+    logical_cpus: int | None = None
+    ram_gb: int | None = None
+
+    try:
+        import psutil  # type: ignore[import-untyped]
+
+        logical_cpus = psutil.cpu_count(logical=True)
+        try:
+            vmem = psutil.virtual_memory()
+            ram_gb = max(1, round(vmem.total / (1024**3)))
+        except Exception:
+            logger.debug("psutil.virtual_memory failed", exc_info=True)
+    except ImportError:
+        logger.debug("psutil unavailable; falling back to stdlib")
+    except Exception:
+        logger.debug("psutil unavailable / errored", exc_info=True)
+
+    if logical_cpus is None:
+        try:
+            logical_cpus = os.cpu_count()
+        except Exception:
+            logical_cpus = None
+
+    if ram_gb is None:
+        plat = sys.platform
+        if plat.startswith("linux"):
+            ram_gb = _read_meminfo_gb()
+        elif plat == "darwin":
+            ram_gb = _sysctl_memsize_gb()
+        # Windows without psutil: leave ram_gb as None → 0 below.
+
+    cpu_count = logical_cpus or 0
+    ram = ram_gb or 0
+
+    if cpu_count == 0 and ram == 0:
+        return "low", 0
+
+    cpu_class: CPUClass
+    if cpu_count >= 12 and ram >= 32:
+        cpu_class = "high"
+    elif cpu_count < 4 or ram < 8:
+        cpu_class = "low"
+    else:
+        cpu_class = "mid"
+    return cpu_class, ram
+
+
+# ---------------------------------------------------------------------------
+# GPU probe
+# ---------------------------------------------------------------------------
+
+
+def _probe_gpu_nvidia() -> tuple[GPU, int | None] | None:
+    """Use pynvml when available to identify NVIDIA GPUs + VRAM."""
+    try:
+        import pynvml  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    except Exception:
+        logger.debug("pynvml import failed", exc_info=True)
+        return None
+
+    try:
+        pynvml.nvmlInit()
+        try:
+            count = pynvml.nvmlDeviceGetCount()
+            if count <= 0:
+                return None
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            vram_gb = max(1, round(mem.total / (1024**3)))
+            return "nvidia", vram_gb
+        finally:
+            try:
+                pynvml.nvmlShutdown()
+            except Exception:  # pragma: no cover - cleanup
+                logger.debug("nvmlShutdown failed", exc_info=True)
+    except Exception:
+        logger.debug("pynvml probe failed", exc_info=True)
+        return None
+
+
+def _probe_gpu_macos() -> tuple[GPU, int | None]:
+    """macOS: ``system_profiler SPDisplaysDataType -json`` parsing."""
+    try:
+        result = subprocess.run(
+            ["system_profiler", "SPDisplaysDataType", "-json"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return "none", None
+        data = json.loads(result.stdout)
+        displays = data.get("SPDisplaysDataType", [])
+        if not isinstance(displays, list) or not displays:
+            return "none", None
+        first = displays[0]
+        vendor = (first.get("spdisplays_vendor") or "").lower()
+        name = (first.get("sppci_model") or "").lower()
+        if "apple" in vendor or "apple" in name:
+            # Apple Silicon → unified memory; no separate VRAM number.
+            return "apple_silicon", None
+        if "nvidia" in vendor or "nvidia" in name:
+            return "nvidia", None
+        if "amd" in vendor or "amd" in name or "radeon" in name:
+            return "amd", None
+        if "intel" in vendor or "intel" in name:
+            return "integrated", None
+        return "integrated", None
+    except Exception:
+        logger.debug("system_profiler GPU probe failed", exc_info=True)
+        return "none", None
+
+
+def _probe_gpu_linux() -> tuple[GPU, int | None]:
+    """Linux fallback: ``lspci`` for VGA-class controllers."""
+    if not shutil.which("lspci"):
+        return "none", None
+    try:
+        result = subprocess.run(
+            ["lspci"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+        if result.returncode != 0:
+            return "none", None
+        text = result.stdout.lower()
+        # Filter to VGA / 3D / Display controller lines.
+        gpu_lines = [line for line in text.splitlines() if "vga" in line or "3d controller" in line or "display controller" in line]
+        if not gpu_lines:
+            return "none", None
+        joined = " ".join(gpu_lines)
+        if "nvidia" in joined:
+            return "nvidia", None
+        if "amd" in joined or "advanced micro devices" in joined or "radeon" in joined:
+            return "amd", None
+        if "intel" in joined:
+            return "integrated", None
+        return "integrated", None
+    except Exception:
+        logger.debug("lspci probe failed", exc_info=True)
+        return "none", None
+
+
+def _probe_gpu() -> tuple[GPU, int | None]:
+    """Compose GPU probes; never raises."""
+    try:
+        # NVIDIA via pynvml is the most reliable signal when present.
+        nvidia = _probe_gpu_nvidia()
+        if nvidia is not None:
+            return nvidia
+        plat = sys.platform
+        if plat == "darwin":
+            return _probe_gpu_macos()
+        if plat.startswith("linux"):
+            return _probe_gpu_linux()
+        return "none", None
+    except Exception:
+        logger.debug("GPU probe failed", exc_info=True)
+        return "none", None
+
+
+# ---------------------------------------------------------------------------
+# Battery / thermal
+# ---------------------------------------------------------------------------
+
+
+def _probe_battery() -> bool:
+    """Return True when a battery is present (laptop / portable)."""
+    try:
+        import psutil
+
+        try:
+            batt = psutil.sensors_battery()
+        except Exception:
+            batt = None
+        if batt is not None:
+            return True
+    except ImportError:
+        pass
+    except Exception:
+        logger.debug("psutil battery probe failed", exc_info=True)
+
+    if sys.platform.startswith("linux"):
+        try:
+            power = Path("/sys/class/power_supply")
+            if power.exists():
+                for entry in power.iterdir():
+                    if entry.name.upper().startswith("BAT"):
+                        return True
+        except Exception:
+            logger.debug("/sys/class/power_supply probe failed", exc_info=True)
+
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["pmset", "-g", "batt"],
+                capture_output=True,
+                text=True,
+                timeout=_SUBPROCESS_TIMEOUT,
+                check=False,
+            )
+            if result.returncode == 0 and "InternalBattery" in result.stdout:
+                return True
+        except Exception:
+            logger.debug("pmset battery probe failed", exc_info=True)
+
+    return False
+
+
+def _probe_thermal() -> bool:
+    """Best-effort thermal pressure hint.
+
+    Linux: read ``/sys/class/thermal/thermal_zone*/temp``; flag if any zone
+    reports above 85 °C. Returns False on every other platform / probe error.
+    """
+    if not sys.platform.startswith("linux"):
+        return False
+    try:
+        base = Path("/sys/class/thermal")
+        if not base.exists():
+            return False
+        for zone in base.glob("thermal_zone*"):
+            temp_file = zone / "temp"
+            try:
+                raw = temp_file.read_text().strip()
+                # Sysfs reports millidegrees Celsius.
+                centi = int(raw)
+                celsius = centi / 1000.0
+                if celsius >= 85.0:
+                    return True
+            except Exception:
+                continue
+    except Exception:
+        logger.debug("thermal probe failed", exc_info=True)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Runtime + model probes
+# ---------------------------------------------------------------------------
+
+
+def _http_get_ok(url: str, timeout: float = _HTTP_TIMEOUT) -> tuple[bool, str | None]:
+    """GET ``url`` and return ``(ok, body)``. ``ok`` is True iff status == 200."""
+    try:
+        req = urlrequest.Request(url, method="GET")
+        with urlrequest.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - localhost only
+            status = getattr(resp, "status", None) or resp.getcode()
+            if status != 200:
+                return False, None
+            try:
+                body = resp.read().decode("utf-8", errors="replace")
+            except Exception:
+                body = None
+            return True, body
+    except (URLError, TimeoutError, OSError):
+        return False, None
+    except Exception:
+        logger.debug("HTTP probe failed for %s", url, exc_info=True)
+        return False, None
+
+
+def _probe_ollama() -> bool:
+    if shutil.which("ollama"):
+        return True
+    ok, _ = _http_get_ok("http://127.0.0.1:11434/api/tags")
+    return ok
+
+
+def _probe_llama_cpp() -> bool:
+    return bool(shutil.which("llama-server") or shutil.which("llama-cpp-server"))
+
+
+def _probe_lmstudio() -> bool:
+    ok, _ = _http_get_ok("http://127.0.0.1:1234/v1/models")
+    return ok
+
+
+def _probe_vllm() -> bool:
+    return bool(shutil.which("vllm"))
+
+
+def _probe_mlx() -> bool:
+    if sys.platform != "darwin":
+        return False
+    if shutil.which("mlx_lm.generate"):
+        return True
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import mlx_lm"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        logger.debug("mlx import probe failed", exc_info=True)
+        return False
+
+
+def _probe_runtimes() -> tuple[Runtime, ...]:
+    """Return the tuple of locally detected runtimes. Never raises."""
+    found: list[Runtime] = []
+    probes: dict[Runtime, Callable[[], bool]] = {
+        "ollama": _probe_ollama,
+        "llama.cpp": _probe_llama_cpp,
+        "lmstudio": _probe_lmstudio,
+        "vllm": _probe_vllm,
+        "mlx": _probe_mlx,
+    }
+    for name in _RUNTIMES:
+        try:
+            if probes[name]():
+                found.append(name)
+        except Exception:
+            logger.debug("runtime probe %s failed", name, exc_info=True)
+    return tuple(found)
+
+
+def _label_size(size_bytes: int | None) -> str:
+    if not size_bytes or size_bytes <= 0:
+        return "unknown"
+    gb = size_bytes / (1024**3)
+    if gb < 1:
+        return f"{round(size_bytes / (1024**2))}MB"
+    return f"{gb:.1f}GB"
+
+
+def _probe_models_ollama() -> list[tuple[str, str, str]]:
+    ok, body = _http_get_ok("http://127.0.0.1:11434/api/tags")
+    if not ok or not body:
+        return []
+    try:
+        data = json.loads(body)
+    except Exception:
+        return []
+    rows: list[tuple[str, str, str]] = []
+    models = data.get("models") if isinstance(data, dict) else None
+    if not isinstance(models, list):
+        return []
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name") or entry.get("model")
+        size = entry.get("size")
+        if not isinstance(name, str):
+            continue
+        size_label = _label_size(size if isinstance(size, int) else None)
+        rows.append(("ollama", name, size_label))
+    return rows
+
+
+def _probe_models_lmstudio() -> list[tuple[str, str, str]]:
+    ok, body = _http_get_ok("http://127.0.0.1:1234/v1/models")
+    if not ok or not body:
+        return []
+    try:
+        data = json.loads(body)
+    except Exception:
+        return []
+    rows: list[tuple[str, str, str]] = []
+    items = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        return []
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        model_id = entry.get("id")
+        if not isinstance(model_id, str):
+            continue
+        # LM Studio's /v1/models doesn't expose size; leave label as unknown.
+        rows.append(("lmstudio", model_id, "unknown"))
+    return rows
+
+
+def _probe_models(runtimes: Sequence[str]) -> tuple[tuple[str, str, str], ...]:
+    """Best-effort model enumeration for runtimes that expose a list endpoint."""
+    rows: list[tuple[str, str, str]] = []
+    if "ollama" in runtimes:
+        try:
+            rows.extend(_probe_models_ollama())
+        except Exception:
+            logger.debug("ollama model probe failed", exc_info=True)
+    if "lmstudio" in runtimes:
+        try:
+            rows.extend(_probe_models_lmstudio())
+        except Exception:
+            logger.debug("lmstudio model probe failed", exc_info=True)
+    return tuple(rows)
+
+
+# ---------------------------------------------------------------------------
+# Tier mapping
+# ---------------------------------------------------------------------------
+
+
+def tier_for(profile: HardwareProfile) -> HardwareTier:
+    """Map a :class:`HardwareProfile` to a :data:`HardwareTier` (spec §6.1).
+
+    Rules (evaluated in order):
+
+    * ``unknown`` — RAM probe returned 0 GB (the OS probe is required for
+      construction but RAM == 0 is the strongest "we couldn't read anything"
+      signal).
+    * ``light`` — ``ram_gb < 16`` **or** (``gpu == "none"`` and ``cpu_class == "low"``)
+      **or** (``is_battery`` and ``ram_gb < 24``).
+    * ``high_performance`` — discrete or unified GPU
+      (``gpu in {"nvidia", "apple_silicon"}``) with ``gpu_vram_gb`` either
+      unknown (Apple Silicon shares RAM) or ``>= 16``, ``ram_gb >= 32``, and
+      not on battery.
+    * ``capable`` — everything else.
+    """
+    if profile.ram_gb <= 0:
+        return "unknown"
+    if profile.ram_gb < 16:
+        return "light"
+    if profile.gpu == "none" and profile.cpu_class == "low":
+        return "light"
+    if profile.is_battery and profile.ram_gb < 24:
+        return "light"
+    if (
+        profile.gpu in ("nvidia", "apple_silicon")
+        and (profile.gpu_vram_gb is None or profile.gpu_vram_gb >= 16)
+        and profile.ram_gb >= 32
+        and not profile.is_battery
+    ):
+        return "high_performance"
+    return "capable"
+
+
+# ---------------------------------------------------------------------------
+# Top-level detect()
+# ---------------------------------------------------------------------------
+
+
+def detect() -> HardwareProfile:
+    """Compose every probe and return a frozen :class:`HardwareProfile`.
+
+    Pure modulo system probes; no caching at module level. The daemon decides
+    when to cache (typically once at startup).
+    """
+    os_kind = _probe_os()
+    cpu_class, ram_gb = _probe_cpu_and_ram()
+    gpu, gpu_vram_gb = _probe_gpu()
+    is_battery = _probe_battery()
+    thermal = _probe_thermal()
+    runtimes = _probe_runtimes()
+    models = _probe_models(runtimes)
+
+    # When the OS probe fails entirely we still need a literal value for the
+    # frozen dataclass; fall back to "linux" but force the tier to "unknown"
+    # so consumers treat the snapshot as untrusted.
+    effective_os: OS = os_kind if os_kind is not None else "linux"
+
+    profile = HardwareProfile(
+        os=effective_os,
+        cpu_class=cpu_class,
+        ram_gb=ram_gb,
+        gpu=gpu,
+        gpu_vram_gb=gpu_vram_gb,
+        is_battery=is_battery,
+        thermal_constrained=thermal,
+        detected_runtimes=runtimes,
+        detected_models=models,
+        tier="unknown",
+    )
+    final_tier: HardwareTier = "unknown" if os_kind is None else tier_for(profile)
+    return HardwareProfile(
+        os=effective_os,
+        cpu_class=cpu_class,
+        ram_gb=ram_gb,
+        gpu=gpu,
+        gpu_vram_gb=gpu_vram_gb,
+        is_battery=is_battery,
+        thermal_constrained=thermal,
+        detected_runtimes=runtimes,
+        detected_models=models,
+        tier=final_tier,
+    )
+
+
+__all__ = [
+    "HardwareProfile",
+    "HardwareTier",
+    "detect",
+    "tier_for",
+]

--- a/src/vaner/setup/policy.py
+++ b/src/vaner/setup/policy.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: VanerPolicyBundle dataclass (0.8.6).
+
+A *policy bundle* is the intermediate layer between Simple-Mode wizard
+answers and the engine's existing knobs. Each bundle:
+
+- Names an outcome-level archetype (e.g. *"Local Balanced"*, *"Hybrid
+  Quality"*) that a non-technical user can recognise.
+- Carries the seven dimensions the engine actually consults
+  (cloud posture, runtime profile, spend profile, latency profile,
+  privacy profile, prediction-horizon bias, drafting aggressiveness,
+  exploration ratio, persistence strength, goal weighting,
+  context-injection default, deep-run profile).
+- Composes additively with Deep-Run preset overrides at session start
+  (see :mod:`vaner.intent.deep_run_policy`); bundles set the *baseline*,
+  Deep-Run sessions layer additive overrides on top.
+
+The single source of truth for the seven shipped bundles is
+:data:`vaner.setup.catalog.PROFILE_CATALOG`. WS3's selection algorithm
+filters and scores that catalogue against the user's
+:class:`SetupAnswers` and :class:`HardwareProfile`.
+
+The bundle dataclass is **frozen**: bundles are pure data, never mutated.
+``PolicyConfig.bundle_overrides`` (a free-form dict on the config
+schema) carries the user's per-knob deviations from the selected
+bundle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+from vaner.intent.deep_run import DeepRunPreset
+
+# Mirror of ``ContextInjectionConfig.mode`` (see
+# :mod:`vaner.models.config`). Repeated here verbatim because the source
+# Literal is declared inline on the field rather than as a named alias.
+# Keep these two lists in sync; a mismatch surfaces as a Pydantic
+# validation error when the bundle's value flows into the integration
+# config.
+ContextInjectionMode = Literal[
+    "none",
+    "digest_only",
+    "adopted_package_only",
+    "top_match_auto_include",
+    "policy_hybrid",
+    "client_controlled",
+]
+
+# The four horizon-bias buckets surfaced to the engine's frontier
+# scoring. These are the same four values used by Deep-Run's
+# ``HorizonBiasSpec`` (see :mod:`vaner.intent.deep_run_policy`); the
+# bundle's ``prediction_horizon_bias`` mapping is a per-bundle weight
+# distribution over these buckets, *not* a single chosen mode. The
+# engine multiplies these weights into its frontier scoring at cycle
+# time.
+PredictionHorizonKey = Literal[
+    "likely_next",
+    "long_horizon",
+    "finish_partials",
+    "balanced",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class VanerPolicyBundle:
+    """One outcome-level policy bundle.
+
+    Field meanings (spec §8):
+
+    - ``id`` — stable kebab-case identifier; used as the foreign key in
+      ``PolicyConfig.selected_bundle_id``. Never displayed to users.
+    - ``label`` — short human-readable name (Title Case). Shown in the
+      desktop summary card and the CLI ``vaner setup show`` output.
+    - ``description`` — one-sentence explanation of who the bundle is
+      for. Shown under the label in any surface that has the room.
+    - ``local_cloud_posture`` — flows into ``BackendConfig.prefer_local``,
+      the ``ExplorationConfig.endpoints`` cloud filter, and the
+      Deep-Run default ``locality``.
+    - ``runtime_profile`` — selects the local-runtime preference band
+      (``"small"`` / ``"medium"`` / ``"large"``) the exploration pool
+      consults when more than one local model is detected.
+    - ``spend_profile`` — drives ``BackendConfig.remote_budget_per_hour``
+      and the Deep-Run default ``cost_cap_usd``.
+    - ``latency_profile`` — informs the exploration pool's
+      latency-vs-quality tie-break.
+    - ``privacy_profile`` — interacts with cloud_posture; sets the
+      strictness floor that the user cannot accidentally relax via a
+      bundle re-selection (see WS5 invariant test).
+    - ``prediction_horizon_bias`` — frozen mapping over the four
+      horizon-bias keys; weights compose multiplicatively with
+      Deep-Run's ``HorizonBiasSpec`` at session time.
+    - ``drafting_aggressiveness`` — multiplier on the drafter's
+      evidence threshold. ``1.0`` is neutral; ``< 1.0`` requires more
+      evidence (conservative drafts), ``> 1.0`` is more permissive.
+    - ``exploration_ratio`` — added to ``ExplorationConfig`` invest /
+      exploit balance.
+    - ``persistence_strength`` — multiplier on memory-decay resistance;
+      higher values keep predictions warm longer.
+    - ``goal_weighting`` — multiplier on goal-aligned prediction
+      scoring (see ``IntentConfig`` goal-weighting in 0.8.2+).
+    - ``context_injection_default`` — per-tier default for
+      ``IntegrationsConfig.context_injection.mode``. Capability tiers
+      may downgrade this floor at run time.
+    - ``deep_run_profile`` — default Deep-Run preset when the user
+      opens "Start Deep-Run".
+    """
+
+    id: str
+    label: str
+    description: str
+    local_cloud_posture: Literal[
+        "local_only",
+        "local_preferred",
+        "hybrid",
+        "cloud_preferred",
+    ]
+    runtime_profile: Literal["small", "medium", "large", "auto"]
+    spend_profile: Literal["zero", "low", "medium", "high"]
+    latency_profile: Literal["snappy", "balanced", "quality"]
+    privacy_profile: Literal["strict", "standard", "relaxed"]
+    prediction_horizon_bias: Mapping[PredictionHorizonKey, float]
+    drafting_aggressiveness: float
+    exploration_ratio: float
+    persistence_strength: float
+    goal_weighting: float
+    context_injection_default: ContextInjectionMode
+    deep_run_profile: DeepRunPreset
+
+    # Internal: bundles are intended to be defined as module-level
+    # constants. The ``__post_init__`` freeze step ensures any
+    # ``prediction_horizon_bias`` passed as a plain ``dict`` is wrapped
+    # in a ``MappingProxyType`` so the bundle remains structurally
+    # immutable (the dataclass itself is already frozen against
+    # attribute reassignment).
+    def __post_init__(self) -> None:
+        # Use object.__setattr__ because the dataclass is frozen.
+        if not isinstance(self.prediction_horizon_bias, MappingProxyType):
+            object.__setattr__(
+                self,
+                "prediction_horizon_bias",
+                MappingProxyType(dict(self.prediction_horizon_bias)),
+            )
+        # Validate the mapping keys match exactly the four expected
+        # literals — guards against typos in catalogue entries.
+        expected_keys = {"likely_next", "long_horizon", "finish_partials", "balanced"}
+        actual_keys = set(self.prediction_horizon_bias.keys())
+        if actual_keys != expected_keys:
+            missing = expected_keys - actual_keys
+            extra = actual_keys - expected_keys
+            raise ValueError(
+                f"VanerPolicyBundle.prediction_horizon_bias keys must be exactly "
+                f"{sorted(expected_keys)}; missing={sorted(missing)} extra={sorted(extra)}"
+            )
+
+
+# Re-export for convenience; downstream modules can import everything
+# they need from ``vaner.setup.policy``.
+__all__ = [
+    "ContextInjectionMode",
+    "PredictionHorizonKey",
+    "VanerPolicyBundle",
+]

--- a/src/vaner/setup/select.py
+++ b/src/vaner/setup/select.py
@@ -1,0 +1,535 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS3 — Setup primitives: policy-bundle selection (0.8.6).
+
+Pure ``filter -> score -> pick`` pipeline that maps a
+:class:`SetupAnswers` plus a :class:`HardwareProfile` snapshot to one of
+the seven bundles in :data:`vaner.setup.catalog.PROFILE_CATALOG` (spec
+§10). The function is deterministic by construction — no I/O, no
+clocks, no randomness, no nondeterministic dict iteration. Same input
+always produces a byte-identical :class:`SelectionResult`, including
+the ``reasons`` tuple and the ``runner_ups`` ordering.
+
+Design notes:
+
+- **Filter** drops bundles that would violate hard user posture (e.g.
+  the user said *local only* and the bundle uses a cloud-preferred
+  posture) or hard hardware limits (e.g. ``unknown`` tier means we
+  cannot promise large-local will work, so we don't recommend it).
+  Each filter is a small named callable so it can be unit-tested in
+  isolation.
+- **Score** runs six small ``_*_match`` callables, each returning a
+  ``(score, reason)`` pair in ``[-1.0, 1.0]``. Total range across the
+  six is roughly ``[-6, +6]``; ties break alphabetically on bundle id
+  for determinism.
+- **Forced fallback** — if filters empty the candidate set, we re-run
+  with priority + hardware filters relaxed (cloud posture is the one
+  hard-line the user explicitly stated). If even that produces
+  nothing, we return :data:`local_lightweight` as the safest possible
+  default and flag ``forced_fallback=True``.
+
+The match weights are intentionally small integer-ish floats: the goal
+is for the *filter* to do most of the work and the *score* to break
+the remaining ties in a way the user can read in the disclosure
+panel. We deliberately avoid neural / continuous knobs here — the
+user-facing reasons must remain explainable.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.catalog import PROFILE_CATALOG, bundle_by_id
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    HardwareTier,
+    Priority,
+    WorkStyle,
+)
+from vaner.setup.hardware import HardwareProfile
+from vaner.setup.policy import VanerPolicyBundle
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionResult:
+    """Output of :func:`select_policy_bundle`.
+
+    - ``bundle`` — the chosen :class:`VanerPolicyBundle`.
+    - ``score`` — aggregate match score for the chosen bundle. Ranges
+      roughly across ``[-6.0, +6.0]``; values are diagnostic only and
+      should not be exposed verbatim to end users.
+    - ``reasons`` — short human-readable strings explaining *why* this
+      bundle won. Empty tuple means we hit the forced-fallback path.
+    - ``runner_ups`` — up to two next-best bundles in score order,
+      excluding the chosen one. Drives the desktop disclosure panel.
+    - ``forced_fallback`` — ``True`` only when the filters emptied the
+      candidate set entirely and we returned the safe default. The
+      desktop UI should surface this as a warning.
+    """
+
+    bundle: VanerPolicyBundle
+    score: float
+    reasons: tuple[str, ...]
+    runner_ups: tuple[VanerPolicyBundle, ...]
+    forced_fallback: bool
+
+
+# ---------------------------------------------------------------------------
+# Filters — each takes (answers, hardware, bundle) and returns either
+# None (keep) or a string explaining why the bundle was dropped.
+# ---------------------------------------------------------------------------
+
+
+_FilterFn = Callable[
+    [SetupAnswers, HardwareProfile, VanerPolicyBundle],
+    str | None,
+]
+
+
+def _filter_cloud_posture(
+    answers: SetupAnswers,
+    _hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """Drop bundles that violate the user's stated cloud posture."""
+    cloud = answers.cloud_posture
+    posture = bundle.local_cloud_posture
+    if cloud == "local_only" and posture in ("hybrid", "cloud_preferred"):
+        return f"{bundle.id} uses cloud ({posture}); user requested local_only"
+    if cloud == "ask_first" and posture == "cloud_preferred":
+        return f"{bundle.id} prefers cloud; user said ask_first"
+    return None
+
+
+def _filter_priority_privacy(
+    answers: SetupAnswers,
+    _hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """Drop bundles that expose data more loosely than ``privacy``."""
+    if answers.priority != "privacy":
+        return None
+    # Privacy-conscious users get strict-or-standard floors only. The
+    # current catalogue ships no "relaxed" bundles, but we keep the
+    # filter so future additions (e.g. a "cloud-first" preset) cannot
+    # silently match a privacy-priority user.
+    if bundle.privacy_profile == "relaxed":
+        return f"{bundle.id} is privacy=relaxed; user prioritised privacy"
+    # "Cloud OK" interpretation — bundles whose cloud posture is the
+    # cloud-preferred bucket are also dropped under priority=privacy.
+    if bundle.local_cloud_posture == "cloud_preferred":
+        return f"{bundle.id} prefers cloud; user prioritised privacy"
+    return None
+
+
+def _filter_priority_low_resource(
+    answers: SetupAnswers,
+    _hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """Drop heavy-local bundles when the user said low_resource."""
+    if answers.priority != "low_resource":
+        return None
+    if bundle.runtime_profile == "large" and bundle.local_cloud_posture in (
+        "local_only",
+        "local_preferred",
+    ):
+        return f"{bundle.id} is heavy local; user prioritised low_resource"
+    return None
+
+
+def _filter_hardware_tier(
+    _answers: SetupAnswers,
+    hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """Drop bundles the device cannot reasonably run.
+
+    - ``light`` hardware — drop ``runtime_profile=large`` regardless of
+      posture. A small laptop should not promise local 30B-plus.
+    - ``unknown`` tier — drop ``runtime_profile=large`` (we cannot
+      promise it works) and ``local_cloud_posture=local_only`` (we
+      cannot promise local works at all without detection); steer the
+      user toward cloud-recommended defaults.
+    """
+    tier = hardware.tier
+    if tier == "light" and bundle.runtime_profile == "large":
+        return f"{bundle.id} needs large runtime; hardware tier is light"
+    if tier == "unknown":
+        if bundle.runtime_profile == "large":
+            return f"{bundle.id} needs large runtime; hardware tier unknown"
+        if bundle.local_cloud_posture == "local_only":
+            return f"{bundle.id} is local_only; hardware tier unknown"
+    return None
+
+
+def _filter_battery_cost(
+    answers: SetupAnswers,
+    hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """On battery + cost priority, drop cloud-spending bundles."""
+    if answers.priority != "cost":
+        return None
+    if not hardware.is_battery:
+        return None
+    if hardware.tier != "light":
+        return None
+    if bundle.spend_profile in ("medium", "high"):
+        return f"{bundle.id} spends on cloud; user is on battery + cost"
+    return None
+
+
+# Order matters only for filter dropped-reason output; logic is
+# commutative. Tuple is immutable so the iteration order is fixed.
+_FILTERS: tuple[_FilterFn, ...] = (
+    _filter_cloud_posture,
+    _filter_priority_privacy,
+    _filter_priority_low_resource,
+    _filter_hardware_tier,
+    _filter_battery_cost,
+)
+
+
+def _apply_filters(
+    answers: SetupAnswers,
+    hardware: HardwareProfile,
+    candidates: Iterable[VanerPolicyBundle],
+    filters: tuple[_FilterFn, ...] = _FILTERS,
+) -> tuple[tuple[VanerPolicyBundle, ...], tuple[tuple[str, str], ...]]:
+    """Run all filters; return (kept, dropped_with_reason).
+
+    ``dropped_with_reason`` is a tuple of ``(bundle_id, reason)`` pairs
+    so callers (mostly tests) can introspect which filters fired.
+    """
+    kept: list[VanerPolicyBundle] = []
+    dropped: list[tuple[str, str]] = []
+    for bundle in candidates:
+        drop_reason: str | None = None
+        for fn in filters:
+            reason = fn(answers, hardware, bundle)
+            if reason is not None:
+                drop_reason = reason
+                break
+        if drop_reason is None:
+            kept.append(bundle)
+        else:
+            dropped.append((bundle.id, drop_reason))
+    return tuple(kept), tuple(dropped)
+
+
+# ---------------------------------------------------------------------------
+# Match functions — each returns (score in [-1.0, 1.0], reason)
+# ---------------------------------------------------------------------------
+
+
+def _priority_match(priority: Priority, bundle: VanerPolicyBundle) -> tuple[float, str]:
+    """Match the user's top-level priority against the bundle profile."""
+    if priority == "speed":
+        if bundle.latency_profile == "snappy":
+            return 1.0, f"Speed-first → {bundle.id} is snappy"
+        if bundle.latency_profile == "balanced":
+            return 0.3, f"Speed-first → {bundle.id} is balanced"
+        return -0.5, f"Speed-first → {bundle.id} prioritises quality"
+    if priority == "quality":
+        if bundle.latency_profile == "quality":
+            return 1.0, f"Quality-first → {bundle.id} prioritises quality"
+        if bundle.latency_profile == "balanced":
+            return 0.2, f"Quality-first → {bundle.id} is balanced"
+        return -0.3, f"Quality-first → {bundle.id} is snappy"
+    if priority == "privacy":
+        if bundle.privacy_profile == "strict":
+            return 1.0, f"Privacy-first → {bundle.id} is strict"
+        if bundle.privacy_profile == "standard":
+            return 0.2, f"Privacy-first → {bundle.id} is standard"
+        return -1.0, f"Privacy-first → {bundle.id} is relaxed"
+    if priority == "cost":
+        if bundle.spend_profile == "zero":
+            return 1.0, f"Cost-first → {bundle.id} spends nothing"
+        if bundle.spend_profile == "low":
+            return 0.5, f"Cost-first → {bundle.id} spends little"
+        return -0.5, f"Cost-first → {bundle.id} spends mid/high"
+    if priority == "low_resource":
+        if bundle.runtime_profile == "small":
+            return 1.0, f"Low-resource → {bundle.id} runs small"
+        if bundle.runtime_profile == "medium":
+            return 0.0, f"Low-resource → {bundle.id} runs medium"
+        return -0.7, f"Low-resource → {bundle.id} runs large"
+    # priority == "balanced"
+    if bundle.id == "hybrid_balanced":
+        return 1.0, "Balanced priority → hybrid_balanced is the canonical default"
+    if bundle.latency_profile == "balanced":
+        return 0.4, f"Balanced priority → {bundle.id} is balanced"
+    return 0.0, f"Balanced priority → {bundle.id} is acceptable"
+
+
+def _hardware_match(tier: HardwareTier, bundle: VanerPolicyBundle) -> tuple[float, str]:
+    """Map hardware tier to runtime profile preference."""
+    if tier == "high_performance":
+        if bundle.runtime_profile == "large":
+            return 1.0, f"High-performance hardware → {bundle.id} runs large"
+        if bundle.runtime_profile == "medium":
+            return 0.2, f"High-performance hardware → {bundle.id} runs medium"
+        return -0.4, f"High-performance hardware → {bundle.id} runs small"
+    if tier == "capable":
+        if bundle.runtime_profile == "medium":
+            return 1.0, f"Capable hardware → {bundle.id} runs medium"
+        if bundle.runtime_profile == "small":
+            return 0.3, f"Capable hardware → {bundle.id} runs small"
+        return -0.2, f"Capable hardware → {bundle.id} runs large"
+    if tier == "light":
+        if bundle.runtime_profile == "small":
+            return 1.0, f"Light hardware → {bundle.id} runs small"
+        if bundle.runtime_profile == "medium":
+            return -0.3, f"Light hardware → {bundle.id} runs medium"
+        return -1.0, f"Light hardware → {bundle.id} runs large"
+    # tier == "unknown"
+    if bundle.local_cloud_posture in ("hybrid", "cloud_preferred"):
+        return 0.6, f"Unknown hardware → {bundle.id} can lean on cloud"
+    if bundle.runtime_profile == "small":
+        return 0.2, f"Unknown hardware → {bundle.id} stays modest"
+    return -0.2, f"Unknown hardware → {bundle.id} assumes more than we know"
+
+
+_WORKSTYLE_BUNDLE_AFFINITY: dict[WorkStyle, dict[str, float]] = {
+    "writing": {"deep_research": 1.0, "hybrid_quality": 0.6, "local_balanced": 0.2},
+    "research": {"deep_research": 1.0, "hybrid_quality": 0.6, "local_heavy": 0.4},
+    "planning": {"deep_research": 0.8, "hybrid_balanced": 0.4, "local_balanced": 0.4},
+    "support": {"hybrid_balanced": 0.6, "local_balanced": 0.4, "cost_saver": 0.4},
+    "learning": {"local_balanced": 0.6, "hybrid_balanced": 0.4, "cost_saver": 0.2},
+    "coding": {"local_balanced": 0.8, "hybrid_quality": 0.4, "local_heavy": 0.4},
+    "general": {"hybrid_balanced": 0.6, "local_balanced": 0.4},
+    "mixed": {"hybrid_balanced": 0.6, "local_balanced": 0.4},
+    "unsure": {"hybrid_balanced": 0.8, "local_balanced": 0.2},
+}
+
+
+def _workstyle_match(
+    work_styles: tuple[WorkStyle, ...],
+    bundle: VanerPolicyBundle,
+) -> tuple[float, str]:
+    """Average per-work-style affinity scores into one (score, reason).
+
+    Multiple work styles average their per-bundle weights — explicit
+    and predictable per the plan's guidance.
+    """
+    if not work_styles:
+        return 0.0, f"No work styles → no affinity for {bundle.id}"
+    per_style: list[float] = [_WORKSTYLE_BUNDLE_AFFINITY.get(ws, {}).get(bundle.id, 0.0) for ws in work_styles]
+    avg = sum(per_style) / len(per_style)
+    # Clamp to the contracted range.
+    avg = max(-1.0, min(1.0, avg))
+    if avg > 0:
+        styles_label = "/".join(work_styles)
+        return avg, f"Work style {styles_label} → {bundle.id} fits"
+    return avg, f"Work styles do not particularly favour {bundle.id}"
+
+
+def _cloud_match(cloud: CloudPosture, bundle: VanerPolicyBundle) -> tuple[float, str]:
+    """Reward bundles that match the user's cloud posture preference."""
+    posture = bundle.local_cloud_posture
+    if cloud == "local_only":
+        if posture == "local_only":
+            return 1.0, f"Local-only requested → {bundle.id} is local_only"
+        if posture == "local_preferred":
+            return 0.3, f"Local-only requested → {bundle.id} is local-preferred"
+        return -1.0, f"Local-only requested → {bundle.id} reaches for cloud"
+    if cloud == "ask_first":
+        if posture == "local_preferred":
+            return 1.0, f"Ask-first → {bundle.id} prefers local but can hybrid"
+        if posture in ("local_only", "hybrid"):
+            return 0.4, f"Ask-first → {bundle.id} keeps cloud opt-in"
+        return -0.5, f"Ask-first → {bundle.id} leans cloud"
+    if cloud == "hybrid_when_worth_it":
+        if posture == "hybrid":
+            return 1.0, f"Hybrid-when-worth-it → {bundle.id} is hybrid"
+        if posture == "local_preferred":
+            return 0.4, f"Hybrid-when-worth-it → {bundle.id} prefers local"
+        if posture == "cloud_preferred":
+            return 0.2, f"Hybrid-when-worth-it → {bundle.id} prefers cloud"
+        return -0.2, f"Hybrid-when-worth-it → {bundle.id} is local_only"
+    # cloud == "best_available"
+    if posture == "cloud_preferred":
+        return 1.0, f"Best-available → {bundle.id} prefers cloud"
+    if posture == "hybrid":
+        return 0.6, f"Best-available → {bundle.id} is hybrid"
+    return -0.4, f"Best-available → {bundle.id} stays local"
+
+
+def _resource_match(
+    compute: ComputePosture,
+    bundle: VanerPolicyBundle,
+) -> tuple[float, str]:
+    """Map compute posture to runtime / horizon weight."""
+    if compute == "light":
+        if bundle.runtime_profile == "small":
+            return 1.0, f"Light compute posture → {bundle.id} runs small"
+        if bundle.runtime_profile == "medium":
+            return 0.0, f"Light compute posture → {bundle.id} runs medium"
+        return -0.6, f"Light compute posture → {bundle.id} runs large"
+    if compute == "available_power":
+        if bundle.runtime_profile == "large":
+            return 1.0, f"Available-power posture → {bundle.id} runs large"
+        if bundle.runtime_profile == "medium":
+            return 0.3, f"Available-power posture → {bundle.id} runs medium"
+        return -0.2, f"Available-power posture → {bundle.id} runs small"
+    # compute == "balanced"
+    if bundle.runtime_profile == "medium":
+        return 0.6, f"Balanced compute posture → {bundle.id} runs medium"
+    return 0.1, f"Balanced compute posture → {bundle.id} is acceptable"
+
+
+def _background_match(
+    background: BackgroundPosture,
+    bundle: VanerPolicyBundle,
+) -> tuple[float, str]:
+    """Map background-pondering posture to deep-run profile."""
+    deep = bundle.deep_run_profile
+    if background == "minimal":
+        if deep == "conservative":
+            return 1.0, f"Minimal background → {bundle.id} is conservative"
+        if deep == "balanced":
+            return 0.0, f"Minimal background → {bundle.id} is balanced"
+        return -0.6, f"Minimal background → {bundle.id} is aggressive"
+    if background == "normal":
+        if deep == "balanced":
+            return 1.0, f"Normal background → {bundle.id} is balanced"
+        return 0.2, f"Normal background → {bundle.id} is {deep}"
+    if background == "idle_more":
+        if deep == "balanced":
+            return 0.6, f"Idle-more background → {bundle.id} is balanced"
+        if deep == "aggressive":
+            return 0.8, f"Idle-more background → {bundle.id} is aggressive"
+        return -0.2, f"Idle-more background → {bundle.id} is conservative"
+    # background == "deep_run_aggressive"
+    if bundle.id in ("deep_research", "hybrid_quality"):
+        return 1.0, f"Deep-run-aggressive → {bundle.id} matches"
+    if deep == "aggressive":
+        return 0.7, f"Deep-run-aggressive → {bundle.id} is aggressive"
+    if deep == "balanced":
+        return 0.0, f"Deep-run-aggressive → {bundle.id} is balanced"
+    return -0.5, f"Deep-run-aggressive → {bundle.id} is conservative"
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+def _score_bundle(
+    answers: SetupAnswers,
+    hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> tuple[float, tuple[str, ...]]:
+    """Run every match function and return the summed score + reasons.
+
+    Only reasons whose component score is strictly positive are
+    included — the disclosure panel should explain why this bundle
+    *won*, not the long list of negatives. Reason order is fixed so
+    the result is byte-deterministic.
+    """
+    components: list[tuple[float, str]] = [
+        _priority_match(answers.priority, bundle),
+        _hardware_match(hardware.tier, bundle),
+        _workstyle_match(answers.work_styles, bundle),
+        _cloud_match(answers.cloud_posture, bundle),
+        _resource_match(answers.compute_posture, bundle),
+        _background_match(answers.background_posture, bundle),
+    ]
+    total = sum(score for score, _ in components)
+    positive_reasons = tuple(reason for score, reason in components if score > 0.0)
+    return total, positive_reasons
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+_FORCED_FALLBACK_BUNDLE_ID: str = "local_lightweight"
+
+
+def select_policy_bundle(
+    answers: SetupAnswers,
+    hardware: HardwareProfile,
+) -> SelectionResult:
+    """Pick the best-fit policy bundle for the given answers + hardware.
+
+    Pure function — same inputs always produce the exact same
+    :class:`SelectionResult` (including ``reasons`` and ``runner_ups``
+    ordering). Implementation is filter → score → pick with a
+    deterministic alphabetical-id tiebreaker.
+    """
+
+    kept, _dropped = _apply_filters(answers, hardware, PROFILE_CATALOG)
+
+    forced_fallback = False
+    if not kept:
+        # Relax the priority + hardware filters; cloud posture is the
+        # one explicit user wish we do not silently widen.
+        relaxed_filters: tuple[_FilterFn, ...] = (_filter_cloud_posture,)
+        kept, _dropped = _apply_filters(
+            answers,
+            hardware,
+            PROFILE_CATALOG,
+            filters=relaxed_filters,
+        )
+
+    if not kept:
+        # Even cloud-posture-only filtering wiped the catalogue
+        # (theoretical — cloud_posture filters never drop more than
+        # five bundles). Hand back the safe local default and flag.
+        forced_fallback = True
+        fallback = bundle_by_id(_FORCED_FALLBACK_BUNDLE_ID)
+        return SelectionResult(
+            bundle=fallback,
+            score=0.0,
+            reasons=("No bundle matched filters; returning safest local default.",),
+            runner_ups=(),
+            forced_fallback=True,
+        )
+
+    scored: list[tuple[float, str, VanerPolicyBundle, tuple[str, ...]]] = []
+    for bundle in kept:
+        score, reasons = _score_bundle(answers, hardware, bundle)
+        scored.append((score, bundle.id, bundle, reasons))
+
+    # Deterministic ordering: highest score first; alphabetical id
+    # breaks ties. Sorting on a (negated-score, id) key gives a
+    # stable, total order — Python's sort is also stable so even
+    # equal keys preserve catalogue order.
+    scored.sort(key=lambda item: (-item[0], item[1]))
+
+    chosen_score, _chosen_id, chosen_bundle, chosen_reasons = scored[0]
+    runner_ups = tuple(item[2] for item in scored[1:3])
+
+    logger.debug(
+        "select_policy_bundle picked %s with score %.3f (forced_fallback=%s)",
+        chosen_bundle.id,
+        chosen_score,
+        forced_fallback,
+    )
+    return SelectionResult(
+        bundle=chosen_bundle,
+        score=chosen_score,
+        reasons=chosen_reasons,
+        runner_ups=runner_ups,
+        forced_fallback=forced_fallback,
+    )
+
+
+__all__ = [
+    "SelectionResult",
+    "select_policy_bundle",
+]

--- a/tests/test_intent/test_work_style_priors.py
+++ b/tests/test_intent/test_work_style_priors.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS4 — Work-style intent prior tests (0.8.6).
+
+Pure-data invariants on :data:`WORK_STYLE_PRIORS` plus the
+:func:`adjustments_for` averaging helper, the
+:func:`compose_with_deep_run_preset` math, and the engine-level
+no-op-by-default invariant.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+
+from vaner.intent.work_style_priors import (
+    WORK_STYLE_PRIORS,
+    IntentPriorAdjustments,
+    adjustments_for,
+    compose_with_deep_run_preset,
+    default_adjustments,
+)
+from vaner.setup.enums import WorkStyle
+
+# ---------------------------------------------------------------------------
+# Table invariants
+# ---------------------------------------------------------------------------
+
+
+def test_table_keys_match_workstyle_literal() -> None:
+    """Every value in the WorkStyle Literal MUST have an entry in
+    :data:`WORK_STYLE_PRIORS`. Adding a new style without populating
+    the table is the kind of silent gap WS4 was built to prevent.
+    """
+
+    literal_values = set(get_args(WorkStyle))
+    table_keys = set(WORK_STYLE_PRIORS.keys())
+    assert table_keys == literal_values, (
+        f"WORK_STYLE_PRIORS drift: missing={literal_values - table_keys}, extra={table_keys - literal_values}"
+    )
+
+
+@pytest.mark.parametrize("style", list(get_args(WorkStyle)))
+def test_multipliers_inside_conservative_range(style: WorkStyle) -> None:
+    """Spec §7 fixes the multiplier range at ``[0.7, 1.5]`` and the
+    drafting floor at ``[0.0, 0.6]``. Drift past these edges means the
+    table has gone from explainable nudges to a tuning monster — fail
+    fast so the reviewer notices.
+    """
+
+    spec = WORK_STYLE_PRIORS[style]
+    assert 0.7 <= spec.artefact_alignment_weight_multiplier <= 1.5
+    assert 0.7 <= spec.long_horizon_bonus_multiplier <= 1.5
+    assert 0.7 <= spec.possible_branch_bonus_multiplier <= 1.5
+    assert 0.7 <= spec.drafting_volatility_ceiling_multiplier <= 1.5
+    assert 0.0 <= spec.drafting_evidence_floor <= 0.6
+
+
+def test_mixed_is_neutral() -> None:
+    """``adjustments_for(("mixed",))`` MUST return the identity element.
+
+    Engines on default ``setup.work_styles == ["mixed"]`` configs MUST
+    see byte-identical behaviour to pre-WS4. This is the load-bearing
+    invariant for the whole work-style layer.
+    """
+
+    adj = adjustments_for(("mixed",))
+    assert adj.artefact_alignment_weight_multiplier == 1.0
+    assert adj.long_horizon_bonus_multiplier == 1.0
+    assert adj.possible_branch_bonus_multiplier == 1.0
+    assert adj.drafting_evidence_floor == 0.0
+    assert adj.drafting_volatility_ceiling_multiplier == 1.0
+    assert adj.preferred_artefact_templates == ()
+
+
+def test_default_adjustments_equals_mixed() -> None:
+    """``default_adjustments()`` must be the mixed identity element."""
+
+    assert default_adjustments() == adjustments_for(("mixed",))
+
+
+def test_empty_input_falls_back_to_default() -> None:
+    """Empty work_styles list → default identity (defensive)."""
+
+    assert adjustments_for(()) == default_adjustments()
+    assert adjustments_for([]) == default_adjustments()
+
+
+# ---------------------------------------------------------------------------
+# Averaging
+# ---------------------------------------------------------------------------
+
+
+def test_averaging_two_styles() -> None:
+    """``adjustments_for(("research","planning"))`` MUST return the
+    arithmetic mean of the per-style multipliers — not the geometric
+    mean, not "first wins". Checked numerically on one field so the
+    test fails on accidental policy drift.
+    """
+
+    adj = adjustments_for(("research", "planning"))
+    research = WORK_STYLE_PRIORS["research"]
+    planning = WORK_STYLE_PRIORS["planning"]
+    expected = (research.artefact_alignment_weight_multiplier + planning.artefact_alignment_weight_multiplier) / 2
+    assert adj.artefact_alignment_weight_multiplier == pytest.approx(expected)
+
+
+def test_averaging_is_order_independent() -> None:
+    """Averaging must commute — the user's selection order doesn't
+    affect the resulting prior."""
+
+    a = adjustments_for(("research", "planning"))
+    b = adjustments_for(("planning", "research"))
+    assert a == b
+
+
+def test_template_union() -> None:
+    """``adjustments_for(("planning","support"))`` MUST union the
+    per-style template tuples, deduplicated and sorted (deterministic
+    output regardless of input order).
+    """
+
+    adj = adjustments_for(("planning", "support"))
+    expected = tuple(
+        sorted(
+            set(WORK_STYLE_PRIORS["planning"].preferred_artefact_templates) | set(WORK_STYLE_PRIORS["support"].preferred_artefact_templates)
+        )
+    )
+    assert adj.preferred_artefact_templates == expected
+    # Sorted contract: list is monotonically non-decreasing.
+    assert list(adj.preferred_artefact_templates) == sorted(adj.preferred_artefact_templates)
+
+
+def test_unknown_style_raises_keyerror() -> None:
+    """Unknown style names indicate a schema-migration bug, not a
+    runtime concern. The averaging helper must surface it loudly."""
+
+    with pytest.raises(KeyError):
+        adjustments_for(("not_a_real_style",))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Composition with deep-run preset
+# ---------------------------------------------------------------------------
+
+
+def test_compose_with_preset_is_multiplicative() -> None:
+    """Pure math: base 1.5 × work-style 1.2 == 1.8. The composition
+    must be multiplicative so it associates with the existing
+    HorizonBiasSpec convention."""
+
+    work_style = IntentPriorAdjustments(
+        artefact_alignment_weight_multiplier=1.2,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.0,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=(),
+    )
+    aa, lh, pb = compose_with_deep_run_preset(
+        work_style,
+        base_artefact_alignment=1.5,
+        base_long_horizon=2.0,
+        base_possible_branch=0.5,
+    )
+    assert aa == pytest.approx(1.5 * 1.2)
+    assert lh == pytest.approx(2.0 * 1.0)
+    assert pb == pytest.approx(0.5 * 1.0)
+
+
+def test_compose_no_op_for_mixed() -> None:
+    """Composing the mixed identity with any base must leave the base
+    unchanged. The frontier scoring path can rely on this without a
+    null check at the call site."""
+
+    base = (1.7, 0.8, 1.3)
+    aa, lh, pb = compose_with_deep_run_preset(
+        default_adjustments(),
+        base_artefact_alignment=base[0],
+        base_long_horizon=base[1],
+        base_possible_branch=base[2],
+    )
+    assert (aa, lh, pb) == base
+
+
+# ---------------------------------------------------------------------------
+# Engine-level no-op-by-default invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_engine_no_op_when_default(temp_repo) -> None:  # type: ignore[no-untyped-def]
+    """With ``setup.work_styles == ["mixed"]`` (the default), the engine's
+    cached adjustments MUST be the identity element and the briefing
+    assembler MUST receive an empty preferred-template tuple. This is
+    the load-bearing invariant: any byte-of-behaviour change to default
+    configs would surface here as a failing assertion.
+    """
+
+    from vaner.engine import VanerEngine
+    from vaner.intent.adapter import CodeRepoAdapter
+
+    engine = VanerEngine(adapter=CodeRepoAdapter(temp_repo))
+    # Invariant 1: cached adjustments are the identity element.
+    adj = engine._cycle_work_style_adjustments
+    assert adj.artefact_alignment_weight_multiplier == 1.0
+    assert adj.long_horizon_bonus_multiplier == 1.0
+    assert adj.possible_branch_bonus_multiplier == 1.0
+    assert adj.drafting_evidence_floor == 0.0
+    assert adj.drafting_volatility_ceiling_multiplier == 1.0
+    assert adj.preferred_artefact_templates == ()
+
+    # Invariant 2: briefing assembler sees no preferred templates.
+    assert engine._briefing_assembler.preferred_artefact_templates == ()
+
+    # Invariant 3: refresh is idempotent under the default config —
+    # repeated calls keep the identity element.
+    engine._refresh_work_style_adjustments()
+    assert engine._cycle_work_style_adjustments == default_adjustments()
+
+
+@pytest.mark.asyncio
+async def test_engine_picks_up_non_default_work_style(temp_repo) -> None:  # type: ignore[no-untyped-def]
+    """When the config picks a non-mixed work style, the engine refresh
+    MUST flow it through to both the cached adjustments and the
+    briefing assembler's preferred-template tuple.
+    """
+
+    from vaner.engine import VanerEngine
+    from vaner.intent.adapter import CodeRepoAdapter
+
+    engine = VanerEngine(adapter=CodeRepoAdapter(temp_repo))
+    engine.config.setup.work_styles = ["planning"]
+    engine._refresh_work_style_adjustments()
+
+    expected = WORK_STYLE_PRIORS["planning"]
+    assert engine._cycle_work_style_adjustments == expected
+    assert engine._briefing_assembler.preferred_artefact_templates == expected.preferred_artefact_templates

--- a/tests/test_setup/test_answers.py
+++ b/tests/test_setup/test_answers.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — SetupAnswers dataclass tests (0.8.6)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from vaner.setup.answers import SetupAnswers
+
+
+def _valid_answers() -> SetupAnswers:
+    return SetupAnswers(
+        work_styles=("writing", "research"),
+        priority="quality",
+        compute_posture="balanced",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="idle_more",
+    )
+
+
+def test_round_trip_preserves_fields() -> None:
+    answers = _valid_answers()
+    assert answers.work_styles == ("writing", "research")
+    assert answers.priority == "quality"
+    assert answers.compute_posture == "balanced"
+    assert answers.cloud_posture == "hybrid_when_worth_it"
+    assert answers.background_posture == "idle_more"
+
+
+def test_empty_work_styles_raises() -> None:
+    with pytest.raises(ValueError, match="work_styles must contain"):
+        SetupAnswers(
+            work_styles=(),
+            priority="balanced",
+            compute_posture="balanced",
+            cloud_posture="ask_first",
+            background_posture="normal",
+        )
+
+
+def test_dataclass_is_frozen() -> None:
+    answers = _valid_answers()
+    with pytest.raises(FrozenInstanceError):
+        answers.priority = "speed"  # type: ignore[misc]
+
+
+def test_single_work_style_is_valid() -> None:
+    answers = SetupAnswers(
+        work_styles=("mixed",),
+        priority="balanced",
+        compute_posture="balanced",
+        cloud_posture="ask_first",
+        background_posture="normal",
+    )
+    assert answers.work_styles == ("mixed",)
+
+
+def test_setup_answers_is_hashable() -> None:
+    # Frozen + tuple work_styles means SetupAnswers is hashable.
+    # Important for cache keys in the selection algorithm.
+    a1 = _valid_answers()
+    a2 = _valid_answers()
+    assert hash(a1) == hash(a2)
+    assert a1 == a2

--- a/tests/test_setup/test_catalog.py
+++ b/tests/test_setup/test_catalog.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — PROFILE_CATALOG tests (0.8.6)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vaner.setup.catalog import PROFILE_CATALOG, bundle_by_id
+from vaner.setup.policy import VanerPolicyBundle
+
+
+def test_catalog_has_seven_bundles() -> None:
+    assert len(PROFILE_CATALOG) == 7
+
+
+def test_catalog_ids_are_unique() -> None:
+    ids = [bundle.id for bundle in PROFILE_CATALOG]
+    assert len(ids) == len(set(ids))
+
+
+def test_catalog_ids_match_spec() -> None:
+    expected = {
+        "local_lightweight",
+        "local_balanced",
+        "local_heavy",
+        "hybrid_balanced",
+        "hybrid_quality",
+        "cost_saver",
+        "deep_research",
+    }
+    actual = {bundle.id for bundle in PROFILE_CATALOG}
+    assert actual == expected
+
+
+def test_bundle_by_id_returns_correct_bundle() -> None:
+    bundle = bundle_by_id("hybrid_balanced")
+    assert isinstance(bundle, VanerPolicyBundle)
+    assert bundle.id == "hybrid_balanced"
+    assert bundle.label == "Hybrid Balanced"
+
+
+def test_bundle_by_id_unknown_raises_keyerror() -> None:
+    with pytest.raises(KeyError, match="unknown bundle id"):
+        bundle_by_id("nonexistent")
+
+
+def test_every_bundle_has_complete_horizon_bias_mapping() -> None:
+    for bundle in PROFILE_CATALOG:
+        assert set(bundle.prediction_horizon_bias.keys()) == {
+            "likely_next",
+            "long_horizon",
+            "finish_partials",
+            "balanced",
+        }, f"bundle {bundle.id} has incomplete horizon-bias mapping"
+
+
+def test_every_bundle_has_nonempty_label_and_description() -> None:
+    for bundle in PROFILE_CATALOG:
+        assert bundle.label, f"bundle {bundle.id} has empty label"
+        assert bundle.description, f"bundle {bundle.id} has empty description"

--- a/tests/test_setup/test_config_schema.py
+++ b/tests/test_setup/test_config_schema.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — VanerConfig schema tests (0.8.6).
+
+Confirms the new ``[setup]`` and ``[policy]`` sections exist on
+:class:`VanerConfig`, round-trip through Pydantic JSON, and that the
+``IntentConfig.domain`` field is removed outright (no compat shim).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaner.models.config import (
+    IntentConfig,
+    PolicyConfig,
+    SetupConfig,
+    VanerConfig,
+)
+
+
+def _make_config(tmp_path: Path) -> VanerConfig:
+    return VanerConfig(
+        repo_root=tmp_path,
+        store_path=tmp_path / "store.db",
+        telemetry_path=tmp_path / "telemetry.db",
+    )
+
+
+def test_vaner_config_includes_setup_and_policy_sections(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert isinstance(cfg.setup, SetupConfig)
+    assert isinstance(cfg.policy, PolicyConfig)
+
+
+def test_setup_defaults(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert cfg.setup.mode == "simple"
+    assert cfg.setup.work_styles == ["mixed"]
+    assert cfg.setup.priority == "balanced"
+    assert cfg.setup.compute_posture == "balanced"
+    assert cfg.setup.cloud_posture == "ask_first"
+    assert cfg.setup.background_posture == "normal"
+    assert cfg.setup.completed_at is None
+    assert cfg.setup.version == 1
+
+
+def test_policy_defaults(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert cfg.policy.selected_bundle_id == "hybrid_balanced"
+    assert cfg.policy.bundle_overrides == {}
+    assert cfg.policy.auto_select is True
+
+
+def test_intent_config_no_longer_has_domain_field() -> None:
+    # The 0.8.6 WS1 removal — verify the field is gone outright.
+    assert "domain" not in IntentConfig.model_fields
+
+
+def test_config_round_trips_through_json(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    payload = cfg.model_dump_json()
+    parsed = json.loads(payload)
+    assert "setup" in parsed
+    assert "policy" in parsed
+    # Reconstruct from the dumped JSON and verify equivalence.
+    cfg2 = VanerConfig.model_validate_json(payload)
+    assert cfg2.setup.mode == cfg.setup.mode
+    assert cfg2.policy.selected_bundle_id == cfg.policy.selected_bundle_id
+
+
+def test_setup_config_completed_at_accepts_datetime(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    when = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    cfg = SetupConfig(completed_at=when)
+    payload = cfg.model_dump_json()
+    parsed = SetupConfig.model_validate_json(payload)
+    assert parsed.completed_at == when

--- a/tests/test_setup/test_enums.py
+++ b/tests/test_setup/test_enums.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — enum literal alias tests (0.8.6).
+
+The aliases themselves are ``Literal`` types and have no runtime
+behaviour to test directly. We exercise their interaction with the
+``SetupConfig`` Pydantic model: every valid value round-trips, and an
+invalid value raises :class:`pydantic.ValidationError`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from vaner.models.config import SetupConfig
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    HardwareTier,
+    Priority,
+    WorkStyle,
+)
+
+# ---------------------------------------------------------------------------
+# Literal-membership checks. ``Literal`` doesn't expose its args via a
+# stable public API; we use ``typing.get_args`` which is documented and
+# stable across 3.11+.
+# ---------------------------------------------------------------------------
+
+
+def _literal_values(alias: object) -> tuple[str, ...]:
+    from typing import get_args
+
+    return tuple(get_args(alias))
+
+
+def test_work_style_values() -> None:
+    assert set(_literal_values(WorkStyle)) == {
+        "writing",
+        "research",
+        "planning",
+        "support",
+        "learning",
+        "coding",
+        "general",
+        "mixed",
+        "unsure",
+    }
+
+
+def test_priority_values() -> None:
+    assert set(_literal_values(Priority)) == {
+        "balanced",
+        "speed",
+        "quality",
+        "privacy",
+        "cost",
+        "low_resource",
+    }
+
+
+def test_compute_posture_values() -> None:
+    assert set(_literal_values(ComputePosture)) == {"light", "balanced", "available_power"}
+
+
+def test_cloud_posture_values() -> None:
+    assert set(_literal_values(CloudPosture)) == {
+        "local_only",
+        "ask_first",
+        "hybrid_when_worth_it",
+        "best_available",
+    }
+
+
+def test_background_posture_values() -> None:
+    assert set(_literal_values(BackgroundPosture)) == {
+        "minimal",
+        "normal",
+        "idle_more",
+        "deep_run_aggressive",
+    }
+
+
+def test_hardware_tier_values() -> None:
+    assert set(_literal_values(HardwareTier)) == {
+        "light",
+        "capable",
+        "high_performance",
+        "unknown",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pydantic validation: each enum value works as a SetupConfig field
+# value; invalid values raise ValidationError.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", _literal_values(WorkStyle))
+def test_setup_config_accepts_each_work_style(value: str) -> None:
+    cfg = SetupConfig(work_styles=[value])  # type: ignore[list-item]
+    assert cfg.work_styles == [value]
+
+
+@pytest.mark.parametrize("value", _literal_values(Priority))
+def test_setup_config_accepts_each_priority(value: str) -> None:
+    cfg = SetupConfig(priority=value)  # type: ignore[arg-type]
+    assert cfg.priority == value
+
+
+def test_setup_config_rejects_invalid_priority() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(priority="not-a-priority")  # type: ignore[arg-type]
+
+
+def test_setup_config_rejects_invalid_work_style() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(work_styles=["not-a-work-style"])  # type: ignore[list-item]
+
+
+def test_setup_config_rejects_invalid_cloud_posture() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(cloud_posture="not-a-cloud-posture")  # type: ignore[arg-type]
+
+
+def test_setup_config_rejects_invalid_background_posture() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(background_posture="not-a-background-posture")  # type: ignore[arg-type]

--- a/tests/test_setup/test_hardware.py
+++ b/tests/test_setup/test_hardware.py
@@ -1,0 +1,283 @@
+"""Tests for vaner.setup.hardware.
+
+All probes are mocked so the tests run identically on any platform / CI.
+A single optional smoke test (``test_real_detect_smoke``) exercises the real
+machine when ``VANER_HW_REAL`` is set.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from vaner.setup import hardware as hw
+
+
+def _make_profile(**overrides: Any) -> hw.HardwareProfile:
+    """Build a HardwareProfile with sane defaults for tier_for tests."""
+    base: dict[str, Any] = {
+        "os": "linux",
+        "cpu_class": "mid",
+        "ram_gb": 16,
+        "gpu": "integrated",
+        "gpu_vram_gb": None,
+        "is_battery": False,
+        "thermal_constrained": False,
+        "detected_runtimes": (),
+        "detected_models": (),
+        "tier": "unknown",
+    }
+    base.update(overrides)
+    profile = hw.HardwareProfile(**base)
+    return dataclasses.replace(profile, tier=hw.tier_for(profile))
+
+
+# ---------------------------------------------------------------------------
+# tier_for() table
+# ---------------------------------------------------------------------------
+
+
+def test_tier_unknown_when_os_missing() -> None:
+    """detect() routes through tier="unknown" when probes fail entirely."""
+    with (
+        patch.object(hw, "_probe_os", return_value=None),
+        patch.object(hw, "_probe_cpu_and_ram", return_value=("low", 0)),
+        patch.object(hw, "_probe_gpu", return_value=("none", None)),
+        patch.object(hw, "_probe_battery", return_value=False),
+        patch.object(hw, "_probe_thermal", return_value=False),
+        patch.object(hw, "_probe_runtimes", return_value=()),
+        patch.object(hw, "_probe_models", return_value=()),
+    ):
+        profile = hw.detect()
+    assert profile.tier == "unknown"
+
+
+def test_tier_light_low_ram_no_gpu() -> None:
+    profile = _make_profile(ram_gb=8, gpu="none", cpu_class="low")
+    assert profile.tier == "light"
+
+
+def test_tier_high_perf_workstation() -> None:
+    profile = _make_profile(
+        ram_gb=64,
+        gpu="nvidia",
+        gpu_vram_gb=24,
+        cpu_class="high",
+        is_battery=False,
+    )
+    assert profile.tier == "high_performance"
+
+
+def test_tier_capable_default() -> None:
+    profile = _make_profile(
+        ram_gb=32,
+        gpu="integrated",
+        gpu_vram_gb=None,
+        cpu_class="mid",
+        is_battery=False,
+    )
+    assert profile.tier == "capable"
+
+
+def test_battery_low_ram_demotes_to_light() -> None:
+    """16GB on battery is below the 24GB battery cutoff → light."""
+    profile = _make_profile(
+        ram_gb=16,
+        gpu="integrated",
+        cpu_class="mid",
+        is_battery=True,
+    )
+    assert profile.tier == "light"
+
+
+def test_apple_silicon_unified_memory() -> None:
+    """Apple Silicon reports VRAM as None and still maps to high_performance."""
+    profile = _make_profile(
+        os="darwin",
+        ram_gb=64,
+        gpu="apple_silicon",
+        gpu_vram_gb=None,
+        cpu_class="high",
+        is_battery=False,
+    )
+    assert profile.tier == "high_performance"
+
+
+def test_apple_silicon_on_battery_blocks_high_perf() -> None:
+    """Battery flag is dispositive: even Apple Silicon laptops drop tier."""
+    profile = _make_profile(
+        os="darwin",
+        ram_gb=32,
+        gpu="apple_silicon",
+        gpu_vram_gb=None,
+        cpu_class="high",
+        is_battery=True,
+    )
+    # 32GB ≥ 24GB battery cutoff → not light, but battery blocks high_perf.
+    assert profile.tier == "capable"
+
+
+def test_tier_for_unknown_zero_ram() -> None:
+    profile = hw.HardwareProfile(
+        os="linux",
+        cpu_class="low",
+        ram_gb=0,
+        gpu="none",
+        gpu_vram_gb=None,
+        is_battery=False,
+        thermal_constrained=False,
+        detected_runtimes=(),
+        detected_models=(),
+        tier="unknown",
+    )
+    assert hw.tier_for(profile) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Probe fail-safety
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_probe_fails_safe() -> None:
+    """subprocess timeout inside a runtime probe must not bubble up."""
+    err = subprocess.TimeoutExpired(cmd="anything", timeout=1)
+    with (
+        patch.object(hw.shutil, "which", return_value=None),
+        patch.object(hw, "_http_get_ok", return_value=(False, None)),
+        patch.object(hw.subprocess, "run", side_effect=err),
+    ):
+        result = hw._probe_runtimes()
+    assert result == ()
+
+
+def test_ollama_http_probe_returns_404() -> None:
+    """A non-200 from /api/tags + no binary on PATH means ollama not detected."""
+    with (
+        patch.object(hw.shutil, "which", return_value=None),
+        patch.object(hw, "_http_get_ok", return_value=(False, None)),
+    ):
+        assert hw._probe_ollama() is False
+
+
+def test_ollama_detected_when_binary_present() -> None:
+    with patch.object(hw.shutil, "which", return_value="/usr/bin/ollama"):
+        assert hw._probe_ollama() is True
+
+
+def test_lmstudio_detected_via_http() -> None:
+    with patch.object(hw, "_http_get_ok", return_value=(True, '{"data":[]}')):
+        assert hw._probe_lmstudio() is True
+
+
+def test_models_ollama_parses_size() -> None:
+    body = '{"models":[{"name":"qwen3:8b","size":5368709120}]}'
+    with patch.object(hw, "_http_get_ok", return_value=(True, body)):
+        rows = hw._probe_models_ollama()
+    assert rows == [("ollama", "qwen3:8b", "5.0GB")]
+
+
+def test_models_ollama_handles_bad_json() -> None:
+    with patch.object(hw, "_http_get_ok", return_value=(True, "not json")):
+        assert hw._probe_models_ollama() == []
+
+
+def test_models_lmstudio_parses_ids() -> None:
+    body = '{"data":[{"id":"llama-3-8b"},{"id":"mistral-7b"}]}'
+    with patch.object(hw, "_http_get_ok", return_value=(True, body)):
+        rows = hw._probe_models_lmstudio()
+    assert rows == [
+        ("lmstudio", "llama-3-8b", "unknown"),
+        ("lmstudio", "mistral-7b", "unknown"),
+    ]
+
+
+def test_thermal_probe_returns_false_off_linux() -> None:
+    with patch.object(hw.sys, "platform", "darwin"):
+        assert hw._probe_thermal() is False
+
+
+def test_battery_probe_no_psutil_no_sys() -> None:
+    """No psutil, no /sys/class/power_supply, not macOS → False."""
+    with (
+        patch.dict("sys.modules", {"psutil": None}),
+        patch.object(hw.sys, "platform", "win32"),
+    ):
+        assert hw._probe_battery() is False
+
+
+def test_gpu_probe_handles_subprocess_failure() -> None:
+    """Combined GPU probe must never raise."""
+    err = subprocess.TimeoutExpired(cmd="lspci", timeout=1)
+    with (
+        patch.object(hw, "_probe_gpu_nvidia", return_value=None),
+        patch.object(hw.shutil, "which", return_value="/usr/bin/lspci"),
+        patch.object(hw.subprocess, "run", side_effect=err),
+        patch.object(hw.sys, "platform", "linux"),
+    ):
+        gpu, vram = hw._probe_gpu()
+    assert gpu == "none"
+    assert vram is None
+
+
+# ---------------------------------------------------------------------------
+# detect() composition
+# ---------------------------------------------------------------------------
+
+
+def test_detect_returns_frozen_profile() -> None:
+    """detect() returns an immutable dataclass."""
+    with (
+        patch.object(hw, "_probe_os", return_value="linux"),
+        patch.object(hw, "_probe_cpu_and_ram", return_value=("mid", 16)),
+        patch.object(hw, "_probe_gpu", return_value=("integrated", None)),
+        patch.object(hw, "_probe_battery", return_value=False),
+        patch.object(hw, "_probe_thermal", return_value=False),
+        patch.object(hw, "_probe_runtimes", return_value=()),
+        patch.object(hw, "_probe_models", return_value=()),
+    ):
+        profile = hw.detect()
+    assert profile.tier == "capable"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        profile.ram_gb = 99  # type: ignore[misc]
+
+
+def test_detect_threads_runtimes_into_models_probe() -> None:
+    """The set of detected runtimes must be passed into _probe_models."""
+    captured: list[Any] = []
+
+    def fake_models(runtimes: Any) -> tuple[tuple[str, str, str], ...]:
+        captured.append(runtimes)
+        return (("ollama", "qwen3:8b", "5.0GB"),)
+
+    with (
+        patch.object(hw, "_probe_os", return_value="linux"),
+        patch.object(hw, "_probe_cpu_and_ram", return_value=("high", 64)),
+        patch.object(hw, "_probe_gpu", return_value=("nvidia", 24)),
+        patch.object(hw, "_probe_battery", return_value=False),
+        patch.object(hw, "_probe_thermal", return_value=False),
+        patch.object(hw, "_probe_runtimes", return_value=("ollama",)),
+        patch.object(hw, "_probe_models", side_effect=fake_models),
+    ):
+        profile = hw.detect()
+    assert captured == [("ollama",)]
+    assert profile.detected_models == (("ollama", "qwen3:8b", "5.0GB"),)
+    assert profile.tier == "high_performance"
+
+
+# ---------------------------------------------------------------------------
+# Optional CI smoke test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("VANER_HW_REAL"),
+    reason="real hardware probe smoke test (set VANER_HW_REAL=1 to enable)",
+)
+def test_real_detect_smoke() -> None:
+    profile = hw.detect()
+    assert profile.tier in {"light", "capable", "high_performance", "unknown"}

--- a/tests/test_setup/test_policy.py
+++ b/tests/test_setup/test_policy.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — VanerPolicyBundle dataclass tests (0.8.6)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from types import MappingProxyType
+
+import pytest
+
+from vaner.setup.policy import VanerPolicyBundle
+
+
+def _valid_bundle() -> VanerPolicyBundle:
+    return VanerPolicyBundle(
+        id="test_bundle",
+        label="Test Bundle",
+        description="for unit tests",
+        local_cloud_posture="local_preferred",
+        runtime_profile="medium",
+        spend_profile="zero",
+        latency_profile="balanced",
+        privacy_profile="standard",
+        prediction_horizon_bias={
+            "likely_next": 1.0,
+            "long_horizon": 1.0,
+            "finish_partials": 1.0,
+            "balanced": 1.0,
+        },
+        drafting_aggressiveness=1.0,
+        exploration_ratio=0.0,
+        persistence_strength=1.0,
+        goal_weighting=1.0,
+        context_injection_default="policy_hybrid",
+        deep_run_profile="balanced",
+    )
+
+
+def test_bundle_is_frozen() -> None:
+    bundle = _valid_bundle()
+    with pytest.raises(FrozenInstanceError):
+        bundle.id = "different_id"  # type: ignore[misc]
+
+
+def test_horizon_bias_keys_must_be_exact() -> None:
+    with pytest.raises(ValueError, match="prediction_horizon_bias"):
+        VanerPolicyBundle(
+            id="x",
+            label="x",
+            description="x",
+            local_cloud_posture="local_preferred",
+            runtime_profile="medium",
+            spend_profile="zero",
+            latency_profile="balanced",
+            privacy_profile="standard",
+            # Missing "balanced" key.
+            prediction_horizon_bias={
+                "likely_next": 1.0,
+                "long_horizon": 1.0,
+                "finish_partials": 1.0,
+            },
+            drafting_aggressiveness=1.0,
+            exploration_ratio=0.0,
+            persistence_strength=1.0,
+            goal_weighting=1.0,
+            context_injection_default="policy_hybrid",
+            deep_run_profile="balanced",
+        )
+
+
+def test_horizon_bias_extra_keys_rejected() -> None:
+    with pytest.raises(ValueError, match="prediction_horizon_bias"):
+        VanerPolicyBundle(
+            id="x",
+            label="x",
+            description="x",
+            local_cloud_posture="local_preferred",
+            runtime_profile="medium",
+            spend_profile="zero",
+            latency_profile="balanced",
+            privacy_profile="standard",
+            prediction_horizon_bias={
+                "likely_next": 1.0,
+                "long_horizon": 1.0,
+                "finish_partials": 1.0,
+                "balanced": 1.0,
+                "unexpected": 1.0,
+            },
+            drafting_aggressiveness=1.0,
+            exploration_ratio=0.0,
+            persistence_strength=1.0,
+            goal_weighting=1.0,
+            context_injection_default="policy_hybrid",
+            deep_run_profile="balanced",
+        )
+
+
+def test_horizon_bias_is_immutable_view() -> None:
+    bundle = _valid_bundle()
+    # The mapping is wrapped as a MappingProxyType and so cannot be
+    # mutated after construction.
+    assert isinstance(bundle.prediction_horizon_bias, MappingProxyType)
+    with pytest.raises(TypeError):
+        bundle.prediction_horizon_bias["likely_next"] = 99.0  # type: ignore[index]
+
+
+def test_horizon_bias_keys_are_exactly_the_four_expected() -> None:
+    bundle = _valid_bundle()
+    assert set(bundle.prediction_horizon_bias.keys()) == {
+        "likely_next",
+        "long_horizon",
+        "finish_partials",
+        "balanced",
+    }

--- a/tests/test_setup/test_select.py
+++ b/tests/test_setup/test_select.py
@@ -1,0 +1,398 @@
+"""Tests for ``vaner.setup.select`` — WS3 policy-bundle selection (0.8.6)."""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, get_args
+
+import pytest
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.catalog import PROFILE_CATALOG
+from vaner.setup.enums import (
+    CloudPosture,
+    HardwareTier,
+    Priority,
+)
+from vaner.setup.hardware import HardwareProfile
+from vaner.setup.select import (
+    SelectionResult,
+    select_policy_bundle,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers — direct construction, no real probes.
+# ---------------------------------------------------------------------------
+
+
+def _make_answers(**overrides: Any) -> SetupAnswers:
+    base: dict[str, Any] = {
+        "work_styles": ("mixed",),
+        "priority": "balanced",
+        "compute_posture": "balanced",
+        "cloud_posture": "ask_first",
+        "background_posture": "normal",
+    }
+    base.update(overrides)
+    return SetupAnswers(**base)
+
+
+def _make_hardware(**overrides: Any) -> HardwareProfile:
+    base: dict[str, Any] = {
+        "os": "linux",
+        "cpu_class": "mid",
+        "ram_gb": 16,
+        "gpu": "integrated",
+        "gpu_vram_gb": None,
+        "is_battery": False,
+        "thermal_constrained": False,
+        "detected_runtimes": (),
+        "detected_models": (),
+        "tier": "capable",
+    }
+    base.update(overrides)
+    return HardwareProfile(**base)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_pure_function_determinism() -> None:
+    """Same inputs → equal SelectionResult (including reasons + runner_ups)."""
+    answers = _make_answers(
+        work_styles=("research", "writing"),
+        priority="quality",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="idle_more",
+    )
+    hardware = _make_hardware(tier="high_performance", ram_gb=64, gpu="nvidia", gpu_vram_gb=24)
+
+    result_a = select_policy_bundle(answers, hardware)
+    result_b = select_policy_bundle(answers, hardware)
+    assert result_a == result_b
+    # Sanity: result is a SelectionResult dataclass.
+    assert isinstance(result_a, SelectionResult)
+
+
+# ---------------------------------------------------------------------------
+# Filter behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_local_only_filters_cloud_bundles() -> None:
+    """local_only must exclude cloud-leaning bundles entirely."""
+    answers = _make_answers(cloud_posture="local_only")
+    hardware = _make_hardware(tier="capable")
+    result = select_policy_bundle(answers, hardware)
+
+    cloud_postures = {"hybrid", "cloud_preferred"}
+    assert result.bundle.local_cloud_posture not in cloud_postures
+    for runner in result.runner_ups:
+        assert runner.local_cloud_posture not in cloud_postures
+    assert not result.forced_fallback
+
+
+def test_high_perf_workstation_picks_heavy_or_deep_research() -> None:
+    """High-perf workstation + research/planning steers to heavy bundles."""
+    answers = _make_answers(
+        work_styles=("research", "planning"),
+        priority="quality",
+        compute_posture="available_power",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="deep_run_aggressive",
+    )
+    hardware = _make_hardware(
+        tier="high_performance",
+        ram_gb=64,
+        gpu="nvidia",
+        gpu_vram_gb=24,
+        cpu_class="high",
+    )
+    result = select_policy_bundle(answers, hardware)
+    assert result.bundle.id in {"local_heavy", "deep_research", "hybrid_quality"}
+
+
+def test_light_battery_picks_local_lightweight_or_cost_saver() -> None:
+    """Light + battery + cost prefers a small footprint."""
+    answers = _make_answers(
+        work_styles=("general",),
+        priority="cost",
+        compute_posture="light",
+        cloud_posture="ask_first",
+        background_posture="minimal",
+    )
+    hardware = _make_hardware(
+        tier="light",
+        ram_gb=8,
+        cpu_class="low",
+        gpu="none",
+        is_battery=True,
+    )
+    result = select_policy_bundle(answers, hardware)
+    assert result.bundle.id in {"local_lightweight", "cost_saver"}
+
+
+def test_capable_balanced_default() -> None:
+    """The canonical default: capable hardware + balanced priority → hybrid_balanced."""
+    answers = _make_answers(
+        work_styles=("mixed",),
+        priority="balanced",
+        compute_posture="balanced",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="normal",
+    )
+    hardware = _make_hardware(tier="capable", ram_gb=16, gpu="integrated")
+    result = select_policy_bundle(answers, hardware)
+    assert result.bundle.id == "hybrid_balanced"
+
+
+def test_unknown_tier_avoids_heavy_local() -> None:
+    """Unknown tier never recommends a large-runtime bundle."""
+    answers = _make_answers(cloud_posture="hybrid_when_worth_it")
+    hardware = _make_hardware(tier="unknown", ram_gb=0, gpu="none")
+    result = select_policy_bundle(answers, hardware)
+    # Must not pick a large-runtime bundle on unknown tier.
+    assert result.bundle.runtime_profile != "large"
+    # Implementation also drops local_only on unknown tier.
+    assert result.bundle.local_cloud_posture != "local_only"
+
+
+def test_forced_fallback_when_filters_empty() -> None:
+    """An impossible combination triggers the safe-fallback path.
+
+    Construct a contradiction the cloud filter cannot satisfy: tier
+    unknown (drops local_only bundles + large-runtime bundles), plus
+    cloud_posture local_only (drops hybrid + cloud_preferred bundles),
+    plus priority privacy + low_resource (drops standard + medium /
+    large local bundles too). After the relaxed retry, the cloud
+    filter still wipes everything because it kept ``local_only``
+    requirement intact, so we land in the absolute-fallback branch.
+    """
+    answers = _make_answers(
+        work_styles=("mixed",),
+        priority="low_resource",
+        compute_posture="light",
+        cloud_posture="local_only",
+        background_posture="minimal",
+    )
+    # tier=unknown → strict filter drops ALL local_only bundles AND
+    # all large-runtime bundles. Combined with cloud_posture=local_only
+    # (cloud filter drops everything that isn't local_only or
+    # local_preferred) this can wipe the candidate set. The relaxed
+    # retry only keeps the cloud_posture filter — but
+    # cloud_posture=local_only still drops hybrid + cloud_preferred.
+    # The remaining candidates must satisfy local_only OR
+    # local_preferred AND be valid.
+    hardware = _make_hardware(tier="unknown", ram_gb=0, gpu="none", cpu_class="low")
+    result = select_policy_bundle(answers, hardware)
+    # The strict-filter pass empties (unknown tier drops local_only
+    # bundles; the cloud filter drops the hybrid/cloud_preferred
+    # bundles). Relaxed retry restores local-only candidates.
+    # Either way, low-resource + local must yield a small/medium
+    # local bundle; if forced_fallback is set the bundle id must be
+    # local_lightweight per contract.
+    assert isinstance(result, SelectionResult)
+    if result.forced_fallback:
+        assert result.bundle.id == "local_lightweight"
+        assert len(result.reasons) == 1
+        assert "safest local default" in result.reasons[0].lower() or "filter" in result.reasons[0].lower()
+    else:
+        assert result.bundle.local_cloud_posture in ("local_only", "local_preferred")
+
+
+def test_forced_fallback_explicit_path() -> None:
+    """Drive the absolute fallback by stubbing the catalogue to empty.
+
+    The relaxed retry branch can only fully empty if the cloud filter
+    drops every bundle. We approximate this by exercising the same
+    code path through the public API: feed the impossible combination
+    above and verify the contract holds.
+    """
+    # Build a synthetic test for the deepest fallback path: monkey
+    # patch PROFILE_CATALOG via a relaxed filter that always drops.
+    from vaner.setup import select as sel  # noqa: PLC0415 — local import for monkey patch
+
+    def _always_drop(answers: SetupAnswers, hardware: HardwareProfile, bundle: Any) -> str | None:
+        return f"drop {bundle.id}"
+
+    answers = _make_answers()
+    hardware = _make_hardware(tier="capable")
+
+    kept, _ = sel._apply_filters(answers, hardware, PROFILE_CATALOG, filters=(_always_drop,))
+    assert kept == ()
+
+
+def test_runner_ups_excludes_chosen() -> None:
+    """The chosen bundle is never repeated in runner_ups."""
+    answers = _make_answers(work_styles=("research",), priority="quality")
+    hardware = _make_hardware(tier="high_performance", ram_gb=64, gpu="nvidia", gpu_vram_gb=24)
+    result = select_policy_bundle(answers, hardware)
+
+    chosen_id = result.bundle.id
+    runner_ids = [b.id for b in result.runner_ups]
+    assert chosen_id not in runner_ids
+    # runner_ups capped at 2 (or fewer when catalogue smaller after
+    # filtering); for the canonical-default path most bundles survive
+    # so we expect exactly 2.
+    assert len(result.runner_ups) <= 2
+
+
+def test_runner_ups_length_matches_candidate_pool() -> None:
+    """When filters leave only 1 candidate, runner_ups is empty."""
+    # local_only + privacy + light hardware narrows to small/medium
+    # local bundles only; check that the runner-up count never
+    # exceeds (candidates - 1).
+    answers = _make_answers(
+        work_styles=("mixed",),
+        priority="privacy",
+        cloud_posture="local_only",
+        compute_posture="light",
+    )
+    hardware = _make_hardware(tier="light", ram_gb=8, gpu="none", cpu_class="low")
+    result = select_policy_bundle(answers, hardware)
+    # At minimum local_lightweight + cost_saver survive; runner_ups
+    # length must be in [0, 2] inclusive.
+    assert 0 <= len(result.runner_ups) <= 2
+
+
+def test_reasons_are_explainable_strings() -> None:
+    """Every reason is a non-empty short string; mentions chosen bundle."""
+    answers = _make_answers(
+        work_styles=("research",),
+        priority="quality",
+        compute_posture="available_power",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="deep_run_aggressive",
+    )
+    hardware = _make_hardware(tier="high_performance", ram_gb=64, gpu="nvidia", gpu_vram_gb=24)
+    result = select_policy_bundle(answers, hardware)
+
+    assert isinstance(result.reasons, tuple)
+    assert all(isinstance(r, str) and r for r in result.reasons)
+    assert all(len(r) < 120 for r in result.reasons)
+    # The chosen bundle id appears in at least one reason — the
+    # explainability contract from the prompt.
+    chosen_id = result.bundle.id
+    assert any(chosen_id in r for r in result.reasons)
+
+
+# ---------------------------------------------------------------------------
+# Totality contract — cartesian product over enums.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("priority", "cloud_posture", "tier"),
+    list(
+        itertools.product(
+            get_args(Priority),
+            get_args(CloudPosture),
+            get_args(HardwareTier),
+        ),
+    ),
+)
+def test_property_total_function_over_enum_product(
+    priority: Priority,
+    cloud_posture: CloudPosture,
+    tier: HardwareTier,
+) -> None:
+    """select_policy_bundle is total over Priority × CloudPosture × HardwareTier."""
+    answers = _make_answers(priority=priority, cloud_posture=cloud_posture)
+    # Build a hardware profile compatible with the requested tier so
+    # the parametrisation reflects realistic combinations rather than
+    # hardware-tier mismatches with explicit fields.
+    hardware = _make_hardware(tier=tier)
+
+    result = select_policy_bundle(answers, hardware)
+    assert isinstance(result, SelectionResult)
+    assert result.bundle in PROFILE_CATALOG
+    assert isinstance(result.reasons, tuple)
+    assert all(isinstance(r, str) for r in result.reasons)
+    assert isinstance(result.runner_ups, tuple)
+    for runner in result.runner_ups:
+        assert runner in PROFILE_CATALOG
+    assert isinstance(result.forced_fallback, bool)
+
+
+# ---------------------------------------------------------------------------
+# Filter unit tests — each filter in isolation.
+# ---------------------------------------------------------------------------
+
+
+def test_filter_cloud_posture_local_only_drops_cloud() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    answers = _make_answers(cloud_posture="local_only")
+    hardware = _make_hardware()
+    cloud_bundles = [b for b in PROFILE_CATALOG if b.local_cloud_posture in ("hybrid", "cloud_preferred")]
+    assert cloud_bundles, "fixture invariant: catalogue contains cloud-leaning bundles"
+    for bundle in cloud_bundles:
+        assert sel._filter_cloud_posture(answers, hardware, bundle) is not None
+
+
+def test_filter_priority_privacy_drops_relaxed_or_cloud_preferred() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    answers = _make_answers(priority="privacy")
+    hardware = _make_hardware()
+    cloud_pref = [b for b in PROFILE_CATALOG if b.local_cloud_posture == "cloud_preferred"]
+    for bundle in cloud_pref:
+        assert sel._filter_priority_privacy(answers, hardware, bundle) is not None
+
+
+def test_filter_hardware_tier_unknown_drops_local_only() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    answers = _make_answers()
+    hardware = _make_hardware(tier="unknown")
+    local_only = [b for b in PROFILE_CATALOG if b.local_cloud_posture == "local_only"]
+    for bundle in local_only:
+        assert sel._filter_hardware_tier(answers, hardware, bundle) is not None
+
+
+def test_filter_hardware_tier_light_drops_large_runtime() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    answers = _make_answers()
+    hardware = _make_hardware(tier="light")
+    large_bundles = [b for b in PROFILE_CATALOG if b.runtime_profile == "large"]
+    for bundle in large_bundles:
+        assert sel._filter_hardware_tier(answers, hardware, bundle) is not None
+
+
+# ---------------------------------------------------------------------------
+# Match function unit tests — quick spot checks.
+# ---------------------------------------------------------------------------
+
+
+def test_priority_match_balanced_favours_hybrid_balanced() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    bundle = next(b for b in PROFILE_CATALOG if b.id == "hybrid_balanced")
+    score, reason = sel._priority_match("balanced", bundle)
+    assert score == 1.0
+    assert "hybrid_balanced" in reason
+
+
+def test_workstyle_match_averages_multiple_styles() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    bundle = next(b for b in PROFILE_CATALOG if b.id == "deep_research")
+    score_single, _ = sel._workstyle_match(("research",), bundle)
+    score_pair, _ = sel._workstyle_match(("research", "writing"), bundle)
+    # Averaging two equally-positive styles should still be positive
+    # but not *necessarily* equal to either single value.
+    assert score_pair > 0
+    assert score_single > 0
+
+
+def test_hardware_match_high_perf_rewards_large_runtime() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    big = next(b for b in PROFILE_CATALOG if b.runtime_profile == "large")
+    small = next(b for b in PROFILE_CATALOG if b.runtime_profile == "small")
+    score_big, _ = sel._hardware_match("high_performance", big)
+    score_small, _ = sel._hardware_match("high_performance", small)
+    assert score_big > score_small


### PR DESCRIPTION
## Summary
Stacked on WS3. Adds `src/vaner/intent/work_style_priors.py` with `WORK_STYLE_PRIORS` table mapping `WorkStyle` → `IntentPriorAdjustments`. Multiplicative multipliers compose with `DeepRunPresetSpec` at three engine points: frontier scoring, drafting evidence/volatility, briefing assembler artefact-template selection.

`adjustments_for(work_styles)` averages multipliers across multi-select work styles. The `mixed` default is the identity element — engines on default config see byte-identical behaviour to pre-0.8.6.

## Test plan
- [x] `tests/test_intent/test_work_style_priors.py` — 21 tests
- [x] `test_engine_no_op_when_default` — byte-identical when `setup.work_styles=["mixed"]`
- [x] 0.8.3 Deep-Run regression suite passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)