### PR TITLE
feat(daemon): 0.8.6 WS8 — HTTP setup endpoints

### DIFF
--- a/.github/workflows/cockpit-a11y.yml
+++ b/.github/workflows/cockpit-a11y.yml
@@ -1,0 +1,98 @@
+name: cockpit-a11y
+
+# 0.8.6 WS10 — Accessibility scan for the cockpit + the MCP Apps UI
+# bundle. Runs axe-core (via @axe-core/cli) against:
+#   1. The built cockpit served by `vite preview`.
+#   2. The static MCP Apps active-predictions HTML bundle.
+# Fails the PR when any new HIGH/SERIOUS violation appears that isn't in
+# `ui/cockpit/tests/a11y-audit-baseline.json`.
+
+on:
+  pull_request:
+    paths:
+      - "ui/cockpit/**"
+      - "src/vaner/mcp/apps/active_predictions.html"
+      - ".github/workflows/cockpit-a11y.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  axe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
+      - name: Install cockpit dependencies
+        working-directory: ui/cockpit
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
+
+      - name: Typecheck
+        working-directory: ui/cockpit
+        run: npm run typecheck
+
+      - name: Lint
+        working-directory: ui/cockpit
+        run: npm run lint || echo "lint script absent; skipping"
+
+      - name: Unit tests (incl. jest-axe component-level a11y)
+        working-directory: ui/cockpit
+        run: npm test
+
+      - name: Build cockpit
+        working-directory: ui/cockpit
+        run: npm run build
+
+      - name: Start cockpit preview server
+        working-directory: ui/cockpit
+        run: |
+          npx vite preview --host 127.0.0.1 --port 5173 --strictPort &
+          echo $! > preview.pid
+          # Wait until the preview server responds.
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:5173/ > /dev/null; then
+              echo "preview server ready"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: axe-core scan — cockpit dev server
+        working-directory: ui/cockpit
+        run: npm run a11y:scan -- --cockpit
+        env:
+          AXE_TARGET_URL: "http://127.0.0.1:5173/"
+
+      - name: axe-core scan — MCP Apps UI bundle
+        working-directory: ui/cockpit
+        run: npm run a11y:scan -- --mcp
+
+      - name: Stop cockpit preview server
+        if: always()
+        working-directory: ui/cockpit
+        run: |
+          if [ -f preview.pid ]; then
+            kill "$(cat preview.pid)" || true
+            rm -f preview.pid
+          fi
+
+      - name: Upload axe-core report
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        with:
+          name: axe-core-report
+          path: ui/cockpit/tests/a11y-audit-baseline.json
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+#### Setup primitives + config schema (0.8.6 WS1)
+- **`src/vaner/setup/` module** — outcome-level configuration surface for the 0.8.6 Simple Mode wizard. Five `Literal` type aliases — `WorkStyle`, `Priority`, `ComputePosture`, `CloudPosture`, `BackgroundPosture` — plus a shared `HardwareTier` alias declared here for WS2 to populate via `tier_for()`.
+- **`SetupAnswers`** frozen dataclass (`src/vaner/setup/answers.py`) — immutable record of one wizard run, with `__post_init__` validation that rejects empty `work_styles` (the engine has no priors to average without at least one selection).
+- **`VanerPolicyBundle`** frozen dataclass (`src/vaner/setup/policy.py`) — outcome-level policy archetype. Carries cloud posture, runtime profile, spend profile, latency profile, privacy profile, four-key prediction-horizon-bias mapping, drafting aggressiveness, exploration ratio, persistence strength, goal weighting, context-injection default, and Deep-Run profile. Mapping keys are validated and frozen into a `MappingProxyType` view at construction time.
+- **`PROFILE_CATALOG`** (`src/vaner/setup/catalog.py`) — the seven shipped bundles per spec §9: `local_lightweight`, `local_balanced`, `local_heavy`, `hybrid_balanced`, `hybrid_quality`, `cost_saver`, `deep_research`. Plus `bundle_by_id()` lookup helper that raises `KeyError` (not a swallowed `None`) on unknown ids.
+- **`SetupConfig` and `PolicyConfig` Pydantic models** (`src/vaner/models/config.py`) — added to `VanerConfig` with default factories. `setup` carries the wizard answers + `mode` + `completed_at` first-run marker + schema `version`. `policy` carries `selected_bundle_id` (default `"hybrid_balanced"`), `bundle_overrides`, and `auto_select`.
+
+### Removed
+- **`IntentConfig.domain`** field — the unused `Literal["coding","research","writing","ops"]` field is removed outright (zero callers; no external users to migrate). Superseded by the multi-select `setup.work_styles` field on `SetupConfig`. CHANGELOG is the only record needed.
+
 ## [0.8.4] - 2026-04-24
 
 ### Added

--- a/crates/vaner-contract/README.md
+++ b/crates/vaner-contract/README.md
@@ -32,6 +32,67 @@ whichever side has fallen behind.
 - `sse` — event stream (requires `http`).
 - `ts-rs` — emit TypeScript types for the SvelteKit frontend; run `cargo test --features ts-rs` to regenerate.
 
+## TypeScript bindings (Linux desktop consumption)
+
+`vaner-desktop-linux` (the SvelteKit/Tauri app) consumes these types
+through `ts-rs`-generated TypeScript declarations. The bindings dir is
+**gitignored** at the workspace root — every consumer regenerates
+locally so the source of truth stays in Rust.
+
+### Regenerate
+
+Either of these commands writes `bindings/*.ts` under
+`crates/vaner-contract/`:
+
+```sh
+# Test-driven (matches what CI runs in `.github/workflows/rust.yml`):
+cargo test --features ts-rs --package vaner-contract regen_types
+
+# Or via the dedicated example binary (one command, no test harness):
+cargo run --example export_bindings --features ts-rs --package vaner-contract
+```
+
+Both paths emit the same files; pick whichever suits your tooling.
+
+### Consume from `vaner-desktop-linux`
+
+The Linux desktop's preferred pattern is to copy or symlink
+`crates/vaner-contract/bindings/` into its own `src/lib/contract/`
+tree at build time. A typical Tauri pre-build script:
+
+```sh
+# In vaner-desktop-linux's package.json `scripts.predev` /
+# `scripts.prebuild`:
+cargo run --example export_bindings --features ts-rs \
+  --manifest-path ../Vaner/Cargo.toml --package vaner-contract
+rsync -a ../Vaner/crates/vaner-contract/bindings/ src/lib/contract/
+```
+
+Don't commit the copy; treat it as a generated artefact. The CI step
+`test (ts-rs feature)` in `rust.yml` regenerates on every push and
+fails the build if any annotated type can't export, so the Linux side
+gets a clean cross-repo signal when a contract change lands.
+
+### macOS does NOT consume these bindings
+
+`vaner-desktop-macos` (Swift) compiles its own `Codable` mirrors and
+runs the same conformance fixtures from `tests/conformance-fixtures/`.
+The bindings dir is irrelevant to the macOS build — Linux-desktop-only.
+
+### When new public types are added
+
+Any new public struct or enum that needs a TypeScript mirror must
+carry both:
+
+```rust
+#[cfg_attr(feature = "ts-rs", derive(TS), ts(export))]
+```
+
+…and be added to the `export_all` list inside `examples/export_bindings.rs`
+(plus the same list in `src/ts.rs`'s `regen_types` test). The test
+path is what CI exercises; the example binary mirrors it for ad-hoc
+local runs.
+
 ## Conformance
 
 Run `cargo test` to exercise every layer. `tests/conformance.rs` consumes

--- a/crates/vaner-contract/examples/export_bindings.rs
+++ b/crates/vaner-contract/examples/export_bindings.rs
@@ -1,0 +1,89 @@
+//! Regenerate the TypeScript bindings under `crates/vaner-contract/bindings/`.
+//!
+//! 0.8.6 WS11 — companion to the existing `regen_types` test in
+//! `src/ts.rs`. The test path is fine for CI, but a dedicated binary
+//! gives downstream consumers (notably `vaner-desktop-linux`) a single
+//! command they can run from anywhere in the workspace:
+//!
+//! ```sh
+//! cargo run --example export_bindings --features ts-rs --package vaner-contract
+//! ```
+//!
+//! The output directory is whatever `ts-rs` decides — by default it
+//! lands at `crates/vaner-contract/bindings/*.ts`. The bindings dir is
+//! gitignored at the workspace root; downstream apps copy or symlink
+//! it into their own tree.
+//!
+//! When invoked WITHOUT the `ts-rs` feature flag, the binary prints a
+//! reminder and exits 0 — this lets `cargo build --examples` succeed
+//! in default-feature CI without spuriously regenerating files.
+
+#[cfg(feature = "ts-rs")]
+fn main() {
+    use ts_rs::TS;
+
+    use vaner_contract::enums::{
+        EtaBucket, HypothesisType, PredictionSource, Readiness, Specificity,
+    };
+    use vaner_contract::models::{
+        EngineStatus, PredictedPrompt, PredictionArtifacts, PredictionRun, PredictionSpec,
+        Provenance, Resolution, ResolutionAlternative, ResolutionEvidence, ScenarioCounts,
+    };
+    use vaner_contract::reducer::VanerState;
+
+    // Each `export_all` call writes the type *and* its transitive
+    // dependencies, deduplicated by ts-rs. We invoke once per
+    // top-level type so any new transitive dependency lands without
+    // editing this list.
+    let exports: &[(&str, fn() -> Result<(), ts_rs::ExportError>)] = &[
+        ("PredictedPrompt", PredictedPrompt::export_all),
+        ("PredictionSpec", PredictionSpec::export_all),
+        ("PredictionRun", PredictionRun::export_all),
+        ("PredictionArtifacts", PredictionArtifacts::export_all),
+        ("Resolution", Resolution::export_all),
+        ("ResolutionEvidence", ResolutionEvidence::export_all),
+        ("ResolutionAlternative", ResolutionAlternative::export_all),
+        ("Provenance", Provenance::export_all),
+        ("EngineStatus", EngineStatus::export_all),
+        ("ScenarioCounts", ScenarioCounts::export_all),
+        ("PredictionSource", PredictionSource::export_all),
+        ("HypothesisType", HypothesisType::export_all),
+        ("Specificity", Specificity::export_all),
+        ("Readiness", Readiness::export_all),
+        ("EtaBucket", EtaBucket::export_all),
+        ("VanerState", VanerState::export_all),
+    ];
+
+    let mut failures: Vec<(&str, ts_rs::ExportError)> = Vec::new();
+    for (name, export) in exports {
+        match export() {
+            Ok(()) => println!("ok   {name}"),
+            Err(err) => failures.push((name, err)),
+        }
+    }
+
+    if !failures.is_empty() {
+        eprintln!();
+        eprintln!("ts-rs export failed for {} type(s):", failures.len());
+        for (name, err) in &failures {
+            eprintln!("  - {name}: {err}");
+        }
+        std::process::exit(1);
+    }
+
+    eprintln!();
+    eprintln!(
+        "Bindings written under crates/vaner-contract/bindings/ \
+         (gitignored at workspace root)."
+    );
+    eprintln!("Downstream apps (e.g. vaner-desktop-linux) vendor by copy or symlink.");
+}
+
+#[cfg(not(feature = "ts-rs"))]
+fn main() {
+    eprintln!(
+        "vaner-contract: example `export_bindings` requires --features ts-rs.\n\
+         Re-run with:\n  cargo run --example export_bindings \
+         --features ts-rs --package vaner-contract"
+    );
+}

--- a/crates/vaner-contract/src/ts.rs
+++ b/crates/vaner-contract/src/ts.rs
@@ -21,7 +21,7 @@
 
 #[cfg(test)]
 mod regen {
-    use crate::enums::{HypothesisType, PredictionSource, Readiness, Specificity};
+    use crate::enums::{EtaBucket, HypothesisType, PredictionSource, Readiness, Specificity};
     use crate::models::{
         EngineStatus, PredictedPrompt, PredictionArtifacts, PredictionRun, PredictionSpec,
         Provenance, Resolution, ResolutionAlternative, ResolutionEvidence, ScenarioCounts,
@@ -33,6 +33,10 @@ mod regen {
     /// derived type to `bindings/*.ts` in the crate root. The frontend
     /// vendors these (copies to `vaner-linux/src/lib/contract/`) and
     /// CI enforces that the committed copy matches.
+    ///
+    /// 0.8.6 WS11: kept in lockstep with the `examples/export_bindings.rs`
+    /// list — the example binary is the equivalent path for downstream
+    /// consumers who want a single command rather than the test harness.
     #[test]
     fn regen_types() {
         // Invoking `T::export_all_to` would write to each type's
@@ -54,6 +58,7 @@ mod regen {
         HypothesisType::export_all().expect("export_all HypothesisType");
         Specificity::export_all().expect("export_all Specificity");
         Readiness::export_all().expect("export_all Readiness");
+        EtaBucket::export_all().expect("export_all EtaBucket");
         VanerState::export_all().expect("export_all VanerState");
     }
 }

--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -67,6 +67,7 @@ from vaner.cli.commands.integrations import integrations_app
 from vaner.cli.commands.primer import PRIMER_SURFACES, write_primers
 from vaner.cli.commands.profile import export_pins, import_pins, pin_fact, profile_show, unpin_fact
 from vaner.cli.commands.runtime_snapshot import runtime_snapshot
+from vaner.cli.commands.setup import setup_app
 from vaner.cli.commands.supervisor import run_down, run_up
 from vaner.daemon.http import create_daemon_http_app
 from vaner.daemon.preflight import check_repo_root
@@ -617,6 +618,32 @@ def init(
             typer.echo("Could not install completion automatically. Run `vaner --install-completion` manually.")
     else:
         typer.echo("Tip: enable command completion with `vaner --install-completion`.")
+
+    # 0.8.6 WS6: chain into the Simple-Mode setup wizard when interactive.
+    # The wizard is a no-op-or-skip from the user's perspective; they
+    # can also run it later with `vaner setup wizard`.
+    if resolved_interactive:
+        try:
+            run_wizard_now = typer.confirm(
+                "Run the setup wizard now to choose a profile?",
+                default=True,
+            )
+        except (EOFError, KeyboardInterrupt):
+            run_wizard_now = False
+        if run_wizard_now:
+            try:
+                from vaner.cli.commands.setup import wizard_cmd
+
+                wizard_cmd(path=str(repo_root))
+            except typer.Exit:
+                # The wizard signals control flow with typer.Exit; let it
+                # propagate normally without aborting the rest of init.
+                pass
+            except Exception as exc:  # pragma: no cover - defensive
+                typer.echo(f"Setup wizard skipped (error: {exc}).")
+                typer.echo("Run `vaner setup wizard` to choose a profile.")
+        else:
+            typer.echo("Skipped. Run `vaner setup wizard` later to choose a profile.")
 
 
 @daemon_app.command("start")
@@ -2117,6 +2144,7 @@ app.add_typer(deep_run_app, name="deep-run", rich_help_panel="Background and loc
 app.add_typer(guidance_app, name="guidance", rich_help_panel="Use with an agent")
 app.add_typer(integrations_app, name="integrations", rich_help_panel="Inspect and debug")
 app.add_typer(clients_app, name="clients", rich_help_panel="Connect MCP clients")
+app.add_typer(setup_app, name="setup", rich_help_panel="Get started")
 
 
 def run() -> None:

--- a/src/vaner/cli/commands/setup.py
+++ b/src/vaner/cli/commands/setup.py
@@ -59,8 +59,14 @@ from vaner.setup.apply import (
 )
 from vaner.setup.catalog import bundle_by_id
 from vaner.setup.hardware import HardwareProfile, detect
-from vaner.setup.policy import VanerPolicyBundle
 from vaner.setup.select import SelectionResult, select_policy_bundle
+from vaner.setup.serializers import (
+    AnswersValidationError,
+    answers_from_payload,
+    bundle_to_dict,
+    hardware_to_dict,
+    selection_to_dict,
+)
 
 setup_app = typer.Typer(
     help=("Simple-Mode setup wizard: pick a policy bundle, persist it to .vaner/config.toml, and inspect hardware/policy state."),
@@ -238,59 +244,13 @@ def _persist_setup_and_policy(
 # ---------------------------------------------------------------------------
 
 
-def _bundle_to_dict(bundle: VanerPolicyBundle) -> dict[str, Any]:
-    """Serialise a :class:`VanerPolicyBundle` to a JSON-safe dict."""
-
-    return {
-        "id": bundle.id,
-        "label": bundle.label,
-        "description": bundle.description,
-        "local_cloud_posture": bundle.local_cloud_posture,
-        "runtime_profile": bundle.runtime_profile,
-        "spend_profile": bundle.spend_profile,
-        "latency_profile": bundle.latency_profile,
-        "privacy_profile": bundle.privacy_profile,
-        "prediction_horizon_bias": dict(bundle.prediction_horizon_bias),
-        "drafting_aggressiveness": bundle.drafting_aggressiveness,
-        "exploration_ratio": bundle.exploration_ratio,
-        "persistence_strength": bundle.persistence_strength,
-        "goal_weighting": bundle.goal_weighting,
-        "context_injection_default": bundle.context_injection_default,
-        "deep_run_profile": bundle.deep_run_profile,
-    }
-
-
-def _selection_to_dict(result: SelectionResult) -> dict[str, Any]:
-    """Serialise a :class:`SelectionResult` for the recommend surface.
-
-    The shape is the contract MCP wiring (WS7) and desktop apps will
-    consume, so keep it stable.
-    """
-
-    return {
-        "bundle": _bundle_to_dict(result.bundle),
-        "score": result.score,
-        "reasons": list(result.reasons),
-        "runner_ups": [_bundle_to_dict(b) for b in result.runner_ups],
-        "forced_fallback": result.forced_fallback,
-    }
-
-
-def _hardware_to_dict(hw: HardwareProfile) -> dict[str, Any]:
-    """Serialise a :class:`HardwareProfile` for the hardware surface."""
-
-    return {
-        "os": hw.os,
-        "cpu_class": hw.cpu_class,
-        "ram_gb": hw.ram_gb,
-        "gpu": hw.gpu,
-        "gpu_vram_gb": hw.gpu_vram_gb,
-        "is_battery": hw.is_battery,
-        "thermal_constrained": hw.thermal_constrained,
-        "detected_runtimes": list(hw.detected_runtimes),
-        "detected_models": [list(row) for row in hw.detected_models],
-        "tier": hw.tier,
-    }
+# 0.8.6 WS7: serialisation helpers moved to :mod:`vaner.setup.serializers`
+# so the MCP server (which must not pull in typer/rich) can share the
+# same JSON shape. The underscore-prefixed names remain as aliases for
+# in-tree callers and tests that imported them before WS7.
+_bundle_to_dict = bundle_to_dict
+_selection_to_dict = selection_to_dict
+_hardware_to_dict = hardware_to_dict
 
 
 def _tier_to_human(tier: str) -> str:
@@ -498,20 +458,16 @@ def _load_answers_from_path(path: Path) -> SetupAnswers:
 
 
 def _answers_from_payload(raw: object) -> SetupAnswers:
-    if not isinstance(raw, dict):
-        raise typer.BadParameter("answers JSON must be an object")
-    work_styles = raw.get("work_styles") or ["mixed"]
-    if isinstance(work_styles, str):
-        work_styles = [work_styles]
-    if not isinstance(work_styles, list) or not all(isinstance(s, str) for s in work_styles):
-        raise typer.BadParameter("work_styles must be a list of strings")
-    return SetupAnswers(
-        work_styles=tuple(work_styles),
-        priority=str(raw.get("priority", "balanced")),  # type: ignore[arg-type]
-        compute_posture=str(raw.get("compute_posture", "balanced")),  # type: ignore[arg-type]
-        cloud_posture=str(raw.get("cloud_posture", "ask_first")),  # type: ignore[arg-type]
-        background_posture=str(raw.get("background_posture", "normal")),  # type: ignore[arg-type]
-    )
+    """CLI-side wrapper around :func:`answers_from_payload`.
+
+    Translates :class:`AnswersValidationError` into ``typer.BadParameter``
+    so the CLI commands keep their previous error surface unchanged.
+    """
+
+    try:
+        return answers_from_payload(raw)
+    except AnswersValidationError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/vaner/cli/commands/setup.py
+++ b/src/vaner/cli/commands/setup.py
@@ -1,0 +1,1049 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS6 — `vaner setup` CLI commands (0.8.6).
+
+Six subcommands compose the Simple-Mode wizard surface for the CLI:
+
+- ``vaner setup wizard`` — interactive five-question Rich flow that
+  collects answers, runs hardware detection, picks a policy bundle,
+  surfaces overrides + cloud-widening warnings, and persists the
+  result to ``.vaner/config.toml``.
+- ``vaner setup show`` — print the current ``[setup]`` / ``[policy]``
+  state plus a fresh hardware probe and the materialised
+  :class:`AppliedPolicy`. ``--json`` for programmatic consumers.
+- ``vaner setup recommend`` — read :class:`SetupAnswers` from stdin or
+  ``--answers`` and emit :class:`SelectionResult` as JSON. Always JSON
+  — this is the programmatic-recommendation surface (desktop apps,
+  scripts, MCP wiring).
+- ``vaner setup apply`` — persist already-collected answers (or an
+  explicit ``--bundle-id``) without re-running the wizard. Best-effort
+  daemon ping; the daemon picks up the change on its next config
+  refresh.
+- ``vaner setup advanced`` — open ``.vaner/config.toml`` in ``$EDITOR``
+  for direct knob editing. Prints a one-line "managed sections" hint.
+- ``vaner setup hardware`` — print :class:`HardwareProfile` from
+  :func:`vaner.setup.hardware.detect`. ``--json`` for raw output.
+
+The CLI never mutates :mod:`vaner.setup` modules; it only consumes
+their pure-function surface. Persistence here uses the shared
+``_update_toml_section`` helper from :mod:`vaner.cli.commands.init`
+to keep ``[setup]`` / ``[policy]`` writes consistent with the rest of
+the config-editing surface.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated, Any
+
+import httpx
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from vaner.cli.commands.config import load_config
+from vaner.cli.commands.init import init_repo
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.apply import (
+    WIDENS_CLOUD_POSTURE_SENTINEL,
+    AppliedPolicy,
+    apply_policy_bundle,
+)
+from vaner.setup.catalog import bundle_by_id
+from vaner.setup.hardware import HardwareProfile, detect
+from vaner.setup.policy import VanerPolicyBundle
+from vaner.setup.select import SelectionResult, select_policy_bundle
+
+setup_app = typer.Typer(
+    help=("Simple-Mode setup wizard: pick a policy bundle, persist it to .vaner/config.toml, and inspect hardware/policy state."),
+    no_args_is_help=True,
+)
+
+_console = Console()
+_DAEMON_URL = "http://127.0.0.1:8473"
+
+# ---------------------------------------------------------------------------
+# Path / config helpers
+# ---------------------------------------------------------------------------
+
+
+def _repo_root(path: str | None) -> Path:
+    """Resolve ``--path`` / ``$VANER_PATH`` / ``cwd`` to a repo root.
+
+    Mirrors the convention from :mod:`vaner.cli.commands.app` so every
+    setup subcommand picks up the same root the rest of the CLI does.
+    """
+
+    if path:
+        return Path(path).resolve()
+    env_path = os.environ.get("VANER_PATH", "").strip()
+    return Path(env_path).resolve() if env_path else Path.cwd()
+
+
+def _read_setup_section(repo_root: Path) -> dict[str, Any]:
+    """Read the raw ``[setup]`` table from ``.vaner/config.toml``.
+
+    ``load_config`` does not yet hydrate :class:`SetupConfig` /
+    :class:`PolicyConfig` from disk, so the CLI reads them directly.
+    Returns an empty dict when the file or section is absent.
+    """
+
+    config_path = repo_root / ".vaner" / "config.toml"
+    if not config_path.exists():
+        return {}
+    try:
+        parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    section = parsed.get("setup", {})
+    return section if isinstance(section, dict) else {}
+
+
+def _read_policy_section(repo_root: Path) -> dict[str, Any]:
+    """Read the raw ``[policy]`` table from ``.vaner/config.toml``."""
+
+    config_path = repo_root / ".vaner" / "config.toml"
+    if not config_path.exists():
+        return {}
+    try:
+        parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    section = parsed.get("policy", {})
+    return section if isinstance(section, dict) else {}
+
+
+def _toml_literal(value: object) -> str:
+    """Render a Python value as a TOML literal.
+
+    Extension over the small editor in :mod:`vaner.cli.commands.init`:
+    we also support ``list[str]`` (rendered as a TOML inline array).
+    The ``[setup]`` section needs proper ``work_styles = ["mixed"]``
+    arrays — not the JSON-string the init helper would emit.
+    """
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if value is None:
+        return '""'
+    if isinstance(value, list):
+        items = []
+        for item in value:
+            if isinstance(item, str):
+                escaped = item.replace("\\", "\\\\").replace('"', '\\"')
+                items.append(f'"{escaped}"')
+            else:
+                items.append(_toml_literal(item))
+        return "[" + ", ".join(items) + "]"
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _update_section(text: str, section: str, values: dict[str, object]) -> str:
+    """Update keys within a TOML section, leaving unrelated keys untouched.
+
+    Mirror of ``_update_toml_section`` in :mod:`vaner.cli.commands.init`
+    but with proper list rendering. Single-line ``key = value`` only;
+    matches the shape the wizard writes.
+    """
+
+    if not values:
+        return text
+    lines = text.splitlines()
+    header = f"[{section}]"
+    start: int | None = None
+    for idx, line in enumerate(lines):
+        if line.strip() == header:
+            start = idx
+            break
+    if start is None:
+        lines.append("")
+        lines.append(header)
+        for key, val in values.items():
+            lines.append(f"{key} = {_toml_literal(val)}")
+        return "\n".join(lines) + ("\n" if not text.endswith("\n") else "")
+
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        stripped = lines[idx].strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            end = idx
+            break
+    remaining = dict(values)
+    for idx in range(start + 1, end):
+        stripped = lines[idx].lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key = stripped.split("=", 1)[0].strip()
+        if key in remaining:
+            lines[idx] = f"{key} = {_toml_literal(remaining.pop(key))}"
+    if remaining:
+        insert_at = end
+        for key, val in remaining.items():
+            lines.insert(insert_at, f"{key} = {_toml_literal(val)}")
+            insert_at += 1
+    out = "\n".join(lines)
+    return out + ("\n" if not out.endswith("\n") else "")
+
+
+def _persist_setup_and_policy(
+    repo_root: Path,
+    answers: SetupAnswers,
+    bundle_id: str,
+    *,
+    completed_at: datetime | None = None,
+) -> Path:
+    """Write the wizard answers + selected bundle id to ``config.toml``.
+
+    Returns the path to the written file. Idempotent: re-writing the
+    same values produces a byte-identical file. The caller is
+    responsible for any user confirmation upstream.
+    """
+
+    config_path = init_repo(repo_root)
+    text = config_path.read_text(encoding="utf-8")
+    setup_values: dict[str, object] = {
+        "mode": "simple",
+        "work_styles": list(answers.work_styles),
+        "priority": answers.priority,
+        "compute_posture": answers.compute_posture,
+        "cloud_posture": answers.cloud_posture,
+        "background_posture": answers.background_posture,
+        "version": 1,
+    }
+    if completed_at is not None:
+        setup_values["completed_at"] = completed_at.isoformat()
+    text = _update_section(text, "setup", setup_values)
+    text = _update_section(
+        text,
+        "policy",
+        {"selected_bundle_id": bundle_id, "auto_select": True},
+    )
+    config_path.write_text(text, encoding="utf-8")
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (JSON-emitting subcommands)
+# ---------------------------------------------------------------------------
+
+
+def _bundle_to_dict(bundle: VanerPolicyBundle) -> dict[str, Any]:
+    """Serialise a :class:`VanerPolicyBundle` to a JSON-safe dict."""
+
+    return {
+        "id": bundle.id,
+        "label": bundle.label,
+        "description": bundle.description,
+        "local_cloud_posture": bundle.local_cloud_posture,
+        "runtime_profile": bundle.runtime_profile,
+        "spend_profile": bundle.spend_profile,
+        "latency_profile": bundle.latency_profile,
+        "privacy_profile": bundle.privacy_profile,
+        "prediction_horizon_bias": dict(bundle.prediction_horizon_bias),
+        "drafting_aggressiveness": bundle.drafting_aggressiveness,
+        "exploration_ratio": bundle.exploration_ratio,
+        "persistence_strength": bundle.persistence_strength,
+        "goal_weighting": bundle.goal_weighting,
+        "context_injection_default": bundle.context_injection_default,
+        "deep_run_profile": bundle.deep_run_profile,
+    }
+
+
+def _selection_to_dict(result: SelectionResult) -> dict[str, Any]:
+    """Serialise a :class:`SelectionResult` for the recommend surface.
+
+    The shape is the contract MCP wiring (WS7) and desktop apps will
+    consume, so keep it stable.
+    """
+
+    return {
+        "bundle": _bundle_to_dict(result.bundle),
+        "score": result.score,
+        "reasons": list(result.reasons),
+        "runner_ups": [_bundle_to_dict(b) for b in result.runner_ups],
+        "forced_fallback": result.forced_fallback,
+    }
+
+
+def _hardware_to_dict(hw: HardwareProfile) -> dict[str, Any]:
+    """Serialise a :class:`HardwareProfile` for the hardware surface."""
+
+    return {
+        "os": hw.os,
+        "cpu_class": hw.cpu_class,
+        "ram_gb": hw.ram_gb,
+        "gpu": hw.gpu,
+        "gpu_vram_gb": hw.gpu_vram_gb,
+        "is_battery": hw.is_battery,
+        "thermal_constrained": hw.thermal_constrained,
+        "detected_runtimes": list(hw.detected_runtimes),
+        "detected_models": [list(row) for row in hw.detected_models],
+        "tier": hw.tier,
+    }
+
+
+def _tier_to_human(tier: str) -> str:
+    return {
+        "light": "Light",
+        "capable": "Capable",
+        "high_performance": "High-performance",
+        "unknown": "Unknown",
+    }.get(tier, tier)
+
+
+def _os_to_human(os_name: str) -> str:
+    return {"linux": "Linux", "darwin": "macOS", "windows": "Windows"}.get(os_name, os_name)
+
+
+# ---------------------------------------------------------------------------
+# Wizard prompt helpers
+# ---------------------------------------------------------------------------
+
+
+_WORK_STYLE_CHOICES: tuple[tuple[str, str], ...] = (
+    ("writing", "Writing — drafting, editing, narrative"),
+    ("research", "Research — surveys, deep reading, citations"),
+    ("planning", "Planning — design docs, roadmaps, project layout"),
+    ("support", "Support — answering questions, troubleshooting"),
+    ("learning", "Learning — studying, exploring a new domain"),
+    ("coding", "Coding — software development"),
+    ("general", "General — knowledge work, mixed light tasks"),
+    ("mixed", "Mixed — a bit of everything (safe default)"),
+    ("unsure", "Unsure — I'd rather Vaner picks for me"),
+)
+
+
+_PRIORITY_CHOICES: tuple[tuple[str, str], ...] = (
+    ("balanced", "Balanced — a sensible middle"),
+    ("speed", "Speed — snappy responses"),
+    ("quality", "Quality — best answer, even if slow"),
+    ("privacy", "Privacy — keep data on this machine"),
+    ("cost", "Cost — minimise spend"),
+    ("low_resource", "Low-resource — go easy on this machine"),
+)
+
+
+_COMPUTE_CHOICES: tuple[tuple[str, str], ...] = (
+    ("light", "Light — barely use the CPU/GPU"),
+    ("balanced", "Balanced — work with what's idle"),
+    ("available_power", "Available-power — use what this box has"),
+)
+
+
+_CLOUD_CHOICES: tuple[tuple[str, str], ...] = (
+    ("local_only", "Local only — never reach for cloud LLMs"),
+    ("ask_first", "Ask first — confirm before any cloud call"),
+    ("hybrid_when_worth_it", "Hybrid — cloud when it's clearly worth it"),
+    ("best_available", "Best available — use the best model for the job"),
+)
+
+
+_BACKGROUND_CHOICES: tuple[tuple[str, str], ...] = (
+    ("minimal", "Minimal — barely ponder when idle"),
+    ("normal", "Normal — moderate background pondering"),
+    ("idle_more", "Idle-more — ponder broadly when the box is idle"),
+    ("deep_run_aggressive", "Deep-Run-aggressive — happy to run overnight"),
+)
+
+
+def _print_choice_menu(
+    console: Console,
+    title: str,
+    choices: tuple[tuple[str, str], ...],
+) -> None:
+    """Render a numbered choice menu (1-indexed)."""
+
+    console.print(f"\n[bold]{title}[/bold]")
+    for idx, (_value, label) in enumerate(choices, start=1):
+        console.print(f"  [cyan]{idx}[/cyan]) {label}")
+
+
+def _resolve_choice_token(
+    token: str,
+    choices: tuple[tuple[str, str], ...],
+) -> str | None:
+    """Map a user-typed token (number or value-id) to a choice value."""
+
+    cleaned = token.strip().lower()
+    if not cleaned:
+        return None
+    if cleaned.isdigit():
+        idx = int(cleaned) - 1
+        if 0 <= idx < len(choices):
+            return choices[idx][0]
+        return None
+    by_value = {value for value, _label in choices}
+    if cleaned in by_value:
+        return cleaned
+    return None
+
+
+def _prompt_single(
+    title: str,
+    choices: tuple[tuple[str, str], ...],
+    default_value: str,
+) -> str:
+    """Prompt for a single-select answer; returns the chosen value."""
+
+    _print_choice_menu(_console, title, choices)
+    default_idx = next(
+        (i + 1 for i, (value, _label) in enumerate(choices) if value == default_value),
+        1,
+    )
+    answer = typer.prompt("Choice", default=str(default_idx))
+    resolved = _resolve_choice_token(str(answer), choices)
+    return resolved or default_value
+
+
+def _prompt_multi(
+    title: str,
+    choices: tuple[tuple[str, str], ...],
+    default_values: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Prompt for a multi-select answer; returns a tuple of values.
+
+    Empty input keeps ``default_values``. Tokens may be numbers (1..N)
+    or value-ids; comma- or space-separated.
+    """
+
+    _print_choice_menu(_console, title, choices)
+    default_str = ",".join(default_values) if default_values else "mixed"
+    answer = typer.prompt(
+        'Choice(s) (comma- or space-separated; e.g. "1 3" or "writing,research")',
+        default=default_str,
+    )
+    raw_tokens = [token for token in str(answer).replace(",", " ").split() if token.strip()]
+    if not raw_tokens:
+        return default_values or ("mixed",)
+    selected: list[str] = []
+    for token in raw_tokens:
+        resolved = _resolve_choice_token(token, choices)
+        if resolved is not None and resolved not in selected:
+            selected.append(resolved)
+    if not selected:
+        return default_values or ("mixed",)
+    return tuple(selected)
+
+
+def _collect_answers_interactive() -> SetupAnswers:
+    """Run the five Simple-Mode questions and return :class:`SetupAnswers`."""
+
+    work_styles = _prompt_multi(
+        "1/5 — What kind of work do you want help with?",
+        _WORK_STYLE_CHOICES,
+        ("mixed",),
+    )
+    priority = _prompt_single(
+        "2/5 — What matters most?",
+        _PRIORITY_CHOICES,
+        "balanced",
+    )
+    compute = _prompt_single(
+        "3/5 — How hard should this machine work for you?",
+        _COMPUTE_CHOICES,
+        "balanced",
+    )
+    cloud = _prompt_single(
+        "4/5 — How do you feel about cloud LLMs?",
+        _CLOUD_CHOICES,
+        "ask_first",
+    )
+    background = _prompt_single(
+        "5/5 — How aggressive should background pondering be?",
+        _BACKGROUND_CHOICES,
+        "normal",
+    )
+    return SetupAnswers(
+        work_styles=work_styles,  # type: ignore[arg-type]
+        priority=priority,  # type: ignore[arg-type]
+        compute_posture=compute,  # type: ignore[arg-type]
+        cloud_posture=cloud,  # type: ignore[arg-type]
+        background_posture=background,  # type: ignore[arg-type]
+    )
+
+
+def _default_answers() -> SetupAnswers:
+    """Sensible defaults for non-interactive / ``--accept-defaults`` use."""
+
+    return SetupAnswers(
+        work_styles=("mixed",),
+        priority="balanced",
+        compute_posture="balanced",
+        cloud_posture="ask_first",
+        background_posture="normal",
+    )
+
+
+def _load_answers_from_path(path: Path) -> SetupAnswers:
+    """Load a :class:`SetupAnswers` from a JSON file.
+
+    Accepts the shape produced by :func:`dataclasses.asdict` plus the
+    minor adjustment of ``work_styles`` being a list (the dataclass
+    converts back to a tuple on construction).
+    """
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return _answers_from_payload(raw)
+
+
+def _answers_from_payload(raw: object) -> SetupAnswers:
+    if not isinstance(raw, dict):
+        raise typer.BadParameter("answers JSON must be an object")
+    work_styles = raw.get("work_styles") or ["mixed"]
+    if isinstance(work_styles, str):
+        work_styles = [work_styles]
+    if not isinstance(work_styles, list) or not all(isinstance(s, str) for s in work_styles):
+        raise typer.BadParameter("work_styles must be a list of strings")
+    return SetupAnswers(
+        work_styles=tuple(work_styles),
+        priority=str(raw.get("priority", "balanced")),  # type: ignore[arg-type]
+        compute_posture=str(raw.get("compute_posture", "balanced")),  # type: ignore[arg-type]
+        cloud_posture=str(raw.get("cloud_posture", "ask_first")),  # type: ignore[arg-type]
+        background_posture=str(raw.get("background_posture", "normal")),  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wizard rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_hardware_one_line(console: Console, hw: HardwareProfile) -> None:
+    console.print(f"This [bold]{_os_to_human(hw.os)}[/bold] machine looks [bold]{_tier_to_human(hw.tier)}[/bold].")
+
+
+def _render_selection_panel(console: Console, result: SelectionResult) -> None:
+    title = f"Recommended bundle: {result.bundle.label} ({result.bundle.id})"
+    body_lines = [
+        f"[bold]{result.bundle.label}[/bold]",
+        result.bundle.description,
+        "",
+        "Why this bundle:",
+    ]
+    if result.reasons:
+        body_lines.extend(f"  - {reason}" for reason in result.reasons)
+    else:
+        body_lines.append("  - (no positive reasons; safe default)")
+    if result.runner_ups:
+        body_lines.append("")
+        body_lines.append("Runner-ups:")
+        for ru in result.runner_ups[:2]:
+            body_lines.append(f"  - {ru.label} ({ru.id})")
+    if result.forced_fallback:
+        body_lines.append("")
+        body_lines.append("[yellow]Note:[/yellow] no bundle matched filters; using safe default.")
+    console.print(Panel("\n".join(body_lines), title=title, border_style="cyan"))
+
+
+def _split_overrides(applied: AppliedPolicy) -> tuple[list[str], list[str]]:
+    """Split overrides into (cloud_widening_warnings, regular_overrides)."""
+
+    warnings: list[str] = []
+    regular: list[str] = []
+    for entry in applied.overrides_applied:
+        if entry.startswith(WIDENS_CLOUD_POSTURE_SENTINEL):
+            warnings.append(entry)
+        else:
+            regular.append(entry)
+    return warnings, regular
+
+
+def _render_overrides_table(console: Console, overrides: list[str]) -> None:
+    if not overrides:
+        console.print("[dim]No overrides applied (config already matches the bundle).[/dim]")
+        return
+    table = Table(title="Overrides applied", show_header=True, header_style="bold")
+    table.add_column("#")
+    table.add_column("Description")
+    for idx, line in enumerate(overrides, start=1):
+        table.add_row(str(idx), line)
+    console.print(table)
+
+
+def _render_cloud_widening_warning(console: Console, warnings: list[str]) -> None:
+    body_lines = [
+        "Switching to this bundle widens your cloud posture:",
+        "",
+    ]
+    body_lines.extend(f"  - {entry}" for entry in warnings)
+    body_lines.append("")
+    body_lines.append("Cloud calls may incur cost and route data off this machine.")
+    console.print(
+        Panel(
+            "\n".join(body_lines),
+            title="Cloud posture is widening",
+            border_style="yellow",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+@setup_app.command(
+    "wizard",
+    help="Interactive Simple-Mode wizard. Asks five questions, picks a bundle, persists it.",
+)
+def wizard_cmd(
+    path: Annotated[
+        str | None,
+        typer.Option("--path", help="Repository root override."),
+    ] = None,
+    accept_defaults: Annotated[
+        bool,
+        typer.Option(
+            "--accept-defaults",
+            help="Skip prompts; accept sensible defaults (CI / Docker / non-TTY).",
+        ),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Auto-confirm cloud-widening + write prompts (use with --accept-defaults).",
+        ),
+    ] = False,
+) -> None:
+    """Run the Simple-Mode wizard against the resolved repo root."""
+
+    repo_root = _repo_root(path)
+    config_path = init_repo(repo_root)
+
+    if accept_defaults:
+        answers = _default_answers()
+        _console.print("[dim]--accept-defaults: using sensible default answers.[/dim]")
+    else:
+        try:
+            answers = _collect_answers_interactive()
+        except (EOFError, KeyboardInterrupt):
+            _console.print("[red]Wizard aborted.[/red]")
+            raise typer.Exit(code=1) from None
+
+    hardware = detect()
+    _render_hardware_one_line(_console, hardware)
+
+    selection = select_policy_bundle(answers, hardware)
+    _render_selection_panel(_console, selection)
+
+    config = load_config(repo_root)
+    # Reflect the on-disk previous bundle id into the runtime config so
+    # the cloud-widening guard fires correctly. ``load_config`` does
+    # not yet re-read ``[policy]`` so we patch it from the raw section.
+    prior_policy_section = _read_policy_section(repo_root)
+    prior_bundle_id = prior_policy_section.get("selected_bundle_id")
+    if isinstance(prior_bundle_id, str) and prior_bundle_id:
+        config = config.model_copy(update={"policy": config.policy.model_copy(update={"selected_bundle_id": prior_bundle_id})})
+
+    applied = apply_policy_bundle(config, selection.bundle)
+    warnings, regular_overrides = _split_overrides(applied)
+
+    if warnings:
+        _render_cloud_widening_warning(_console, warnings)
+        if not yes:
+            try:
+                proceed = typer.confirm(
+                    "Continue and widen the cloud posture?",
+                    default=False,
+                )
+            except (EOFError, KeyboardInterrupt):
+                proceed = False
+            if not proceed:
+                _console.print("[red]Aborted: cloud posture not widened. Config left unchanged.[/red]")
+                raise typer.Exit(code=1)
+
+    _render_overrides_table(_console, regular_overrides)
+
+    if yes or accept_defaults:
+        write_proceed = True
+    else:
+        try:
+            write_proceed = typer.confirm(
+                f"Write to {config_path}?",
+                default=True,
+            )
+        except (EOFError, KeyboardInterrupt):
+            write_proceed = False
+
+    if not write_proceed:
+        _console.print("[yellow]Skipped writing config.[/yellow]")
+        return
+
+    completed_at = datetime.now(UTC)
+    _persist_setup_and_policy(repo_root, answers, selection.bundle.id, completed_at=completed_at)
+    _console.print(f"[green]Wrote setup + policy to[/green] {config_path}")
+    _console.print(f"[dim]selected_bundle_id={selection.bundle.id}[/dim]")
+
+
+@setup_app.command(
+    "show",
+    help="Print current [setup]/[policy] state, hardware profile, and applied-policy overrides.",
+)
+def show_cmd(
+    path: Annotated[
+        str | None,
+        typer.Option("--path", help="Repository root override."),
+    ] = None,
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON instead of Rich tables."),
+    ] = False,
+) -> None:
+    """Show the current setup/policy state for this repo root."""
+
+    repo_root = _repo_root(path)
+    setup_section = _read_setup_section(repo_root)
+    policy_section = _read_policy_section(repo_root)
+    hardware = detect()
+
+    selected_bundle_id = policy_section.get("selected_bundle_id") or "hybrid_balanced"
+    applied_dict: dict[str, Any] | None = None
+    bundle_dict: dict[str, Any] | None = None
+    try:
+        bundle = bundle_by_id(str(selected_bundle_id))
+        bundle_dict = _bundle_to_dict(bundle)
+        config = load_config(repo_root)
+        # Make the cloud-widening guard a no-op against itself by
+        # pinning prior bundle id to current.
+        config = config.model_copy(update={"policy": config.policy.model_copy(update={"selected_bundle_id": str(selected_bundle_id)})})
+        applied = apply_policy_bundle(config, bundle)
+        applied_dict = {
+            "bundle_id": applied.bundle_id,
+            "overrides_applied": list(applied.overrides_applied),
+        }
+    except KeyError:
+        applied_dict = {"error": f"unknown bundle id {selected_bundle_id!r}"}
+
+    payload: dict[str, Any] = {
+        "repo_root": str(repo_root),
+        "setup": setup_section,
+        "policy": policy_section,
+        "hardware": _hardware_to_dict(hardware),
+        "applied_policy": applied_dict,
+        "bundle": bundle_dict,
+    }
+
+    if as_json:
+        typer.echo(json.dumps(payload, indent=2, default=str))
+        return
+
+    completed_at = setup_section.get("completed_at")
+    if not setup_section or completed_at is None:
+        _console.print("[yellow]Setup not yet completed.[/yellow] Run [bold]vaner setup wizard[/bold] to choose a profile.")
+    else:
+        _console.print(f"[bold]Setup completed at:[/bold] {completed_at}")
+
+    setup_table = Table(title="Setup", show_header=True, header_style="bold")
+    setup_table.add_column("Field")
+    setup_table.add_column("Value")
+    for key in ("mode", "work_styles", "priority", "compute_posture", "cloud_posture", "background_posture"):
+        setup_table.add_row(key, str(setup_section.get(key, "(default)")))
+    _console.print(setup_table)
+
+    policy_table = Table(title="Policy", show_header=True, header_style="bold")
+    policy_table.add_column("Field")
+    policy_table.add_column("Value")
+    policy_table.add_row("selected_bundle_id", str(selected_bundle_id))
+    if bundle_dict is not None:
+        policy_table.add_row("bundle.label", str(bundle_dict["label"]))
+        policy_table.add_row("bundle.local_cloud_posture", str(bundle_dict["local_cloud_posture"]))
+        policy_table.add_row("bundle.runtime_profile", str(bundle_dict["runtime_profile"]))
+        policy_table.add_row("bundle.deep_run_profile", str(bundle_dict["deep_run_profile"]))
+    policy_table.add_row("auto_select", str(policy_section.get("auto_select", True)))
+    _console.print(policy_table)
+
+    hw_table = Table(title="Hardware", show_header=True, header_style="bold")
+    hw_table.add_column("Field")
+    hw_table.add_column("Value")
+    for key in ("os", "cpu_class", "ram_gb", "gpu", "gpu_vram_gb", "is_battery", "thermal_constrained", "tier"):
+        hw_table.add_row(key, str(payload["hardware"][key]))
+    _console.print(hw_table)
+
+    if applied_dict and "overrides_applied" in applied_dict:
+        overrides = list(applied_dict["overrides_applied"])
+        if overrides:
+            _console.print("[bold]Applied policy overrides:[/bold]")
+            for line in overrides:
+                style = "yellow" if line.startswith(WIDENS_CLOUD_POSTURE_SENTINEL) else "dim"
+                _console.print(f"  [{style}]- {line}[/{style}]")
+
+
+@setup_app.command(
+    "recommend",
+    help="Read SetupAnswers JSON (stdin or --answers) and emit a SelectionResult JSON.",
+)
+def recommend_cmd(
+    answers_path: Annotated[
+        Path | None,
+        typer.Option("--answers", help="Path to a JSON file holding SetupAnswers; '-' or omit for stdin."),
+    ] = None,
+) -> None:
+    """Programmatic-recommendation surface. Always emits JSON.
+
+    The output shape is the contract MCP wiring (WS7) and desktop
+    apps consume:
+
+    .. code-block:: json
+
+        {
+          "bundle": {"id": "...", "label": "...", ...},
+          "score": 5.2,
+          "reasons": ["..."],
+          "runner_ups": [{"id": "...", ...}],
+          "forced_fallback": false
+        }
+    """
+
+    if answers_path is not None and str(answers_path) != "-":
+        try:
+            answers = _load_answers_from_path(answers_path)
+        except FileNotFoundError as exc:
+            typer.secho(f"answers file not found: {answers_path}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=1) from exc
+        except (json.JSONDecodeError, ValueError, TypeError) as exc:
+            typer.secho(f"failed to parse answers: {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=1) from exc
+    else:
+        try:
+            raw_text = sys.stdin.read()
+        except Exception as exc:  # pragma: no cover - defensive
+            typer.secho(f"failed to read stdin: {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=1) from exc
+        if not raw_text.strip():
+            typer.secho(
+                "no answers JSON on stdin (pass --answers <path> or pipe JSON)",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        try:
+            payload = json.loads(raw_text)
+            answers = _answers_from_payload(payload)
+        except (json.JSONDecodeError, ValueError, TypeError) as exc:
+            typer.secho(f"failed to parse answers: {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=1) from exc
+
+    hardware = detect()
+    selection = select_policy_bundle(answers, hardware)
+    typer.echo(json.dumps(_selection_to_dict(selection), indent=2))
+
+
+@setup_app.command(
+    "apply",
+    help=(
+        "Persist answers (or an explicit --bundle-id) without prompts. Best-effort "
+        "daemon ping; the daemon picks up changes on the next cycle (no live-refresh "
+        "endpoint until WS8)."
+    ),
+)
+def apply_cmd(
+    path: Annotated[
+        str | None,
+        typer.Option("--path", help="Repository root override."),
+    ] = None,
+    answers_path: Annotated[
+        Path | None,
+        typer.Option("--answers", help="Path to a JSON file holding SetupAnswers."),
+    ] = None,
+    bundle_id: Annotated[
+        str | None,
+        typer.Option("--bundle-id", help="Skip selection; pin this bundle id directly."),
+    ] = None,
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit a JSON status object instead of human-readable lines."),
+    ] = False,
+) -> None:
+    """Non-interactive apply for batch / scripting use."""
+
+    repo_root = _repo_root(path)
+
+    if bundle_id is not None:
+        try:
+            bundle = bundle_by_id(bundle_id)
+        except KeyError as exc:
+            typer.secho(f"unknown bundle id: {bundle_id!r}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=1) from exc
+        # No answers required for explicit-bundle override; persist the
+        # current setup section unchanged (or defaults) plus the
+        # selected bundle id.
+        existing_setup = _read_setup_section(repo_root)
+        if existing_setup:
+            answers = _answers_from_payload(existing_setup)
+        else:
+            answers = _default_answers()
+        chosen_bundle_id = bundle.id
+        reasons: list[str] = ["explicit --bundle-id override"]
+    else:
+        if answers_path is None:
+            existing_setup = _read_setup_section(repo_root)
+            if not existing_setup:
+                typer.secho(
+                    "no answers provided and no [setup] section on disk; pass --answers or run `vaner setup wizard`",
+                    fg=typer.colors.RED,
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+            answers = _answers_from_payload(existing_setup)
+        else:
+            try:
+                answers = _load_answers_from_path(answers_path)
+            except FileNotFoundError as exc:
+                typer.secho(f"answers file not found: {answers_path}", fg=typer.colors.RED, err=True)
+                raise typer.Exit(code=1) from exc
+            except (json.JSONDecodeError, ValueError, TypeError) as exc:
+                typer.secho(f"failed to parse answers: {exc}", fg=typer.colors.RED, err=True)
+                raise typer.Exit(code=1) from exc
+        hardware = detect()
+        selection = select_policy_bundle(answers, hardware)
+        chosen_bundle_id = selection.bundle.id
+        reasons = list(selection.reasons)
+
+    completed_at = datetime.now(UTC)
+    config_path = _persist_setup_and_policy(
+        repo_root,
+        answers,
+        chosen_bundle_id,
+        completed_at=completed_at,
+    )
+
+    daemon_status = _ping_daemon_for_refresh()
+
+    payload: dict[str, Any] = {
+        "config_path": str(config_path),
+        "selected_bundle_id": chosen_bundle_id,
+        "reasons": reasons,
+        "daemon": daemon_status,
+    }
+    if as_json:
+        typer.echo(json.dumps(payload, indent=2, default=str))
+        return
+
+    _console.print(f"[green]Wrote setup + policy to[/green] {config_path}")
+    _console.print(f"[dim]selected_bundle_id={chosen_bundle_id}[/dim]")
+    if daemon_status.get("reachable"):
+        _console.print("[dim]Daemon reachable. Daemon will pick up changes on next config reload.[/dim]")
+    else:
+        _console.print("[dim]Daemon not running; changes will apply at next start.[/dim]")
+
+
+@setup_app.command(
+    "advanced",
+    help="Open .vaner/config.toml in $EDITOR (or fallback) for direct knob editing.",
+)
+def advanced_cmd(
+    path: Annotated[
+        str | None,
+        typer.Option("--path", help="Repository root override."),
+    ] = None,
+) -> None:
+    """Hand the config off to ``$EDITOR`` for free-form editing."""
+
+    repo_root = _repo_root(path)
+    config_path = init_repo(repo_root)
+    _console.print("[dim]Sections managed by the wizard: [setup], [policy]. Other sections are free-form.[/dim]")
+    editor = os.environ.get("EDITOR") or os.environ.get("VISUAL") or shutil.which("nano") or shutil.which("vi") or shutil.which("vim")
+    if editor is None:
+        typer.secho(
+            "no editor found; set $EDITOR or install nano/vi",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    cmd = [editor, str(config_path)]
+    completed = subprocess.run(cmd, check=False)
+    if completed.returncode != 0:
+        raise typer.Exit(code=completed.returncode)
+
+
+@setup_app.command(
+    "hardware",
+    help="Print HardwareProfile.detect() output. --json for raw JSON.",
+)
+def hardware_cmd(
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON instead of a Rich panel."),
+    ] = False,
+) -> None:
+    """Print the detected hardware profile."""
+
+    hw = detect()
+    if as_json:
+        typer.echo(json.dumps(_hardware_to_dict(hw), indent=2, default=str))
+        return
+    body_lines = [
+        f"OS: [bold]{_os_to_human(hw.os)}[/bold] ({hw.os})",
+        f"Tier: [bold]{_tier_to_human(hw.tier)}[/bold]",
+        f"CPU class: {hw.cpu_class}",
+        f"RAM: {hw.ram_gb} GB",
+        f"GPU: {hw.gpu}" + (f" ({hw.gpu_vram_gb} GB VRAM)" if hw.gpu_vram_gb else ""),
+        f"Battery: {'yes' if hw.is_battery else 'no'}",
+        f"Thermal-constrained: {'yes' if hw.thermal_constrained else 'no'}",
+    ]
+    if hw.detected_runtimes:
+        body_lines.append(f"Runtimes: {', '.join(hw.detected_runtimes)}")
+    if hw.detected_models:
+        body_lines.append(f"Detected models: {len(hw.detected_models)}")
+    _console.print(Panel("\n".join(body_lines), title="Hardware profile", border_style="cyan"))
+
+
+# ---------------------------------------------------------------------------
+# Daemon ping
+# ---------------------------------------------------------------------------
+
+
+def _ping_daemon_for_refresh() -> dict[str, Any]:
+    """Best-effort liveness probe of the local daemon HTTP surface.
+
+    Returns a dict suitable for JSON output. The daemon currently has
+    no live-refresh endpoint; WS8 will add one. Today the engine
+    re-reads ``[setup]`` / ``[policy]`` at the top of every
+    ``precompute_cycle`` (see ``_refresh_policy_bundle_state``), so
+    config writes propagate without a daemon restart.
+    """
+
+    try:
+        with httpx.Client(timeout=1.0) as client:
+            resp = client.get(f"{_DAEMON_URL}/status")
+            if resp.status_code == 200:
+                return {
+                    "reachable": True,
+                    "url": _DAEMON_URL,
+                    "note": "daemon will pick up changes on next config reload",
+                }
+            return {
+                "reachable": False,
+                "url": _DAEMON_URL,
+                "status_code": resp.status_code,
+            }
+    except (httpx.HTTPError, OSError) as exc:
+        return {
+            "reachable": False,
+            "url": _DAEMON_URL,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+# Defensive: keep ``dataclasses`` imported even if unused above so that
+# downstream maintainers can rely on ``dataclasses.asdict`` here for
+# the recommend serialiser. The helper is intentionally explicit (see
+# :func:`_selection_to_dict`) so we don't lock the JSON shape to the
+# dataclass field order.
+_ = dataclasses
+
+
+__all__ = ["setup_app"]

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -5,6 +5,7 @@ import json
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -215,6 +216,504 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         if session is None:
             raise HTTPException(status_code=404, detail=f"session {session_id!r} not found")
         return JSONResponse(_serialize_session(session))
+
+    # ------------------------------------------------------------------
+    # 0.8.6 WS8 — Setup HTTP surface. Mirrors the WS7 MCP tools so
+    # desktop apps that prefer HTTP can drive the wizard end-to-end.
+    # Reuses WS6's serialisation helpers (vaner.cli.commands.setup) as
+    # the canonical contract for the JSON shapes; the MCP tools use the
+    # same helpers so both surfaces stay in lock-step.
+    #
+    # Hardware detection is cached for the daemon process lifetime
+    # because probing reaches into /sys, runs subprocesses, etc — once
+    # is enough per daemon. The cache is process-local; restart picks
+    # up new hardware. Tests reset the cache via the helper below.
+    # ------------------------------------------------------------------
+
+    _hardware_cache: dict[str, Any] = {"profile": None}
+
+    def _get_hardware_profile_cached() -> Any:
+        from vaner.setup.hardware import detect
+
+        if _hardware_cache["profile"] is None:
+            _hardware_cache["profile"] = detect()
+        return _hardware_cache["profile"]
+
+    def _reset_hardware_cache_for_tests() -> None:
+        _hardware_cache["profile"] = None
+
+    # Expose the reset hook on the app so tests can clear the cache
+    # between runs. Production callers never need this.
+    app.state.reset_hardware_cache = _reset_hardware_cache_for_tests
+    # Same for the wired engine, used by /policy/refresh.
+    app.state.engine = engine
+
+    def _read_setup_section_for_http(repo_root: Path) -> dict[str, Any]:
+        from vaner.cli.commands.setup import _read_setup_section
+
+        return _read_setup_section(repo_root)
+
+    def _read_policy_section_for_http(repo_root: Path) -> dict[str, Any]:
+        from vaner.cli.commands.setup import _read_policy_section
+
+        return _read_policy_section(repo_root)
+
+    def _bundle_to_dict_http(bundle: Any) -> dict[str, Any]:
+        from vaner.cli.commands.setup import _bundle_to_dict
+
+        return _bundle_to_dict(bundle)
+
+    def _selection_to_dict_http(result: Any) -> dict[str, Any]:
+        from vaner.cli.commands.setup import _selection_to_dict
+
+        return _selection_to_dict(result)
+
+    def _hardware_to_dict_http(hw: Any) -> dict[str, Any]:
+        from vaner.cli.commands.setup import _hardware_to_dict
+
+        return _hardware_to_dict(hw)
+
+    def _answers_from_payload_http(raw: Any) -> Any:
+        # Mirror the CLI helper but raise HTTPException(400) on bad input
+        # — typer.BadParameter would 500 the request.
+        from vaner.setup.answers import SetupAnswers
+
+        if not isinstance(raw, dict):
+            raise HTTPException(status_code=400, detail="answers must be a JSON object")
+        work_styles = raw.get("work_styles") or ["mixed"]
+        if isinstance(work_styles, str):
+            work_styles = [work_styles]
+        if not isinstance(work_styles, list) or not all(isinstance(s, str) for s in work_styles):
+            raise HTTPException(status_code=400, detail="work_styles must be a list of strings")
+        try:
+            return SetupAnswers(
+                work_styles=tuple(work_styles),
+                priority=str(raw.get("priority", "balanced")),  # type: ignore[arg-type]
+                compute_posture=str(raw.get("compute_posture", "balanced")),  # type: ignore[arg-type]
+                cloud_posture=str(raw.get("cloud_posture", "ask_first")),  # type: ignore[arg-type]
+                background_posture=str(raw.get("background_posture", "normal")),  # type: ignore[arg-type]
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # The five Simple-Mode questions in the wire shape MCP + HTTP both
+    # consume. Kept as a constant so /setup/questions is a pure read.
+    _SETUP_QUESTIONS_PAYLOAD: dict[str, Any] = {
+        "version": 1,
+        "questions": [
+            {
+                "id": "work_styles",
+                "title": "What kind of work do you want help with?",
+                "kind": "multi",
+                "default": ["mixed"],
+                "choices": [
+                    {"value": "writing", "label": "Writing — drafting, editing, narrative"},
+                    {"value": "research", "label": "Research — surveys, deep reading, citations"},
+                    {"value": "planning", "label": "Planning — design docs, roadmaps, project layout"},
+                    {"value": "support", "label": "Support — answering questions, troubleshooting"},
+                    {"value": "learning", "label": "Learning — studying, exploring a new domain"},
+                    {"value": "coding", "label": "Coding — software development"},
+                    {"value": "general", "label": "General — knowledge work, mixed light tasks"},
+                    {"value": "mixed", "label": "Mixed — a bit of everything (safe default)"},
+                    {"value": "unsure", "label": "Unsure — I'd rather Vaner picks for me"},
+                ],
+            },
+            {
+                "id": "priority",
+                "title": "What matters most?",
+                "kind": "single",
+                "default": "balanced",
+                "choices": [
+                    {"value": "balanced", "label": "Balanced — a sensible middle"},
+                    {"value": "speed", "label": "Speed — snappy responses"},
+                    {"value": "quality", "label": "Quality — best answer, even if slow"},
+                    {"value": "privacy", "label": "Privacy — keep data on this machine"},
+                    {"value": "cost", "label": "Cost — minimise spend"},
+                    {"value": "low_resource", "label": "Low-resource — go easy on this machine"},
+                ],
+            },
+            {
+                "id": "compute_posture",
+                "title": "How hard should this machine work for you?",
+                "kind": "single",
+                "default": "balanced",
+                "choices": [
+                    {"value": "light", "label": "Light — barely use the CPU/GPU"},
+                    {"value": "balanced", "label": "Balanced — work with what's idle"},
+                    {"value": "available_power", "label": "Available-power — use what this box has"},
+                ],
+            },
+            {
+                "id": "cloud_posture",
+                "title": "How do you feel about cloud LLMs?",
+                "kind": "single",
+                "default": "ask_first",
+                "choices": [
+                    {"value": "local_only", "label": "Local only — never reach for cloud LLMs"},
+                    {"value": "ask_first", "label": "Ask first — confirm before any cloud call"},
+                    {
+                        "value": "hybrid_when_worth_it",
+                        "label": "Hybrid — cloud when it's clearly worth it",
+                    },
+                    {"value": "best_available", "label": "Best available — use the best model for the job"},
+                ],
+            },
+            {
+                "id": "background_posture",
+                "title": "How aggressive should background pondering be?",
+                "kind": "single",
+                "default": "normal",
+                "choices": [
+                    {"value": "minimal", "label": "Minimal — barely ponder when idle"},
+                    {"value": "normal", "label": "Normal — moderate background pondering"},
+                    {"value": "idle_more", "label": "Idle-more — ponder broadly when the box is idle"},
+                    {
+                        "value": "deep_run_aggressive",
+                        "label": "Deep-Run-aggressive — happy to run overnight",
+                    },
+                ],
+            },
+        ],
+    }
+
+    @app.get("/setup/questions")
+    async def setup_questions() -> JSONResponse:
+        """Return the static five-question Simple-Mode payload.
+
+        Contract-stable — desktop apps and MCP tools both consume this
+        shape. ``version`` lets clients gate against schema drift.
+        """
+
+        return JSONResponse(_SETUP_QUESTIONS_PAYLOAD)
+
+    @app.post("/setup/recommend")
+    async def setup_recommend(request: Request) -> JSONResponse:
+        """Run :func:`vaner.setup.select.select_policy_bundle` over a
+        :class:`SetupAnswers` body and return :class:`SelectionResult`.
+
+        Pure read — no persistence side effects. The hardware probe is
+        cached for the daemon process lifetime.
+        """
+
+        from vaner.setup.select import select_policy_bundle
+
+        try:
+            body = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="request body must be JSON") from exc
+        answers = _answers_from_payload_http(body)
+        hardware = _get_hardware_profile_cached()
+        selection = select_policy_bundle(answers, hardware)
+        return JSONResponse(_selection_to_dict_http(selection))
+
+    @app.post("/setup/apply")
+    async def setup_apply(request: Request) -> JSONResponse:
+        """Persist answers + selected bundle id to ``.vaner/config.toml``.
+
+        Body shape mirrors the WS7 MCP ``vaner.setup.apply`` tool::
+
+            {
+              "answers": {...SetupAnswers...} | null,
+              "bundle_id": "..." | null,
+              "confirm_cloud_widening": false,
+              "dry_run": false
+            }
+
+        WIDENS_CLOUD_POSTURE behaviour: if the new bundle's cloud
+        posture is strictly more permissive than the previous bundle's
+        posture, the response carries ``widens_cloud_posture=true`` and
+        ``written=false`` unless ``confirm_cloud_widening=true``.
+        """
+
+        from vaner.cli.commands.setup import (
+            _answers_from_payload,
+            _default_answers,
+            _persist_setup_and_policy,
+        )
+        from vaner.setup.apply import (
+            WIDENS_CLOUD_POSTURE_SENTINEL,
+            apply_policy_bundle,
+        )
+        from vaner.setup.catalog import bundle_by_id
+        from vaner.setup.select import select_policy_bundle
+
+        try:
+            body = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="request body must be JSON") from exc
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="request body must be a JSON object")
+
+        confirm_cloud_widening = bool(body.get("confirm_cloud_widening", False))
+        dry_run = bool(body.get("dry_run", False))
+        bundle_id_override = body.get("bundle_id")
+        raw_answers = body.get("answers")
+
+        repo_root = config.repo_root
+
+        # Resolve answers + bundle_id ----------------------------------
+        if bundle_id_override is not None:
+            if not isinstance(bundle_id_override, str) or not bundle_id_override.strip():
+                raise HTTPException(status_code=400, detail="bundle_id must be a non-empty string")
+            try:
+                bundle = bundle_by_id(bundle_id_override)
+            except KeyError as exc:
+                raise HTTPException(status_code=400, detail=f"unknown bundle id: {bundle_id_override!r}") from exc
+            if isinstance(raw_answers, dict):
+                answers = _answers_from_payload_http(raw_answers)
+            else:
+                existing = _read_setup_section_for_http(repo_root)
+                if existing:
+                    try:
+                        answers = _answers_from_payload(existing)
+                    except Exception:
+                        answers = _default_answers()
+                else:
+                    answers = _default_answers()
+            chosen_bundle_id = bundle.id
+            reasons: list[str] = ["explicit bundle_id override"]
+        else:
+            if isinstance(raw_answers, dict):
+                answers = _answers_from_payload_http(raw_answers)
+            else:
+                existing = _read_setup_section_for_http(repo_root)
+                if not existing:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            "no answers provided and no [setup] section on disk; supply 'answers' in the body or run `vaner setup wizard`"
+                        ),
+                    )
+                try:
+                    answers = _answers_from_payload(existing)
+                except Exception as exc:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"failed to parse persisted setup answers: {exc}",
+                    ) from exc
+            hardware = _get_hardware_profile_cached()
+            selection = select_policy_bundle(answers, hardware)
+            bundle = selection.bundle
+            chosen_bundle_id = bundle.id
+            reasons = list(selection.reasons)
+
+        # Cloud-widening guard via apply_policy_bundle's diff ----------
+        loaded = load_config(repo_root)
+        prior_policy_section = _read_policy_section_for_http(repo_root)
+        prior_bundle_id = prior_policy_section.get("selected_bundle_id")
+        if isinstance(prior_bundle_id, str) and prior_bundle_id:
+            loaded = loaded.model_copy(update={"policy": loaded.policy.model_copy(update={"selected_bundle_id": prior_bundle_id})})
+        applied = apply_policy_bundle(loaded, bundle)
+        widens = any(entry.startswith(WIDENS_CLOUD_POSTURE_SENTINEL) for entry in applied.overrides_applied)
+
+        applied_summary: dict[str, Any] = {
+            "bundle_id": applied.bundle_id,
+            "overrides_applied": list(applied.overrides_applied),
+        }
+
+        # Block writes when cloud posture would widen and the caller
+        # has not explicitly confirmed.
+        if widens and not confirm_cloud_widening:
+            return JSONResponse(
+                {
+                    "written": False,
+                    "dry_run": dry_run,
+                    "widens_cloud_posture": True,
+                    "selected_bundle_id": chosen_bundle_id,
+                    "reasons": reasons,
+                    "applied_policy": applied_summary,
+                    "bundle": _bundle_to_dict_http(bundle),
+                    "message": ("Cloud posture would widen. Re-send with confirm_cloud_widening=true to proceed."),
+                }
+            )
+
+        if dry_run:
+            return JSONResponse(
+                {
+                    "written": False,
+                    "dry_run": True,
+                    "widens_cloud_posture": widens,
+                    "selected_bundle_id": chosen_bundle_id,
+                    "reasons": reasons,
+                    "applied_policy": applied_summary,
+                    "bundle": _bundle_to_dict_http(bundle),
+                }
+            )
+
+        completed_at = datetime.now(UTC)
+        config_path = _persist_setup_and_policy(repo_root, answers, chosen_bundle_id, completed_at=completed_at)
+
+        return JSONResponse(
+            {
+                "written": True,
+                "dry_run": False,
+                "widens_cloud_posture": widens,
+                "selected_bundle_id": chosen_bundle_id,
+                "reasons": reasons,
+                "applied_policy": applied_summary,
+                "bundle": _bundle_to_dict_http(bundle),
+                "config_path": str(config_path),
+            }
+        )
+
+    @app.get("/setup/status")
+    async def setup_status() -> JSONResponse:
+        """Return the same payload shape as the MCP ``vaner.setup.status`` tool.
+
+        Carries: setup mode + answers, selected bundle id, applied
+        policy summary (with overrides), hardware profile.
+        """
+
+        from vaner.setup.apply import apply_policy_bundle
+        from vaner.setup.catalog import bundle_by_id
+
+        repo_root = config.repo_root
+        setup_section = _read_setup_section_for_http(repo_root)
+        policy_section = _read_policy_section_for_http(repo_root)
+        hardware = _get_hardware_profile_cached()
+
+        selected_bundle_id = policy_section.get("selected_bundle_id") or "hybrid_balanced"
+        applied_dict: dict[str, Any]
+        bundle_dict: dict[str, Any] | None = None
+        try:
+            bundle = bundle_by_id(str(selected_bundle_id))
+            bundle_dict = _bundle_to_dict_http(bundle)
+            loaded = load_config(repo_root)
+            loaded = loaded.model_copy(update={"policy": loaded.policy.model_copy(update={"selected_bundle_id": str(selected_bundle_id)})})
+            applied = apply_policy_bundle(loaded, bundle)
+            applied_dict = {
+                "bundle_id": applied.bundle_id,
+                "overrides_applied": list(applied.overrides_applied),
+            }
+        except KeyError:
+            applied_dict = {"error": f"unknown bundle id {selected_bundle_id!r}"}
+
+        mode = setup_section.get("mode") if isinstance(setup_section, dict) else None
+        completed_at = setup_section.get("completed_at") if isinstance(setup_section, dict) else None
+        completed = bool(setup_section) and completed_at is not None
+
+        return JSONResponse(
+            {
+                "repo_root": str(repo_root),
+                "mode": mode or "unconfigured",
+                "completed": completed,
+                "completed_at": completed_at,
+                "selected_bundle_id": str(selected_bundle_id),
+                "setup": setup_section,
+                "policy": policy_section,
+                "applied_policy": applied_dict,
+                "bundle": bundle_dict,
+                "hardware": _hardware_to_dict_http(hardware),
+            }
+        )
+
+    @app.get("/policy/current")
+    async def policy_current() -> JSONResponse:
+        """Return the materialised :class:`AppliedPolicy` plus its bundle.
+
+        Same payload shape as the WS7 MCP ``vaner.policy.show`` tool —
+        bundle, applied-policy summary (with ``overrides_applied`` and
+        the ``WIDENS_CLOUD_POSTURE`` sentinel passed through), the raw
+        ``[policy]`` section from disk, and the engine's wired status.
+        """
+
+        from vaner.setup.apply import apply_policy_bundle
+        from vaner.setup.catalog import bundle_by_id
+
+        repo_root = config.repo_root
+        policy_section = _read_policy_section_for_http(repo_root)
+        selected_bundle_id = policy_section.get("selected_bundle_id") or "hybrid_balanced"
+
+        try:
+            bundle = bundle_by_id(str(selected_bundle_id))
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"unknown bundle id {selected_bundle_id!r}",
+            ) from None
+
+        loaded = load_config(repo_root)
+        loaded = loaded.model_copy(update={"policy": loaded.policy.model_copy(update={"selected_bundle_id": str(selected_bundle_id)})})
+        applied = apply_policy_bundle(loaded, bundle)
+        applied_dict = {
+            "bundle_id": applied.bundle_id,
+            "overrides_applied": list(applied.overrides_applied),
+        }
+
+        return JSONResponse(
+            {
+                "selected_bundle_id": bundle.id,
+                "bundle": _bundle_to_dict_http(bundle),
+                "applied_policy": applied_dict,
+                "policy_section": policy_section,
+                "engine_wired": engine is not None,
+            }
+        )
+
+    @app.get("/hardware/profile")
+    async def hardware_profile_endpoint() -> JSONResponse:
+        """Return :class:`HardwareProfile` JSON, cached for daemon lifetime.
+
+        First call probes the system; subsequent calls return the
+        cached result. Restart the daemon (or hit the test-only reset
+        hook) to force a fresh probe.
+        """
+
+        hw = _get_hardware_profile_cached()
+        return JSONResponse(_hardware_to_dict_http(hw))
+
+    @app.post("/policy/refresh")
+    async def policy_refresh(request: Request) -> JSONResponse:
+        """Trigger ``engine._refresh_policy_bundle_state()`` on the live engine.
+
+        Used by ``vaner setup apply`` (WS6) to get a hot reload without
+        a daemon restart. Returns 503 when the engine is not wired or
+        the refresh hook is missing.
+        """
+
+        live_engine = app.state.engine
+        if live_engine is None:
+            return JSONResponse(
+                {
+                    "code": "engine_unavailable",
+                    "message": "daemon engine not wired; cannot refresh policy state",
+                },
+                status_code=503,
+            )
+        refresh_hook = getattr(live_engine, "_refresh_policy_bundle_state", None)
+        if refresh_hook is None or not callable(refresh_hook):
+            return JSONResponse(
+                {
+                    "code": "engine_unsupported",
+                    "message": "engine does not expose _refresh_policy_bundle_state",
+                },
+                status_code=503,
+            )
+        try:
+            refresh_hook()
+        except Exception as exc:
+            return JSONResponse(
+                {
+                    "code": "refresh_failed",
+                    "message": f"{type(exc).__name__}: {exc}",
+                },
+                status_code=503,
+            )
+
+        applied = getattr(live_engine, "_applied_policy", None)
+        applied_summary: dict[str, Any] | None = None
+        if applied is not None:
+            applied_summary = {
+                "bundle_id": applied.bundle_id,
+                "overrides_applied": list(applied.overrides_applied),
+            }
+
+        return JSONResponse(
+            {
+                "refreshed": True,
+                "applied_policy_summary": applied_summary,
+            }
+        )
 
     @app.get("/compute/devices")
     async def compute_devices() -> JSONResponse:

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -82,6 +82,15 @@ from vaner.intent.timing import ActivityTimingModel
 from vaner.intent.trainer import IntentTrainer
 from vaner.intent.transfer import bootstrap_transfer_priors
 from vaner.intent.volatility import semantic_volatility_profile
+from vaner.intent.work_style_priors import (
+    IntentPriorAdjustments,
+)
+from vaner.intent.work_style_priors import (
+    adjustments_for as work_style_adjustments_for,
+)
+from vaner.intent.work_style_priors import (
+    default_adjustments as default_work_style_adjustments,
+)
 from vaner.learning.counterfactual import CounterfactualAnalyzer
 from vaner.learning.reward import RewardInput, compute_reward
 from vaner.models.artefact import Artefact, ArtefactKind
@@ -263,6 +272,14 @@ class VanerEngine:
         # later via ``set_briefing_tokenizer`` once the structured LLM client
         # exposes one.
         self._briefing_assembler = BriefingAssembler()
+        # 0.8.6 WS4 — work-style intent priors. Cached per cycle so the
+        # frontier / drafter / briefing assembler all see the same
+        # composed multipliers. Defaults to the ``mixed`` identity so
+        # configs without a populated ``[setup]`` section produce
+        # byte-identical behaviour to pre-WS4. Refreshed at the top of
+        # ``precompute_cycle`` via :meth:`_refresh_work_style_adjustments`.
+        self._cycle_work_style_adjustments: IntentPriorAdjustments = default_work_style_adjustments()
+        self._refresh_work_style_adjustments()
         # WS10: single drafting module. Owns the rewrite + draft LLM
         # templates and the gate arithmetic so arc / pattern / history /
         # future goal-sourced (WS7) predictions all drive through the same
@@ -345,6 +362,23 @@ class VanerEngine:
             "invest_ratio": 0.10,
             "no_regret_ratio": 0.20,
         }
+
+    def _refresh_work_style_adjustments(self) -> None:
+        """Recompute per-cycle work-style adjustments from config.
+
+        0.8.6 WS4. Reads ``config.setup.work_styles`` and caches the
+        averaged :class:`IntentPriorAdjustments` for the cycle. Called
+        from ``__init__`` and again at the top of each ``precompute_cycle``
+        so a hot config edit takes effect on the next cycle without a
+        daemon restart. Default ``["mixed"]`` yields the identity element
+        — the engine produces byte-identical behaviour to pre-WS4.
+        """
+
+        styles = tuple(getattr(self.config.setup, "work_styles", ()) or ())
+        self._cycle_work_style_adjustments = work_style_adjustments_for(styles)
+        # Forward hook for the briefing assembler's artefact-template
+        # tie-break. Empty tuple under the ``mixed`` default → no-op.
+        self._briefing_assembler.set_preferred_templates(self._cycle_work_style_adjustments.preferred_artefact_templates)
 
     async def initialize(self) -> None:
         await self.store.initialize()
@@ -1011,6 +1045,10 @@ class VanerEngine:
         """
         cycle_started = time.monotonic()
         await self.initialize()
+        # 0.8.6 WS4 — refresh work-style adjustments from current config
+        # so a hot edit to ``setup.work_styles`` takes effect on the next
+        # cycle. No-op for the default ``["mixed"]``.
+        self._refresh_work_style_adjustments()
         compute = self.config.compute
         # Keep the binary idle-only gate as an escape hatch: if the load is
         # genuinely saturating, skip the cycle entirely. Between idle and
@@ -1268,7 +1306,12 @@ class VanerEngine:
                         aligned_paths.update(str(p) for p in paths if p)
                 except Exception:
                     continue
-        frontier.set_artefact_aligned_paths(aligned_paths)
+        # 0.8.6 WS4 — compose the default 1.10x artefact-alignment boost with
+        # the work-style multiplier (mixed → 1.0 → no-op). The frontier clamps
+        # to >= 1.0 internally; we still pass a positive value so the contract
+        # holds without WS4 inspecting frontier internals.
+        _ws_boost = 1.10 * self._cycle_work_style_adjustments.artefact_alignment_weight_multiplier
+        frontier.set_artefact_aligned_paths(aligned_paths, boost=_ws_boost)
 
         # Order matters: Jaccard-dedup is first-admitted-wins, and
         # seed_from_workflow_phase produces arc-sourced scenarios whose file
@@ -3206,13 +3249,26 @@ class VanerEngine:
             draft_budget_min_s = float(self._cycle_policy_state.get("draft_budget_min_ms", 2000.0)) / 1000.0
             has_budget = deadline is None or (deadline - time.monotonic()) >= draft_budget_min_s
             # WS10: gates consolidated into the Drafter.
+            # 0.8.6 WS4 — fold work-style intent priors into the gates so a
+            # "coding"/"planning" style demands stronger evidence and a
+            # tighter volatility ceiling, while "writing"/"learning" relax
+            # the bar. ``mixed`` (default) leaves both knobs unchanged.
+            _ws_adj = self._cycle_work_style_adjustments
+            _ws_gates = dict(self._cycle_policy_state)
+            _ws_gates["draft_evidence_threshold"] = max(
+                float(_ws_gates.get("draft_evidence_threshold", 0.45)),
+                _ws_adj.drafting_evidence_floor,
+            )
+            _ws_gates["draft_volatility_ceiling"] = (
+                float(_ws_gates.get("draft_volatility_ceiling", 0.40)) * _ws_adj.drafting_volatility_ceiling_multiplier
+            )
             if not self._drafter.passes_gates(
                 posterior_confidence=posterior_confidence,
                 evidence_quality=evidence_quality,
                 evidence_volatility=evidence_volatility,
                 prior_draft_usefulness=prior_draft_usefulness,
                 has_budget=has_budget,
-                gates=self._cycle_policy_state,
+                gates=_ws_gates,
             ):
                 continue
 

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -98,6 +98,8 @@ from vaner.models.config import ComputeConfig, ExplorationConfig, VanerConfig
 from vaner.models.context import ContextPackage
 from vaner.models.decision import DecisionRecord, PredictionLink, ScoreFactor
 from vaner.models.signal import SignalEvent
+from vaner.setup.apply import AppliedPolicy, apply_policy_bundle
+from vaner.setup.catalog import bundle_by_id
 from vaner.store import deep_run as deep_run_store
 from vaner.store.artefacts import ArtefactStore
 from vaner.store.profile_store import UserProfileStore
@@ -280,6 +282,16 @@ class VanerEngine:
         # ``precompute_cycle`` via :meth:`_refresh_work_style_adjustments`.
         self._cycle_work_style_adjustments: IntentPriorAdjustments = default_work_style_adjustments()
         self._refresh_work_style_adjustments()
+        # 0.8.6 WS5 — applied policy bundle. Materialises the selected
+        # bundle's defaults onto a *snapshot* of the current config and
+        # caches the result on the engine so downstream surfaces can
+        # read bundle-derived knobs (and the audit list) without
+        # re-running the apply step. ``hybrid_balanced`` (the default)
+        # is engineered to be a no-op against a freshly defaulted
+        # config — hence pre-WS5 behaviour is preserved when the user
+        # has not run the wizard.
+        self._applied_policy: AppliedPolicy | None = None
+        self._refresh_policy_bundle_state()
         # WS10: single drafting module. Owns the rewrite + draft LLM
         # templates and the gate arithmetic so arc / pattern / history /
         # future goal-sourced (WS7) predictions all drive through the same
@@ -379,6 +391,51 @@ class VanerEngine:
         # Forward hook for the briefing assembler's artefact-template
         # tie-break. Empty tuple under the ``mixed`` default → no-op.
         self._briefing_assembler.set_preferred_templates(self._cycle_work_style_adjustments.preferred_artefact_templates)
+        # 0.8.6 WS5 — keep the policy-bundle materialisation in lock-
+        # step with the work-style refresh. Both are config-derived
+        # state that depends only on ``config.setup`` / ``config.policy``
+        # and must be coherent for one cycle. Calling here means a hot
+        # config edit (CLI ``vaner setup apply``) is picked up on the
+        # next ``precompute_cycle`` without a daemon restart.
+        self._refresh_policy_bundle_state()
+
+    def _refresh_policy_bundle_state(self) -> None:
+        """Materialise the selected policy bundle onto config-derived knobs.
+
+        0.8.6 WS5. Reads :attr:`config.policy.selected_bundle_id`,
+        looks up the matching :class:`VanerPolicyBundle` from
+        :data:`vaner.setup.catalog.PROFILE_CATALOG`, and stores the
+        resulting :class:`AppliedPolicy` on ``self._applied_policy``.
+
+        Engine code that needs bundle-derived knobs reads from
+        ``self._applied_policy.config`` (or the ``overrides_applied``
+        list for transparency surfaces). The engine's *primary*
+        :attr:`config` is left untouched — apply is a non-destructive
+        snapshot — so a subsequent hot edit doesn't have to undo
+        anything.
+
+        Defensive: an unknown bundle id (corrupted config / future
+        bundle from a newer install) is logged and the engine falls
+        back to no applied policy. The default
+        ``selected_bundle_id="hybrid_balanced"`` always exists.
+        """
+
+        bundle_id = self.config.policy.selected_bundle_id
+        try:
+            bundle = bundle_by_id(bundle_id)
+        except KeyError:
+            logger.warning(
+                "Unknown policy.selected_bundle_id=%r; running without applied bundle defaults",
+                bundle_id,
+            )
+            self._applied_policy = None
+            return
+        user_overrides = self.config.policy.bundle_overrides or None
+        self._applied_policy = apply_policy_bundle(
+            self.config,
+            bundle,
+            user_overrides=user_overrides,
+        )
 
     async def initialize(self) -> None:
         await self.store.initialize()

--- a/src/vaner/intent/briefing.py
+++ b/src/vaner/intent/briefing.py
@@ -96,6 +96,32 @@ class BriefingAssembler:
 
     def __init__(self, tokenizer: Callable[[str], int] | None = None) -> None:
         self._tokenizer = tokenizer
+        # 0.8.6 WS4 — preferred artefact-template ids derived from the
+        # active work-style mix. Updated each cycle by the engine via
+        # :meth:`set_preferred_templates`. The assembler ranks registered
+        # templates by this preference when an artefact-template registry
+        # is consulted (forward hook — no-op until the registry lands in
+        # a later WS). Empty tuple is the neutral default.
+        self._preferred_artefact_templates: tuple[str, ...] = ()
+
+    def set_preferred_templates(self, template_ids: tuple[str, ...]) -> None:
+        """Set the preferred artefact-template ids for tie-breaking.
+
+        0.8.6 WS4. Called once per engine cycle with the work-style
+        mix's preferred templates (e.g. ``("decision_memo", "risk_list")``
+        for planning). When the briefing assembler consults an artefact-
+        template registry it should prefer ids in this tuple. Templates
+        that aren't registered are silently ignored — the assembler falls
+        back to its existing template selection.
+        """
+
+        self._preferred_artefact_templates = tuple(template_ids)
+
+    @property
+    def preferred_artefact_templates(self) -> tuple[str, ...]:
+        """The preferred artefact-template ids (0.8.6 WS4 forward hook)."""
+
+        return self._preferred_artefact_templates
 
     def _count_tokens(self, text: str) -> int:
         if not text:

--- a/src/vaner/intent/work_style_priors.py
+++ b/src/vaner/intent/work_style_priors.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS4 — Work-style intent priors (0.8.6).
+
+Maps each :data:`vaner.setup.enums.WorkStyle` Literal value to a small
+bundle of multiplicative nudges that the engine composes with its base
+scoring / drafting knobs. The table lives here as immutable data: no
+side effects, no lazy loading. Engine code calls
+:func:`adjustments_for` once per cycle (or whenever
+``config.setup.work_styles`` changes) and threads the result into the
+existing call sites that already accept multipliers from
+:class:`vaner.intent.deep_run_policy.DeepRunPresetSpec` and
+:class:`vaner.intent.deep_run_policy.HorizonBiasSpec`.
+
+Design notes
+------------
+
+- **Multiplicative + averaged.** Multipliers compose multiplicatively
+  with preset/horizon multipliers (matches the convention in
+  :mod:`vaner.intent.deep_run_policy`). When the user picks more than
+  one work style, the multipliers are averaged arithmetically — explicit
+  and predictable per the 0.8.6 plan, rather than geometrically.
+- **"mixed" is the identity.** Every multiplier is 1.0, the drafting
+  floor is 0.0, and the preferred-template tuple is empty. Engines
+  running on default ``setup.work_styles == ["mixed"]`` configs see
+  byte-identical behaviour to pre-WS4.
+- **Conservative ranges.** Multipliers stay inside ``[0.7, 1.5]`` and
+  the drafting floor inside ``[0.0, 0.6]``. The point is a small,
+  explainable lookup — not a tuning monster. WS6+ benches can iterate
+  on the numbers; the structure is fixed by spec §7.
+- **Templates are a forward hook.** ``preferred_artefact_templates``
+  is consumed by the briefing assembler when an artefact-template
+  registry exists. If the named templates are not registered (current
+  state — the registry lands in a later WS), the engine silently
+  falls back to its existing template selection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final, get_args
+
+from vaner.setup.enums import WorkStyle
+
+
+@dataclass(frozen=True, slots=True)
+class IntentPriorAdjustments:
+    """Multipliers/floors that nudge engine knobs toward a work style.
+
+    All multiplier values are multiplicative on top of the engine's base
+    value (:class:`DeepRunPresetSpec` already uses this convention; we
+    compose with it the same way). The drafting evidence floor is a
+    lower bound — the drafter takes ``max(threshold, floor)`` so a
+    work style that demands stronger evidence can only raise the bar,
+    never lower it.
+
+    ``preferred_artefact_templates`` is a tuple of template ids the
+    briefing assembler should prefer when ranking ties between
+    otherwise-equivalent artefact templates. Templates that aren't
+    registered are ignored silently.
+    """
+
+    artefact_alignment_weight_multiplier: float
+    long_horizon_bonus_multiplier: float
+    possible_branch_bonus_multiplier: float
+    drafting_evidence_floor: float
+    drafting_volatility_ceiling_multiplier: float
+    preferred_artefact_templates: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# The work-style table (spec §7). Immutable; values are the single source
+# of truth for "what does each work style nudge."
+# ---------------------------------------------------------------------------
+
+
+WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
+    "writing": IntentPriorAdjustments(
+        # Writing rewards continuity; let drafts ride on thinner evidence
+        # but boost long-horizon (next-scene / next-chapter) hypotheses.
+        artefact_alignment_weight_multiplier=1.2,
+        long_horizon_bonus_multiplier=1.3,
+        possible_branch_bonus_multiplier=1.0,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.2,
+        preferred_artefact_templates=("next_scene_draft", "outline_continuation"),
+    ),
+    "research": IntentPriorAdjustments(
+        # Research wants broad branch coverage; weight possible-branch
+        # exploration higher, demand stronger artefact alignment, and
+        # keep drafting bar near baseline.
+        artefact_alignment_weight_multiplier=1.4,
+        long_horizon_bonus_multiplier=1.2,
+        possible_branch_bonus_multiplier=1.4,
+        drafting_evidence_floor=0.45,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=("research_brief", "lit_review"),
+    ),
+    "planning": IntentPriorAdjustments(
+        # Planning is artefact-anchored (decision memos, risk lists);
+        # boost alignment hard, keep horizon balanced, demand decent
+        # evidence so plans aren't wishy-washy.
+        artefact_alignment_weight_multiplier=1.5,
+        long_horizon_bonus_multiplier=1.2,
+        possible_branch_bonus_multiplier=1.1,
+        drafting_evidence_floor=0.50,
+        drafting_volatility_ceiling_multiplier=0.9,
+        preferred_artefact_templates=("decision_memo", "risk_list"),
+    ),
+    "support": IntentPriorAdjustments(
+        # Support work wants to finish what's in flight (short horizon,
+        # low branching); demand strong evidence so answers don't mislead.
+        artefact_alignment_weight_multiplier=1.1,
+        long_horizon_bonus_multiplier=0.8,
+        possible_branch_bonus_multiplier=0.8,
+        drafting_evidence_floor=0.55,
+        drafting_volatility_ceiling_multiplier=0.8,
+        preferred_artefact_templates=("ticket_reply", "troubleshooting_brief"),
+    ),
+    "learning": IntentPriorAdjustments(
+        # Learning rewards exposure to adjacent concepts (high possible-
+        # branch); drafting bar stays gentle so partials still surface.
+        artefact_alignment_weight_multiplier=1.0,
+        long_horizon_bonus_multiplier=1.1,
+        possible_branch_bonus_multiplier=1.5,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.3,
+        preferred_artefact_templates=("study_outline", "concept_brief"),
+    ),
+    "coding": IntentPriorAdjustments(
+        # Coding wants clean patches: high evidence floor, tight volatility
+        # ceiling, modest long-horizon (debugging is short-loop).
+        artefact_alignment_weight_multiplier=1.3,
+        long_horizon_bonus_multiplier=0.9,
+        possible_branch_bonus_multiplier=1.1,
+        drafting_evidence_floor=0.55,
+        drafting_volatility_ceiling_multiplier=0.8,
+        preferred_artefact_templates=("debugging_brief", "patch_proposal"),
+    ),
+    "general": IntentPriorAdjustments(
+        # General-purpose: very gentle nudges, no template preference.
+        artefact_alignment_weight_multiplier=1.1,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.1,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=(),
+    ),
+    "mixed": IntentPriorAdjustments(
+        # Identity element. ``setup.work_styles == ["mixed"]`` is the
+        # default for fresh installs; it MUST be a strict no-op so the
+        # engine produces byte-identical behaviour to pre-WS4.
+        artefact_alignment_weight_multiplier=1.0,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.0,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=(),
+    ),
+    "unsure": IntentPriorAdjustments(
+        # Same identity as ``mixed`` — the user opted out of telling us;
+        # we should not gamble on a guess. Functionally equivalent today;
+        # split out so future surfaces can show "unsure" as a distinct
+        # affordance without breaking the table key invariant.
+        artefact_alignment_weight_multiplier=1.0,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.0,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=(),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Lookups + helpers
+# ---------------------------------------------------------------------------
+
+
+def default_adjustments() -> IntentPriorAdjustments:
+    """Return the identity-element adjustments (``mixed``).
+
+    Used when ``setup.work_styles`` is empty or contains only the
+    ``"mixed"`` sentinel. Every multiplier is 1.0, the drafting floor
+    is 0.0, and the preferred-template tuple is empty — composing
+    these with any base value yields the base value unchanged.
+    """
+
+    return WORK_STYLE_PRIORS["mixed"]
+
+
+def adjustments_for(work_styles: Sequence[WorkStyle]) -> IntentPriorAdjustments:
+    """Average the per-style adjustments across a multi-select input.
+
+    Empty input falls back to :func:`default_adjustments` (the
+    ``"mixed"`` identity element). When more than one style is
+    selected, the float multipliers are averaged arithmetically;
+    template tuples are unioned (deduplicated, sorted) so the result
+    is deterministic regardless of input order.
+
+    Unknown style names raise :class:`KeyError` — that would be a
+    schema-migration bug, not a runtime concern.
+    """
+
+    if not work_styles:
+        return default_adjustments()
+
+    specs = [WORK_STYLE_PRIORS[style] for style in work_styles]
+    n = len(specs)
+
+    templates: set[str] = set()
+    for spec in specs:
+        templates.update(spec.preferred_artefact_templates)
+
+    return IntentPriorAdjustments(
+        artefact_alignment_weight_multiplier=sum(s.artefact_alignment_weight_multiplier for s in specs) / n,
+        long_horizon_bonus_multiplier=sum(s.long_horizon_bonus_multiplier for s in specs) / n,
+        possible_branch_bonus_multiplier=sum(s.possible_branch_bonus_multiplier for s in specs) / n,
+        drafting_evidence_floor=sum(s.drafting_evidence_floor for s in specs) / n,
+        drafting_volatility_ceiling_multiplier=sum(s.drafting_volatility_ceiling_multiplier for s in specs) / n,
+        preferred_artefact_templates=tuple(sorted(templates)),
+    )
+
+
+def compose_with_deep_run_preset(
+    work_style: IntentPriorAdjustments,
+    *,
+    base_artefact_alignment: float,
+    base_long_horizon: float,
+    base_possible_branch: float,
+) -> tuple[float, float, float]:
+    """Multiply work-style multipliers onto base scoring weights.
+
+    The composition is multiplicative — the same convention used by
+    :class:`vaner.intent.deep_run_policy.HorizonBiasSpec` so that
+    work-style + Deep-Run preset + horizon bias compose associatively
+    at the call site (any order yields the same product).
+
+    Returns the three adjusted scoring weights as a tuple in the same
+    order as the parameters: artefact-alignment, long-horizon,
+    possible-branch.
+    """
+
+    return (
+        base_artefact_alignment * work_style.artefact_alignment_weight_multiplier,
+        base_long_horizon * work_style.long_horizon_bonus_multiplier,
+        base_possible_branch * work_style.possible_branch_bonus_multiplier,
+    )
+
+
+# Self-check: every WorkStyle Literal value must have an entry in
+# WORK_STYLE_PRIORS. We also expose the literal's args for the test
+# module to consume without re-importing typing internals.
+_WORK_STYLE_VALUES: Final[tuple[WorkStyle, ...]] = get_args(WorkStyle)
+assert set(_WORK_STYLE_VALUES) == set(WORK_STYLE_PRIORS.keys()), (
+    "WORK_STYLE_PRIORS must cover every value in the WorkStyle Literal "
+    f"(missing: {set(_WORK_STYLE_VALUES) - set(WORK_STYLE_PRIORS.keys())}, "
+    f"extra: {set(WORK_STYLE_PRIORS.keys()) - set(_WORK_STYLE_VALUES)})"
+)
+
+
+__all__ = [
+    "WORK_STYLE_PRIORS",
+    "IntentPriorAdjustments",
+    "adjustments_for",
+    "compose_with_deep_run_preset",
+    "default_adjustments",
+]

--- a/src/vaner/mcp/apps/active_predictions.html
+++ b/src/vaner/mcp/apps/active_predictions.html
@@ -176,9 +176,15 @@
         opacity: 0.5;
         cursor: not-allowed;
       }
-      button.adopt:focus {
+      button.adopt:focus-visible {
         outline: 2px solid var(--accent);
         outline-offset: 2px;
+      }
+      button.adopt:focus:not(:focus-visible) {
+        /* Mouse-induced focus shouldn't paint an outline (a11y carry-over
+           from 0.8.5 — keyboard users get the visible ring via the
+           :focus-visible rule above). */
+        outline: none;
       }
       .empty {
         text-align: center;
@@ -193,9 +199,13 @@
     </style>
   </head>
   <body>
-    <main aria-live="polite">
+    <main>
       <h1 id="heading">Vaner — Prepared predictions</h1>
-      <div id="status" role="status"></div>
+      <!-- aria-live + role=status on the dedicated status region (a11y
+           carry-over fix from 0.8.5 — was previously on <main>, which
+           caused screen readers to re-announce the entire heading + list
+           on every status update). -->
+      <div id="status" role="status" aria-live="polite" aria-label="Status"></div>
       <ol id="cards" class="card-list" aria-labelledby="heading"></ol>
     </main>
     <script type="module">

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -109,6 +109,335 @@ def _ensure_backend(config: Any) -> bool:
     return bool(base_url and model)
 
 
+# ---------------------------------------------------------------------------
+# 0.8.6 WS7 — Setup-surface helpers.
+#
+# These keep the MCP setup tools light: no typer / Rich. The shared JSON
+# shapes come from :mod:`vaner.setup.serializers` so the CLI surface
+# (WS6) and the MCP surface (WS7) emit byte-identical contracts.
+# ---------------------------------------------------------------------------
+
+
+def _setup_question_schema() -> list[dict[str, Any]]:
+    """Static ordered schema for the five Simple-Mode questions.
+
+    Mirrors the choice tables in :mod:`vaner.cli.commands.setup`. Static
+    data — no engine state — so cockpit / desktop UIs can render the
+    same prompts without hardcoding strings.
+    """
+
+    return [
+        {
+            "id": "work_styles",
+            "prompt": "What kind of work do you want help with?",
+            "kind": "multi",
+            "default": ["mixed"],
+            "options": [
+                {"value": "writing", "label": "Writing — drafting, editing, narrative"},
+                {"value": "research", "label": "Research — surveys, deep reading, citations"},
+                {"value": "planning", "label": "Planning — design docs, roadmaps, project layout"},
+                {"value": "support", "label": "Support — answering questions, troubleshooting"},
+                {"value": "learning", "label": "Learning — studying, exploring a new domain"},
+                {"value": "coding", "label": "Coding — software development"},
+                {"value": "general", "label": "General — knowledge work, mixed light tasks"},
+                {"value": "mixed", "label": "Mixed — a bit of everything (safe default)"},
+                {"value": "unsure", "label": "Unsure — I'd rather Vaner picks for me"},
+            ],
+        },
+        {
+            "id": "priority",
+            "prompt": "What matters most?",
+            "kind": "single",
+            "default": "balanced",
+            "options": [
+                {"value": "balanced", "label": "Balanced — a sensible middle"},
+                {"value": "speed", "label": "Speed — snappy responses"},
+                {"value": "quality", "label": "Quality — best answer, even if slow"},
+                {"value": "privacy", "label": "Privacy — keep data on this machine"},
+                {"value": "cost", "label": "Cost — minimise spend"},
+                {"value": "low_resource", "label": "Low-resource — go easy on this machine"},
+            ],
+        },
+        {
+            "id": "compute_posture",
+            "prompt": "How hard should this machine work for you?",
+            "kind": "single",
+            "default": "balanced",
+            "options": [
+                {"value": "light", "label": "Light — barely use the CPU/GPU"},
+                {"value": "balanced", "label": "Balanced — work with what's idle"},
+                {"value": "available_power", "label": "Available-power — use what this box has"},
+            ],
+        },
+        {
+            "id": "cloud_posture",
+            "prompt": "How do you feel about cloud LLMs?",
+            "kind": "single",
+            "default": "ask_first",
+            "options": [
+                {"value": "local_only", "label": "Local only — never reach for cloud LLMs"},
+                {"value": "ask_first", "label": "Ask first — confirm before any cloud call"},
+                {"value": "hybrid_when_worth_it", "label": "Hybrid — cloud when it's clearly worth it"},
+                {"value": "best_available", "label": "Best available — use the best model for the job"},
+            ],
+        },
+        {
+            "id": "background_posture",
+            "prompt": "How aggressive should background pondering be?",
+            "kind": "single",
+            "default": "normal",
+            "options": [
+                {"value": "minimal", "label": "Minimal — barely ponder when idle"},
+                {"value": "normal", "label": "Normal — moderate background pondering"},
+                {"value": "idle_more", "label": "Idle-more — ponder broadly when the box is idle"},
+                {"value": "deep_run_aggressive", "label": "Deep-Run-aggressive — happy to run overnight"},
+            ],
+        },
+    ]
+
+
+def _setup_apply_handler(repo_root: Path, args: dict[str, Any]) -> CallToolResult:
+    """Dispatch for ``vaner.setup.apply``.
+
+    Resolves ``answers`` or ``bundle_id`` into the chosen bundle, runs
+    :func:`apply_policy_bundle` to get the override list (incl. the
+    cloud-widening sentinel), and persists the result unless
+    ``dry_run`` is set or ``confirm_cloud_widening`` is missing while
+    the change widens cloud posture.
+    """
+
+    from datetime import UTC, datetime
+
+    from vaner.cli.commands.config import load_config as _load_config
+    from vaner.cli.commands.setup import (
+        _persist_setup_and_policy,
+        _read_policy_section,
+        _read_setup_section,
+    )
+    from vaner.setup.apply import (
+        WIDENS_CLOUD_POSTURE_SENTINEL,
+        apply_policy_bundle,
+    )
+    from vaner.setup.catalog import bundle_by_id
+    from vaner.setup.hardware import detect as _hw_detect
+    from vaner.setup.select import select_policy_bundle as _select_bundle
+    from vaner.setup.serializers import (
+        AnswersValidationError,
+        answers_from_payload,
+    )
+
+    bundle_id_arg = args.get("bundle_id")
+    answers_arg = args.get("answers")
+    confirm_cloud_widening = bool(args.get("confirm_cloud_widening", False))
+    dry_run = bool(args.get("dry_run", False))
+
+    # ------------------------------------------------------------------
+    # 1. Resolve answers + bundle.
+    # ------------------------------------------------------------------
+    chosen_bundle_id: str
+    answers: Any
+    if isinstance(bundle_id_arg, str) and bundle_id_arg:
+        try:
+            bundle = bundle_by_id(bundle_id_arg)
+        except KeyError:
+            return _json_result(
+                {"code": "unknown_bundle_id", "message": f"unknown bundle id: {bundle_id_arg!r}"},
+                is_error=True,
+            )
+        chosen_bundle_id = bundle.id
+        existing_setup = _read_setup_section(repo_root)
+        if existing_setup:
+            try:
+                answers = answers_from_payload(existing_setup)
+            except AnswersValidationError:
+                from vaner.setup.answers import SetupAnswers
+
+                answers = SetupAnswers(
+                    work_styles=("mixed",),
+                    priority="balanced",
+                    compute_posture="balanced",
+                    cloud_posture="ask_first",
+                    background_posture="normal",
+                )
+        else:
+            from vaner.setup.answers import SetupAnswers
+
+            answers = SetupAnswers(
+                work_styles=("mixed",),
+                priority="balanced",
+                compute_posture="balanced",
+                cloud_posture="ask_first",
+                background_posture="normal",
+            )
+    else:
+        if answers_arg is None:
+            return _json_result(
+                {
+                    "code": "invalid_input",
+                    "message": "either `answers` or `bundle_id` must be provided",
+                },
+                is_error=True,
+            )
+        try:
+            answers = answers_from_payload(answers_arg)
+        except AnswersValidationError as exc:
+            return _json_result(
+                {"code": "invalid_input", "message": str(exc)},
+                is_error=True,
+            )
+        try:
+            hardware = _hw_detect()
+            selection = _select_bundle(answers, hardware)
+        except Exception as exc:
+            return _json_result(
+                {"code": "recommend_failed", "message": str(exc)},
+                is_error=True,
+            )
+        chosen_bundle_id = selection.bundle.id
+        bundle = selection.bundle
+
+    # ------------------------------------------------------------------
+    # 2. Compute overrides + cloud-widening flag.
+    # ------------------------------------------------------------------
+    config = _load_config(repo_root)
+    prior_policy_section = _read_policy_section(repo_root)
+    prior_bundle_id = prior_policy_section.get("selected_bundle_id")
+    if isinstance(prior_bundle_id, str) and prior_bundle_id:
+        config = config.model_copy(update={"policy": config.policy.model_copy(update={"selected_bundle_id": prior_bundle_id})})
+    applied = apply_policy_bundle(config, bundle)
+    overrides_applied = list(applied.overrides_applied)
+    widens_cloud_posture = any(line.startswith(WIDENS_CLOUD_POSTURE_SENTINEL) for line in overrides_applied)
+
+    # ------------------------------------------------------------------
+    # 3. Decide whether to write.
+    # ------------------------------------------------------------------
+    written = False
+    block_reason: str | None = None
+    if dry_run:
+        block_reason = "dry_run=True; config not written"
+    elif widens_cloud_posture and not confirm_cloud_widening:
+        block_reason = "WIDENS_CLOUD_POSTURE: refusing to widen cloud posture without confirm_cloud_widening=True"
+    else:
+        try:
+            _persist_setup_and_policy(
+                repo_root,
+                answers,
+                chosen_bundle_id,
+                completed_at=datetime.now(UTC),
+            )
+            written = True
+        except Exception as exc:
+            return _json_result(
+                {"code": "persist_failed", "message": str(exc)},
+                is_error=True,
+            )
+
+    return _json_result(
+        {
+            "bundle_id": chosen_bundle_id,
+            "overrides_applied": overrides_applied,
+            "widens_cloud_posture": widens_cloud_posture,
+            "written": written,
+            "block_reason": block_reason,
+        }
+    )
+
+
+def _setup_status_handler(repo_root: Path) -> CallToolResult:
+    """Dispatch for ``vaner.setup.status``.
+
+    Read-only snapshot of the current ``[setup]`` / ``[policy]`` state
+    plus a fresh hardware probe and the materialised :class:`AppliedPolicy`.
+    """
+
+    from vaner.cli.commands.config import load_config as _load_config
+    from vaner.cli.commands.setup import (
+        _read_policy_section,
+        _read_setup_section,
+    )
+    from vaner.setup.apply import apply_policy_bundle
+    from vaner.setup.catalog import bundle_by_id
+    from vaner.setup.hardware import detect as _hw_detect
+    from vaner.setup.serializers import hardware_to_dict
+
+    setup_section = _read_setup_section(repo_root)
+    policy_section = _read_policy_section(repo_root)
+    hardware = _hw_detect()
+
+    mode = setup_section.get("mode") if isinstance(setup_section, dict) else None
+    if mode not in ("simple", "advanced"):
+        mode = "simple"
+    selected_bundle_id = policy_section.get("selected_bundle_id") or "hybrid_balanced"
+    completed_at = setup_section.get("completed_at")
+
+    applied_payload: dict[str, Any] | None = None
+    try:
+        bundle = bundle_by_id(str(selected_bundle_id))
+        config = _load_config(repo_root)
+        # Pin prior bundle to current so the cloud-widening guard does
+        # not double-fire when status is re-rendered.
+        config = config.model_copy(update={"policy": config.policy.model_copy(update={"selected_bundle_id": str(selected_bundle_id)})})
+        applied = apply_policy_bundle(config, bundle)
+        applied_payload = {
+            "bundle_id": applied.bundle_id,
+            "overrides_applied": list(applied.overrides_applied),
+        }
+    except KeyError:
+        applied_payload = {
+            "bundle_id": str(selected_bundle_id),
+            "overrides_applied": [],
+            "error": f"unknown bundle id {selected_bundle_id!r}",
+        }
+
+    return _json_result(
+        {
+            "mode": mode,
+            "selected_bundle_id": str(selected_bundle_id),
+            "completed_at": str(completed_at) if completed_at is not None else None,
+            "applied_policy": applied_payload,
+            "hardware": hardware_to_dict(hardware),
+        }
+    )
+
+
+def _policy_show_handler(repo_root: Path) -> CallToolResult:
+    """Dispatch for ``vaner.policy.show``.
+
+    Returns the full :class:`VanerPolicyBundle` JSON for the currently
+    selected bundle plus the verbatim ``overrides_applied`` list. Drives
+    the desktop transparency disclosure panel.
+    """
+
+    from vaner.cli.commands.config import load_config as _load_config
+    from vaner.cli.commands.setup import _read_policy_section
+    from vaner.setup.apply import apply_policy_bundle
+    from vaner.setup.catalog import bundle_by_id
+    from vaner.setup.serializers import bundle_to_dict
+
+    policy_section = _read_policy_section(repo_root)
+    selected_bundle_id = policy_section.get("selected_bundle_id") or "hybrid_balanced"
+    try:
+        bundle = bundle_by_id(str(selected_bundle_id))
+    except KeyError:
+        return _json_result(
+            {
+                "code": "unknown_bundle_id",
+                "message": f"unknown bundle id {selected_bundle_id!r}",
+                "selected_bundle_id": str(selected_bundle_id),
+            },
+            is_error=True,
+        )
+    config = _load_config(repo_root)
+    config = config.model_copy(update={"policy": config.policy.model_copy(update={"selected_bundle_id": str(selected_bundle_id)})})
+    applied = apply_policy_bundle(config, bundle)
+    return _json_result(
+        {
+            "bundle": bundle_to_dict(bundle),
+            "overrides_applied": list(applied.overrides_applied),
+        }
+    )
+
+
 def _tokenize(text: str) -> set[str]:
     return {tok for tok in "".join(ch if ch.isalnum() else " " for ch in text.lower()).split() if len(tok) > 2}
 
@@ -832,6 +1161,87 @@ def build_server(
                         "properties": {"session_id": {"type": "string"}},
                         "required": ["session_id"],
                     },
+                ),
+                # 0.8.6 WS7 — Setup-surface MCP tools.
+                Tool(
+                    name="vaner.setup.questions",
+                    description=(
+                        "Return the ordered Simple-Mode question schema "
+                        "(work styles, priority, compute posture, cloud "
+                        "posture, background posture). Static — no engine "
+                        "state. Desktops/cockpit consume this so they "
+                        "don't hardcode question strings."
+                    ),
+                    inputSchema={"type": "object", "properties": {}},
+                ),
+                Tool(
+                    name="vaner.setup.recommend",
+                    description=(
+                        "Run WS3 bundle selection on a SetupAnswers payload "
+                        "and return the SelectionResult JSON (chosen bundle, "
+                        "score, reasons, runner-ups, forced_fallback). Pure "
+                        "read; no config write."
+                    ),
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "work_styles": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {"type": "array", "items": {"type": "string"}},
+                                ],
+                                "description": "WorkStyle id(s); single string or list.",
+                            },
+                            "priority": {"type": "string"},
+                            "compute_posture": {"type": "string"},
+                            "cloud_posture": {"type": "string"},
+                            "background_posture": {"type": "string"},
+                        },
+                    },
+                ),
+                Tool(
+                    name="vaner.setup.apply",
+                    description=(
+                        "Persist a chosen policy bundle to .vaner/config.toml. "
+                        "Pass `answers` for selection or `bundle_id` to pin a "
+                        "specific bundle. Surfaces a WIDENS_CLOUD_POSTURE "
+                        "warning via `widens_cloud_posture=true`; defaults to "
+                        "NOT writing on widening unless `confirm_cloud_widening` "
+                        "is true. Set `dry_run` to true to preview without "
+                        "writing."
+                    ),
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "answers": {
+                                "type": "object",
+                                "description": "SetupAnswers payload (optional if bundle_id is set).",
+                            },
+                            "bundle_id": {
+                                "type": "string",
+                                "description": "Skip selection; pin this bundle id directly.",
+                            },
+                            "confirm_cloud_widening": {"type": "boolean", "default": False},
+                            "dry_run": {"type": "boolean", "default": False},
+                        },
+                    },
+                ),
+                Tool(
+                    name="vaner.setup.status",
+                    description=(
+                        "Read current setup mode + selected bundle id + applied policy overrides + hardware profile. Read-only; no input."
+                    ),
+                    inputSchema={"type": "object", "properties": {}},
+                ),
+                Tool(
+                    name="vaner.policy.show",
+                    description=(
+                        "Return the full VanerPolicyBundle JSON for the "
+                        "currently selected bundle plus the overrides_applied "
+                        "list. Drives the desktop transparency disclosure "
+                        "panel. Read-only."
+                    ),
+                    inputSchema={"type": "object", "properties": {}},
                 ),
             ]
         )
@@ -2274,6 +2684,54 @@ def build_server(
                     )
                 await _record("ok")
                 return _json_result(_session_to_dict(session))
+
+        # ------------------------------------------------------------------
+        # 0.8.6 WS7 — Setup-surface MCP tools.
+        # ------------------------------------------------------------------
+        if name == "vaner.setup.questions":
+            await _record("ok")
+            return _json_result({"questions": _setup_question_schema()})
+
+        if name == "vaner.setup.recommend":
+            from vaner.setup.hardware import detect as _hw_detect
+            from vaner.setup.select import select_policy_bundle as _select_bundle
+            from vaner.setup.serializers import (
+                AnswersValidationError,
+                answers_from_payload,
+                selection_to_dict,
+            )
+
+            try:
+                answers = answers_from_payload(args)
+            except AnswersValidationError as exc:
+                await _record("error")
+                return _json_result(
+                    {"code": "invalid_input", "message": str(exc)},
+                    is_error=True,
+                )
+            try:
+                hardware = _hw_detect()
+                selection = _select_bundle(answers, hardware)
+            except Exception as exc:
+                await _record("error")
+                return _json_result(
+                    {"code": "recommend_failed", "message": str(exc)},
+                    is_error=True,
+                )
+            await _record("ok")
+            return _json_result(selection_to_dict(selection))
+
+        if name == "vaner.setup.apply":
+            await _record("ok")
+            return _setup_apply_handler(active_repo_root, args)
+
+        if name == "vaner.setup.status":
+            await _record("ok")
+            return _setup_status_handler(active_repo_root)
+
+        if name == "vaner.policy.show":
+            await _record("ok")
+            return _policy_show_handler(active_repo_root)
 
         if name == "vaner.debug.trace":
             if str(__import__("os").environ.get("VANER_MCP_DEBUG", "0")) != "1":

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    Priority,
+    WorkStyle,
+)
 
 
 class PrivacyConfig(BaseModel):
@@ -171,7 +180,11 @@ class IntentConfig(BaseModel):
     lookback_turns: int = 8
     skills_loop_enabled: bool = True
     max_feedback_events_per_cycle: int = 5
-    domain: Literal["coding", "research", "writing", "ops"] = "coding"
+    # 0.8.6 WS1 — the previous ``domain`` field
+    # (``Literal["coding","research","writing","ops"]``) is removed.
+    # It had zero callers and is superseded by the multi-select
+    # ``setup.work_styles`` field on :class:`SetupConfig`. See the
+    # 0.8.6 CHANGELOG entry under "Removed".
     embedding_classifier_enabled: bool = True
     cross_workspace_profile: bool = False
 
@@ -616,6 +629,67 @@ class RefinementConfig(BaseModel):
     adoption_pending_confirm_seconds: float = Field(default=600.0, ge=0.0)
 
 
+class SetupConfig(BaseModel):
+    """``[setup]`` — Simple-Mode wizard state (0.8.6 WS1).
+
+    Holds the answers from one completed wizard run plus a few
+    bookkeeping fields. ``mode`` distinguishes the Simple-Mode
+    (outcome-level questions) surface from the Advanced-Mode (full
+    knob-level config) surface; both are simultaneously valid (the
+    user can flip back and forth from the desktop UI). ``completed_at``
+    marks first-run state — when ``None``, the engine treats this as a
+    fresh install and triggers the wizard on first interaction.
+
+    Configs without a ``[setup]`` section get all defaults at load
+    time, which means ``mode="simple"`` and the no-op ``["mixed"]``
+    work-style. There is no migration path from a legacy
+    ``IntentConfig.domain`` field — that field is removed outright in
+    0.8.6 (see CHANGELOG entry).
+    """
+
+    mode: Literal["simple", "advanced"] = "simple"
+    work_styles: list[WorkStyle] = Field(default_factory=lambda: ["mixed"])  # type: ignore[arg-type]
+    # ^ mypy can't see through the Literal narrowing inside the lambda;
+    # the runtime list ["mixed"] is a perfectly valid list[WorkStyle].
+    priority: Priority = "balanced"
+    compute_posture: ComputePosture = "balanced"
+    cloud_posture: CloudPosture = "ask_first"
+    background_posture: BackgroundPosture = "normal"
+    completed_at: datetime | None = None
+    """ISO timestamp of the most recent wizard completion. ``None``
+    means the wizard has never been run on this config; first-run
+    surfaces use this to decide whether to prompt."""
+    version: int = 1
+    """Schema-migration anchor for future ``[setup]`` extensions.
+    Bumped only when a backwards-incompatible field change lands."""
+
+
+class PolicyConfig(BaseModel):
+    """``[policy]`` — selected policy bundle and per-knob overrides
+    (0.8.6 WS1).
+
+    ``selected_bundle_id`` is the foreign key into
+    :data:`vaner.setup.catalog.PROFILE_CATALOG`. The default
+    ``"hybrid_balanced"`` is the safe middle path used when the
+    wizard has not run yet.
+
+    ``bundle_overrides`` is a free-form dict for per-knob user
+    overrides on top of the selected bundle. Keys are bundle field
+    names; values are the override values. WS5's ``apply_policy_bundle``
+    composes bundle defaults → user overrides → Deep-Run session
+    deltas.
+
+    ``auto_select`` controls whether the engine re-runs WS3's
+    selection algorithm when hardware changes (e.g. desktop → battery,
+    GPU added/removed). When ``False`` (user pinned the bundle), the
+    engine emits a warning but does not re-select.
+    """
+
+    selected_bundle_id: str = "hybrid_balanced"
+    bundle_overrides: dict[str, Any] = Field(default_factory=dict)
+    auto_select: bool = True
+
+
 class VanerConfig(BaseModel):
     repo_root: Path
     store_path: Path
@@ -634,3 +708,5 @@ class VanerConfig(BaseModel):
     sources: SourcesConfig = Field(default_factory=SourcesConfig)
     refinement: RefinementConfig = Field(default_factory=RefinementConfig)
     integrations: IntegrationsConfig = Field(default_factory=IntegrationsConfig)
+    setup: SetupConfig = Field(default_factory=SetupConfig)
+    policy: PolicyConfig = Field(default_factory=PolicyConfig)

--- a/src/vaner/setup/__init__.py
+++ b/src/vaner/setup/__init__.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vaner setup primitives — Simple-Mode wizard data model (0.8.6).
+
+This package owns the outcome-level configuration surface introduced in
+0.8.6:
+
+- :mod:`vaner.setup.enums` — ``WorkStyle`` / ``Priority`` /
+  ``ComputePosture`` / ``CloudPosture`` / ``BackgroundPosture`` /
+  ``HardwareTier`` literal aliases.
+- :mod:`vaner.setup.answers` — :class:`SetupAnswers` dataclass, the
+  immutable record of one wizard run.
+- :mod:`vaner.setup.policy` — :class:`VanerPolicyBundle` dataclass.
+- :mod:`vaner.setup.catalog` — :data:`PROFILE_CATALOG` (the seven
+  shipped bundles) and the ``bundle_by_id()`` lookup helper.
+
+Hardware detection (:mod:`vaner.setup.hardware`), the selection
+algorithm (:mod:`vaner.setup.select`), and the policy applicator
+(:mod:`vaner.setup.apply`) land in subsequent 0.8.6 work streams.
+
+Note: this ``__init__`` deliberately re-exports *only* the leaf modules
+that have no dependency on the engine stack (``enums``, ``answers``).
+Importing :class:`VanerPolicyBundle` or the catalogue requires
+explicit submodule imports — ``from vaner.setup.policy import …`` —
+because :mod:`vaner.setup.policy` depends transitively on
+:mod:`vaner.intent.deep_run` and would create an import cycle if
+re-exported from here while :mod:`vaner.models.config` also imports
+from this package.
+"""
+
+from __future__ import annotations
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    HardwareTier,
+    Priority,
+    WorkStyle,
+)
+
+__all__ = [
+    "BackgroundPosture",
+    "CloudPosture",
+    "ComputePosture",
+    "HardwareTier",
+    "Priority",
+    "SetupAnswers",
+    "WorkStyle",
+]

--- a/src/vaner/setup/answers.py
+++ b/src/vaner/setup/answers.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: SetupAnswers dataclass (0.8.6).
+
+``SetupAnswers`` is the immutable record of one completed Simple-Mode
+wizard run. It is the input to WS3's ``select_policy_bundle()`` and is
+persisted (in normal-form, on the ``[setup]`` section of
+``.vaner/config.toml``) so the engine can re-run selection on hardware
+changes without re-prompting the user.
+
+Validation in ``__post_init__`` enforces the *only* invariant Simple Mode
+cannot recover from: empty ``work_styles``. The engine has no priors to
+average if no work styles were selected; UI surfaces are responsible for
+forcing at least one selection (defaulting to ``"mixed"`` when the user
+has no preference). All other fields are scalar enums and validated by
+their ``Literal`` types when loaded through Pydantic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    Priority,
+    WorkStyle,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SetupAnswers:
+    """Immutable record of one completed Simple-Mode wizard run.
+
+    ``work_styles`` is a tuple (not a list) so the dataclass remains
+    hashable and properly frozen. The wizard surface accepts a list and
+    converts at the boundary.
+    """
+
+    work_styles: tuple[WorkStyle, ...]
+    priority: Priority
+    compute_posture: ComputePosture
+    cloud_posture: CloudPosture
+    background_posture: BackgroundPosture
+
+    def __post_init__(self) -> None:
+        if not self.work_styles:
+            raise ValueError(
+                "SetupAnswers.work_styles must contain at least one WorkStyle; "
+                "the engine has no priors to average if no work styles are selected. "
+                'Pass ("mixed",) when the user has no preference.'
+            )
+
+
+__all__ = ["SetupAnswers"]

--- a/src/vaner/setup/apply.py
+++ b/src/vaner/setup/apply.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS5 — Apply policy bundle as governor input (0.8.6).
+
+This module is the bridge between the outcome-level policy bundles
+(see :mod:`vaner.setup.policy` / :mod:`vaner.setup.catalog`) and the
+engine's existing knob-level config (see :mod:`vaner.models.config`).
+
+The single entry point is :func:`apply_policy_bundle`. It is a **pure
+function** — it never mutates the input ``VanerConfig``; it returns a
+new :class:`AppliedPolicy` that wraps the materialised config plus a
+human-readable list of overrides.
+
+Order of precedence (per plan WS5):
+
+1. Bundle defaults overwrite specific config-derived fields.
+2. ``user_overrides`` (read by the caller from
+   :attr:`PolicyConfig.bundle_overrides`) layer on top.
+3. Deep-Run session deltas are applied at session start by the
+   Deep-Run engine — *not* here. ``apply_policy_bundle`` handles the
+   background-mode defaults only.
+
+Cloud-widening guard
+--------------------
+
+If the new bundle's :pyattr:`VanerPolicyBundle.local_cloud_posture` is
+strictly more permissive than the previous bundle's posture (e.g.
+``local_only`` → ``hybrid``), the function inserts a sentinel string
+into :pyattr:`AppliedPolicy.overrides_applied`. Callers (CLI / desktop
+UI) are expected to surface this to the user before persisting the
+change. The function itself does not block — that is a UX policy, not
+a domain invariant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Final
+
+from vaner.models.config import VanerConfig
+from vaner.setup.catalog import bundle_by_id
+from vaner.setup.policy import VanerPolicyBundle
+
+__all__ = [
+    "AppliedPolicy",
+    "apply_policy_bundle",
+]
+
+
+# ---------------------------------------------------------------------------
+# Posture / spend / runtime mapping tables
+# ---------------------------------------------------------------------------
+
+
+# The four ``local_cloud_posture`` literals ranked by how much cloud
+# they admit. Used only to decide whether one posture is *strictly more
+# permissive* than another for the cloud-widening guard.
+_POSTURE_RANK: Final[Mapping[str, int]] = {
+    "local_only": 0,
+    "local_preferred": 1,
+    "hybrid": 2,
+    "cloud_preferred": 3,
+}
+
+
+# Spend profile -> ``BackendConfig.remote_budget_per_hour``. Numbers are
+# the bundle-default budget envelope; user overrides can still change
+# them. ``zero`` means *no remote spend permitted by default*.
+_SPEND_TO_REMOTE_BUDGET_PER_HOUR: Final[Mapping[str, int]] = {
+    "zero": 0,
+    "low": 30,
+    "medium": 60,
+    "high": 120,
+}
+
+
+# Sentinel prefix for the cloud-widening flag in
+# ``AppliedPolicy.overrides_applied``. Callers can detect widening with
+# a simple ``startswith`` check rather than parsing the diff.
+WIDENS_CLOUD_POSTURE_SENTINEL: Final[str] = "WIDENS_CLOUD_POSTURE"
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AppliedPolicy:
+    """The result of applying a bundle to a config.
+
+    Carries the new :class:`VanerConfig` plus a human-readable list of
+    overrides that were applied — useful for the transparency panel.
+    The bundle id is preserved separately so callers can diff against
+    the user's selection.
+
+    Attributes:
+        config: New :class:`VanerConfig` with bundle defaults +
+            user overrides applied. Original input config is never
+            mutated.
+        bundle_id: The id of the bundle that was applied. Matches
+            :attr:`PolicyConfig.selected_bundle_id` after the caller
+            persists the result.
+        overrides_applied: Human-readable lines describing each
+            override that was written. Includes informational lines
+            for fields the function intentionally does *not* write
+            (e.g. Deep-Run defaults, scoring multipliers without a
+            matching engine knob). May contain a
+            ``WIDENS_CLOUD_POSTURE`` sentinel string when the new
+            bundle's cloud posture is strictly more permissive than
+            the previous bundle's.
+    """
+
+    config: VanerConfig
+    bundle_id: str
+    overrides_applied: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def apply_policy_bundle(
+    config: VanerConfig,
+    bundle: VanerPolicyBundle,
+    *,
+    user_overrides: Mapping[str, Any] | None = None,
+) -> AppliedPolicy:
+    """Materialise bundle defaults onto a :class:`VanerConfig`.
+
+    Pure function. The input ``config`` is never mutated; this returns
+    a new :class:`VanerConfig` (via Pydantic's ``model_copy``) and an
+    audit list describing every override that was applied.
+
+    Apply order:
+
+    1. Bundle defaults overwrite specific config-derived fields
+       (:class:`BackendConfig`, :class:`ExplorationConfig`,
+       :class:`IntegrationsConfig.context_injection`).
+    2. ``user_overrides`` layer on top — concretely, today the only
+       supported user-override key is ``"context_injection_mode"``.
+       (When :attr:`PolicyConfig.bundle_overrides` grows additional
+       knobs, extend this function in lock-step.)
+    3. Deep-Run session deltas are applied by the Deep-Run engine at
+       session start; this function does not pre-write Deep-Run
+       fields. The bundle's Deep-Run defaults are recorded in the
+       audit list so the transparency panel can show them, but they
+       are never written into ``DeepRunSession`` here.
+
+    Cloud-widening guard:
+
+    If ``bundle.local_cloud_posture`` is strictly more permissive
+    than the previous bundle's posture (looked up from
+    ``config.policy.selected_bundle_id``), the audit list contains a
+    sentinel string starting with
+    :data:`WIDENS_CLOUD_POSTURE_SENTINEL`. Callers should surface
+    this to the user before persisting the change.
+
+    Args:
+        config: The current :class:`VanerConfig`. Treated as
+            immutable.
+        bundle: The :class:`VanerPolicyBundle` to apply.
+        user_overrides: Optional mapping of per-knob user overrides
+            on top of the bundle defaults. Pulled by the caller from
+            ``config.policy.bundle_overrides``.
+
+    Returns:
+        :class:`AppliedPolicy` carrying the materialised config and
+        an audit list of every override applied.
+    """
+
+    overrides_user: Mapping[str, Any] = user_overrides if user_overrides is not None else {}
+    overrides_applied: list[str] = []
+
+    # --------------------------------------------------------------
+    # 0. Cloud-widening detection (against the *previous* bundle).
+    # --------------------------------------------------------------
+    prior_bundle_id = config.policy.selected_bundle_id
+    if prior_bundle_id and prior_bundle_id != bundle.id:
+        try:
+            prior_bundle = bundle_by_id(prior_bundle_id)
+        except KeyError:
+            prior_bundle = None
+        if prior_bundle is not None:
+            prior_rank = _POSTURE_RANK.get(prior_bundle.local_cloud_posture, 0)
+            new_rank = _POSTURE_RANK.get(bundle.local_cloud_posture, 0)
+            if new_rank > prior_rank:
+                overrides_applied.append(
+                    f"{WIDENS_CLOUD_POSTURE_SENTINEL}: {prior_bundle.local_cloud_posture}->{bundle.local_cloud_posture}"
+                )
+
+    # --------------------------------------------------------------
+    # 1. BackendConfig — local/cloud posture and remote spend cap.
+    # --------------------------------------------------------------
+    new_prefer_local = bundle.local_cloud_posture in ("local_only", "local_preferred")
+    new_remote_budget = _SPEND_TO_REMOTE_BUDGET_PER_HOUR.get(
+        bundle.spend_profile,
+        config.backend.remote_budget_per_hour,
+    )
+    backend_updates: dict[str, Any] = {}
+    if config.backend.prefer_local != new_prefer_local:
+        backend_updates["prefer_local"] = new_prefer_local
+        overrides_applied.append(f"BackendConfig.prefer_local: {new_prefer_local}")
+    if config.backend.remote_budget_per_hour != new_remote_budget:
+        backend_updates["remote_budget_per_hour"] = new_remote_budget
+        overrides_applied.append(f"BackendConfig.remote_budget_per_hour: {new_remote_budget}")
+    new_backend = config.backend.model_copy(update=backend_updates) if backend_updates else config.backend
+
+    # --------------------------------------------------------------
+    # 2. ExplorationConfig — endpoint filter + economics-first routing.
+    # --------------------------------------------------------------
+    exploration_updates: dict[str, Any] = {}
+    if bundle.local_cloud_posture == "local_only" and config.exploration.endpoints:
+        kept = tuple(ep for ep in config.exploration.endpoints if _is_localhost_url(ep.url))
+        if len(kept) != len(config.exploration.endpoints):
+            exploration_updates["endpoints"] = list(kept)
+            overrides_applied.append(
+                f"ExplorationConfig.endpoints: filtered to localhost only ({len(kept)} of {len(config.exploration.endpoints)} kept)"
+            )
+
+    # economics_first_routing — only flip on when the bundle is
+    # cost-sensitive (small/large runtime profile + low/zero spend).
+    # We never silently flip it OFF; that is a user knob.
+    cost_sensitive = bundle.runtime_profile in ("small", "large") and bundle.spend_profile in ("zero", "low")
+    if cost_sensitive and not config.exploration.economics_first_routing:
+        exploration_updates["economics_first_routing"] = True
+        overrides_applied.append("ExplorationConfig.economics_first_routing: True")
+
+    new_exploration = config.exploration.model_copy(update=exploration_updates) if exploration_updates else config.exploration
+
+    # --------------------------------------------------------------
+    # 3. IntegrationsConfig.context_injection.mode — bundle default
+    #    unless the user has set their own override.
+    # --------------------------------------------------------------
+    user_ci_override = overrides_user.get("context_injection_mode")
+    new_integrations = config.integrations
+    if user_ci_override is not None:
+        # User wins. Apply their override to the integrations config
+        # if it differs from the current value.
+        if user_ci_override != config.integrations.context_injection.mode:
+            new_ci = config.integrations.context_injection.model_copy(update={"mode": user_ci_override})
+            new_integrations = config.integrations.model_copy(update={"context_injection": new_ci})
+            overrides_applied.append(f"IntegrationsConfig.context_injection.mode: {user_ci_override} (user override)")
+        else:
+            overrides_applied.append(f"IntegrationsConfig.context_injection.mode: {user_ci_override} (user override, no-op)")
+    else:
+        # No user override; bundle default applies.
+        if bundle.context_injection_default != config.integrations.context_injection.mode:
+            new_ci = config.integrations.context_injection.model_copy(update={"mode": bundle.context_injection_default})
+            new_integrations = config.integrations.model_copy(update={"context_injection": new_ci})
+            overrides_applied.append(f"IntegrationsConfig.context_injection.mode: {bundle.context_injection_default}")
+
+    # --------------------------------------------------------------
+    # 4. Informational entries: bundle-derived knobs the engine reads
+    #    elsewhere or that have no matching config field. These are
+    #    *not* written to the config but are surfaced to callers so
+    #    the transparency panel can show "the bundle says X" even
+    #    when X is not a knob ``apply_policy_bundle`` writes.
+    # --------------------------------------------------------------
+    overrides_applied.append(f"info: bundle.privacy_profile={bundle.privacy_profile}")
+    overrides_applied.append(f"info: bundle.deep_run_profile={bundle.deep_run_profile}")
+    overrides_applied.append(f"info: bundle.locality (Deep-Run reads at session start): {bundle.local_cloud_posture}")
+    overrides_applied.append(f"info: bundle.cost_cap_usd hint (Deep-Run reads at session start): spend_profile={bundle.spend_profile}")
+    overrides_applied.append(
+        "info: scoring multipliers (no engine knob today): "
+        f"exploration_ratio={bundle.exploration_ratio}, "
+        f"persistence_strength={bundle.persistence_strength}, "
+        f"goal_weighting={bundle.goal_weighting}, "
+        f"drafting_aggressiveness={bundle.drafting_aggressiveness}"
+    )
+    overrides_applied.append(
+        "info: prediction_horizon_bias (Deep-Run consumes at session start): "
+        + ", ".join(f"{k}={v}" for k, v in bundle.prediction_horizon_bias.items())
+    )
+
+    # --------------------------------------------------------------
+    # 5. Build the new config.
+    # --------------------------------------------------------------
+    config_updates: dict[str, Any] = {}
+    if new_backend is not config.backend:
+        config_updates["backend"] = new_backend
+    if new_exploration is not config.exploration:
+        config_updates["exploration"] = new_exploration
+    if new_integrations is not config.integrations:
+        config_updates["integrations"] = new_integrations
+
+    # Always reflect the chosen bundle id on the policy block. This is
+    # how the engine and downstream surfaces look up the bundle.
+    if config.policy.selected_bundle_id != bundle.id:
+        new_policy = config.policy.model_copy(update={"selected_bundle_id": bundle.id})
+        config_updates["policy"] = new_policy
+        overrides_applied.append(f"PolicyConfig.selected_bundle_id: {bundle.id}")
+
+    new_config = config.model_copy(update=config_updates) if config_updates else config
+
+    return AppliedPolicy(
+        config=new_config,
+        bundle_id=bundle.id,
+        overrides_applied=tuple(overrides_applied),
+    )
+
+
+def _is_localhost_url(url: str) -> bool:
+    """Return ``True`` for URLs that target the local machine.
+
+    Used by the ``local_only`` endpoint filter. A URL is considered
+    localhost when its host is ``localhost``, ``127.0.0.1``, ``::1``,
+    or any ``127.x.x.x`` loopback address. Empty URLs are treated as
+    *not* localhost — an empty endpoint is malformed and should be
+    dropped under a strict local-only policy.
+    """
+
+    if not url:
+        return False
+    lowered = url.lower()
+    # Quick string-prefix check before falling back to URL parsing.
+    if "://" in lowered:
+        # Strip scheme and split host:port from path.
+        after_scheme = lowered.split("://", 1)[1]
+        host = after_scheme.split("/", 1)[0].split("@", 1)[-1]
+        host = host.split(":", 1)[0].strip("[]")
+    else:
+        host = lowered.split("/", 1)[0].split(":", 1)[0]
+    if host in ("localhost", "127.0.0.1", "::1"):
+        return True
+    if host.startswith("127."):
+        return True
+    return False

--- a/src/vaner/setup/catalog.py
+++ b/src/vaner/setup/catalog.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: PROFILE_CATALOG (0.8.6).
+
+The seven shipped policy bundles per spec §9. This is the single source
+of truth — desktop apps, the CLI wizard, the cockpit summary card, and
+the MCP/HTTP setup tools all read from this tuple.
+
+Numeric values for the per-bundle multipliers (drafting_aggressiveness,
+exploration_ratio, persistence_strength, goal_weighting,
+prediction_horizon_bias) are calibrated against the Deep-Run preset
+table (see :mod:`vaner.intent.deep_run_policy`) so that bundle defaults
+compose multiplicatively with any Deep-Run session deltas without
+double-application.
+
+Bundle scale:
+
+- ``drafting_aggressiveness``: ``0.7`` (cautious) → ``1.3`` (eager).
+  Multiplier on the drafter evidence threshold.
+- ``exploration_ratio``: ``-0.10`` (exploit-leaning) → ``+0.15``
+  (explore-leaning). Additive bias on top of base exploration weights.
+- ``persistence_strength``: ``0.6`` (decay fast) → ``1.5`` (decay
+  slow). Multiplier on memory retention.
+- ``goal_weighting``: ``0.8`` → ``1.4``. Multiplier on goal-aligned
+  prediction scoring.
+- ``prediction_horizon_bias``: weights sum *roughly* to 4.0 across the
+  four buckets; the engine normalises before applying.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from vaner.setup.policy import VanerPolicyBundle
+
+# ---------------------------------------------------------------------------
+# Bundle definitions. Order matches spec §9 narrative; ids are the
+# stable foreign key persisted to ``PolicyConfig.selected_bundle_id``.
+# ---------------------------------------------------------------------------
+
+
+_LOCAL_LIGHTWEIGHT = VanerPolicyBundle(
+    # Target user: laptop on battery, integrated GPU, wants Vaner to
+    # not heat the room. Local-only by default; minimal background.
+    id="local_lightweight",
+    label="Local Lightweight",
+    description=("Run entirely on this device with a small local model. Best for older laptops, battery, and privacy-first users."),
+    local_cloud_posture="local_only",
+    runtime_profile="small",
+    spend_profile="zero",
+    latency_profile="snappy",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.4,
+        "long_horizon": 0.8,
+        "finish_partials": 1.2,
+        "balanced": 0.6,
+    },
+    drafting_aggressiveness=0.8,
+    exploration_ratio=-0.05,
+    persistence_strength=0.7,
+    goal_weighting=1.0,
+    context_injection_default="digest_only",
+    deep_run_profile="conservative",
+)
+
+
+_LOCAL_BALANCED = VanerPolicyBundle(
+    # Target user: capable laptop or desktop, mid-tier local model
+    # (e.g. 7-13B). Local-first but willing to ponder more in the
+    # background. Default for the "Capable" hardware tier.
+    id="local_balanced",
+    label="Local Balanced",
+    description=("Local-first with a mid-sized model. Solid default for a capable laptop or desktop with no cloud reliance."),
+    local_cloud_posture="local_preferred",
+    runtime_profile="medium",
+    spend_profile="zero",
+    latency_profile="balanced",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.0,
+        "finish_partials": 1.0,
+        "balanced": 1.0,
+    },
+    drafting_aggressiveness=1.0,
+    exploration_ratio=0.0,
+    persistence_strength=1.0,
+    goal_weighting=1.0,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="balanced",
+)
+
+
+_LOCAL_HEAVY = VanerPolicyBundle(
+    # Target user: workstation or homelab with a large local model
+    # (e.g. 30-70B at Q4+). Local-only, but Vaner is allowed to ponder
+    # aggressively because the box can take it.
+    id="local_heavy",
+    label="Local Heavy",
+    description=("All-local with a large model and aggressive background pondering. Built for workstations and homelab GPUs."),
+    local_cloud_posture="local_only",
+    runtime_profile="large",
+    spend_profile="zero",
+    latency_profile="quality",
+    privacy_profile="strict",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.4,
+        "finish_partials": 1.0,
+        "balanced": 1.2,
+    },
+    drafting_aggressiveness=1.1,
+    exploration_ratio=0.10,
+    persistence_strength=1.3,
+    goal_weighting=1.2,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="aggressive",
+)
+
+
+_HYBRID_BALANCED = VanerPolicyBundle(
+    # Target user: anyone who's fine with the engine reaching for a
+    # cloud model when local is genuinely insufficient. The default
+    # bundle for first-run when hardware tier is unknown — safe
+    # middle path.
+    id="hybrid_balanced",
+    label="Hybrid Balanced",
+    description=("Local for everyday work, cloud only when it's clearly worth it. Recommended default for most users."),
+    local_cloud_posture="hybrid",
+    runtime_profile="medium",
+    spend_profile="low",
+    latency_profile="balanced",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 1.0,
+        "long_horizon": 1.1,
+        "finish_partials": 1.0,
+        "balanced": 1.0,
+    },
+    drafting_aggressiveness=1.0,
+    exploration_ratio=0.05,
+    persistence_strength=1.0,
+    goal_weighting=1.0,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="balanced",
+)
+
+
+_HYBRID_QUALITY = VanerPolicyBundle(
+    # Target user: serious work where the user is willing to spend on
+    # cloud capacity to get the best result. Still hybrid, but the
+    # cloud bias is set higher and the latency profile prioritises
+    # quality over snappiness.
+    id="hybrid_quality",
+    label="Hybrid Quality",
+    description=("Reach for the best available model — local or cloud — and trade some snappiness and budget for higher answer quality."),
+    local_cloud_posture="cloud_preferred",
+    runtime_profile="large",
+    spend_profile="medium",
+    latency_profile="quality",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 0.9,
+        "long_horizon": 1.4,
+        "finish_partials": 1.0,
+        "balanced": 1.1,
+    },
+    drafting_aggressiveness=1.2,
+    exploration_ratio=0.10,
+    persistence_strength=1.2,
+    goal_weighting=1.2,
+    context_injection_default="top_match_auto_include",
+    deep_run_profile="balanced",
+)
+
+
+_COST_SAVER = VanerPolicyBundle(
+    # Target user: cost-conscious user who still wants some hybrid
+    # capacity. Tightens spend cap and prefers the cheapest endpoint
+    # that meets the latency / context floor.
+    id="cost_saver",
+    label="Cost Saver",
+    description=("Hybrid setup with tight cloud spend caps. Prefers the cheapest endpoint that still meets the bar."),
+    local_cloud_posture="local_preferred",
+    runtime_profile="small",
+    spend_profile="low",
+    latency_profile="balanced",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 1.2,
+        "long_horizon": 0.9,
+        "finish_partials": 1.1,
+        "balanced": 0.8,
+    },
+    drafting_aggressiveness=0.9,
+    exploration_ratio=-0.05,
+    persistence_strength=0.9,
+    goal_weighting=1.0,
+    context_injection_default="adopted_package_only",
+    deep_run_profile="conservative",
+)
+
+
+_DEEP_RESEARCH = VanerPolicyBundle(
+    # Target user: long-horizon research / writing work where Vaner
+    # should ponder broadly and persistently. Overnight Deep-Run is the
+    # natural mode; daytime use composes the bundle's bias with the
+    # active session's preset.
+    id="deep_research",
+    label="Deep Research",
+    description=("Long-horizon, broad exploration for research and writing. Persists predictions longer and prefers depth over speed."),
+    local_cloud_posture="hybrid",
+    runtime_profile="large",
+    spend_profile="medium",
+    latency_profile="quality",
+    privacy_profile="standard",
+    prediction_horizon_bias={
+        "likely_next": 0.7,
+        "long_horizon": 1.6,
+        "finish_partials": 1.1,
+        "balanced": 1.2,
+    },
+    drafting_aggressiveness=1.1,
+    exploration_ratio=0.15,
+    persistence_strength=1.5,
+    goal_weighting=1.4,
+    context_injection_default="policy_hybrid",
+    deep_run_profile="aggressive",
+)
+
+
+PROFILE_CATALOG: Final[tuple[VanerPolicyBundle, ...]] = (
+    _LOCAL_LIGHTWEIGHT,
+    _LOCAL_BALANCED,
+    _LOCAL_HEAVY,
+    _HYBRID_BALANCED,
+    _HYBRID_QUALITY,
+    _COST_SAVER,
+    _DEEP_RESEARCH,
+)
+
+
+# Internal id-keyed lookup map. Built once at import time so
+# ``bundle_by_id`` is O(1). Not exported — callers should use the
+# helper, which gives a clearer error message on miss.
+_BY_ID: Final[dict[str, VanerPolicyBundle]] = {bundle.id: bundle for bundle in PROFILE_CATALOG}
+
+
+def bundle_by_id(bundle_id: str) -> VanerPolicyBundle:
+    """Return the bundle with the given id.
+
+    Raises :class:`KeyError` (with a helpful message) if no bundle in
+    :data:`PROFILE_CATALOG` matches. The engine should never silently
+    fall back to a default for an unknown id — that would mask a
+    config-shape bug or a corrupted ``.vaner/config.toml``.
+    """
+
+    try:
+        return _BY_ID[bundle_id]
+    except KeyError as exc:
+        known = ", ".join(sorted(_BY_ID))
+        raise KeyError(f"unknown bundle id {bundle_id!r}; known ids: {known}") from exc
+
+
+__all__ = [
+    "PROFILE_CATALOG",
+    "bundle_by_id",
+]

--- a/src/vaner/setup/enums.py
+++ b/src/vaner/setup/enums.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: enums (0.8.6).
+
+These ``Literal`` type aliases are the single source of truth for the
+outcome-level question vocabulary surfaced by Simple Mode (CLI wizard,
+desktop apps, MCP/HTTP setup tools). Each alias matches one question in
+the five-step Simple-Mode flow described in the 0.8.6 spec §5:
+
+- ``WorkStyle`` — multi-select. What kind of work do you want help with?
+  ("writing", "research", "planning", "support", "learning", "coding",
+  "general", "mixed", "unsure"). The engine averages priors when more
+  than one work style is selected.
+- ``Priority`` — single-select. What matters most? ("balanced", "speed",
+  "quality", "privacy", "cost", "low_resource").
+- ``ComputePosture`` — single-select. How hard should this machine work
+  for you? ("light", "balanced", "available_power").
+- ``CloudPosture`` — single-select. How do you feel about cloud LLMs?
+  ("local_only", "ask_first", "hybrid_when_worth_it",
+  "best_available").
+- ``BackgroundPosture`` — single-select. How aggressive should
+  background pondering be? ("minimal", "normal", "idle_more",
+  "deep_run_aggressive").
+- ``HardwareTier`` — output of WS2's ``tier_for()`` mapping. Declared
+  here so all of WS1+WS2+WS3 share one definition.
+
+We use ``Literal`` aliases rather than ``enum.Enum`` classes to match the
+existing codebase pattern (see ``DeepRunPreset`` / ``DeepRunFocus`` /
+``DeepRunHorizonBias`` in :mod:`vaner.intent.deep_run`). The aliases
+participate naturally in Pydantic validation, JSON serialisation, and
+``ts-rs`` codegen on the ``vaner-contract`` side.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+WorkStyle = Literal[
+    "writing",
+    "research",
+    "planning",
+    "support",
+    "learning",
+    "coding",
+    "general",
+    "mixed",
+    "unsure",
+]
+
+Priority = Literal[
+    "balanced",
+    "speed",
+    "quality",
+    "privacy",
+    "cost",
+    "low_resource",
+]
+
+ComputePosture = Literal[
+    "light",
+    "balanced",
+    "available_power",
+]
+
+CloudPosture = Literal[
+    "local_only",
+    "ask_first",
+    "hybrid_when_worth_it",
+    "best_available",
+]
+
+BackgroundPosture = Literal[
+    "minimal",
+    "normal",
+    "idle_more",
+    "deep_run_aggressive",
+]
+
+# Declared here for shared use across WS1 (config schema) and WS2
+# (hardware detection / tier_for()). WS2 owns the mapping logic.
+HardwareTier = Literal[
+    "light",
+    "capable",
+    "high_performance",
+    "unknown",
+]
+
+
+__all__ = [
+    "BackgroundPosture",
+    "CloudPosture",
+    "ComputePosture",
+    "HardwareTier",
+    "Priority",
+    "WorkStyle",
+]

--- a/src/vaner/setup/hardware.py
+++ b/src/vaner/setup/hardware.py
@@ -1,0 +1,629 @@
+"""Hardware detection for Vaner setup wizard.
+
+Read-only, fail-safe probes that build a :class:`HardwareProfile` snapshot of
+the local machine and map it to a :data:`HardwareTier` for policy-bundle
+selection (spec §6.1).
+
+Every probe is wrapped so that a missing dependency, a non-zero subprocess
+exit, a timeout, or unrecognised output yields a sensible default rather than
+raising. This module must import cleanly on any supported platform.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+from urllib import request as urlrequest
+from urllib.error import URLError
+
+from vaner.setup.enums import HardwareTier
+
+OS = Literal["linux", "darwin", "windows"]
+CPUClass = Literal["low", "mid", "high"]
+GPU = Literal["none", "integrated", "nvidia", "amd", "apple_silicon"]
+Runtime = Literal["ollama", "llama.cpp", "lmstudio", "vllm", "mlx"]
+
+_RUNTIMES: tuple[Runtime, ...] = ("ollama", "llama.cpp", "lmstudio", "vllm", "mlx")
+
+_HTTP_TIMEOUT = 1.0
+_SUBPROCESS_TIMEOUT = 2.0
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class HardwareProfile:
+    """Immutable snapshot of detected hardware capabilities.
+
+    The ``tier`` field is computed once at construction time so consumers do
+    not need to re-derive it.
+    """
+
+    os: OS
+    cpu_class: CPUClass
+    ram_gb: int
+    gpu: GPU
+    gpu_vram_gb: int | None
+    is_battery: bool
+    thermal_constrained: bool
+    detected_runtimes: tuple[Runtime, ...]
+    detected_models: tuple[tuple[str, str, str], ...]
+    tier: HardwareTier = field(default="unknown")
+
+
+# ---------------------------------------------------------------------------
+# OS / CPU / RAM probes
+# ---------------------------------------------------------------------------
+
+
+def _probe_os() -> OS | None:
+    """Return the host OS or ``None`` if it cannot be classified."""
+    try:
+        plat = sys.platform
+        if plat.startswith("linux"):
+            return "linux"
+        if plat == "darwin":
+            return "darwin"
+        if plat in {"win32", "cygwin"}:
+            return "windows"
+        # Fall back to platform.system() spelling.
+        sysname = platform.system().lower()
+        if sysname == "linux":
+            return "linux"
+        if sysname == "darwin":
+            return "darwin"
+        if sysname == "windows":
+            return "windows"
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("os probe failed", exc_info=True)
+    return None
+
+
+def _read_meminfo_gb() -> int | None:
+    """Parse Linux ``/proc/meminfo`` for total RAM in GB. Best-effort."""
+    try:
+        text = Path("/proc/meminfo").read_text()
+        for line in text.splitlines():
+            if line.startswith("MemTotal:"):
+                # MemTotal:       16327208 kB
+                parts = line.split()
+                kb = int(parts[1])
+                return max(1, round(kb / (1024 * 1024)))
+    except Exception:
+        logger.debug("/proc/meminfo probe failed", exc_info=True)
+    return None
+
+
+def _sysctl_memsize_gb() -> int | None:
+    """Run ``sysctl hw.memsize`` (macOS) and convert to GB. Best-effort."""
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        value = int(result.stdout.strip())
+        return max(1, round(value / (1024**3)))
+    except Exception:
+        logger.debug("sysctl hw.memsize failed", exc_info=True)
+        return None
+
+
+def _probe_cpu_and_ram() -> tuple[CPUClass, int]:
+    """Return CPU class + RAM in GB.
+
+    Heuristic for ``cpu_class`` (documented):
+
+    * ``low``  — fewer than 4 logical CPUs **or** less than 8 GB RAM.
+    * ``high`` — 12+ logical CPUs **and** 32+ GB RAM.
+    * ``mid``  — everything in between.
+
+    On total probe failure both return ``"low"`` / ``0``; the tier mapper then
+    treats the resulting profile as ``unknown``.
+    """
+    logical_cpus: int | None = None
+    ram_gb: int | None = None
+
+    try:
+        import psutil  # type: ignore[import-untyped]
+
+        logical_cpus = psutil.cpu_count(logical=True)
+        try:
+            vmem = psutil.virtual_memory()
+            ram_gb = max(1, round(vmem.total / (1024**3)))
+        except Exception:
+            logger.debug("psutil.virtual_memory failed", exc_info=True)
+    except ImportError:
+        logger.debug("psutil unavailable; falling back to stdlib")
+    except Exception:
+        logger.debug("psutil unavailable / errored", exc_info=True)
+
+    if logical_cpus is None:
+        try:
+            logical_cpus = os.cpu_count()
+        except Exception:
+            logical_cpus = None
+
+    if ram_gb is None:
+        plat = sys.platform
+        if plat.startswith("linux"):
+            ram_gb = _read_meminfo_gb()
+        elif plat == "darwin":
+            ram_gb = _sysctl_memsize_gb()
+        # Windows without psutil: leave ram_gb as None → 0 below.
+
+    cpu_count = logical_cpus or 0
+    ram = ram_gb or 0
+
+    if cpu_count == 0 and ram == 0:
+        return "low", 0
+
+    cpu_class: CPUClass
+    if cpu_count >= 12 and ram >= 32:
+        cpu_class = "high"
+    elif cpu_count < 4 or ram < 8:
+        cpu_class = "low"
+    else:
+        cpu_class = "mid"
+    return cpu_class, ram
+
+
+# ---------------------------------------------------------------------------
+# GPU probe
+# ---------------------------------------------------------------------------
+
+
+def _probe_gpu_nvidia() -> tuple[GPU, int | None] | None:
+    """Use pynvml when available to identify NVIDIA GPUs + VRAM."""
+    try:
+        import pynvml  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    except Exception:
+        logger.debug("pynvml import failed", exc_info=True)
+        return None
+
+    try:
+        pynvml.nvmlInit()
+        try:
+            count = pynvml.nvmlDeviceGetCount()
+            if count <= 0:
+                return None
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            vram_gb = max(1, round(mem.total / (1024**3)))
+            return "nvidia", vram_gb
+        finally:
+            try:
+                pynvml.nvmlShutdown()
+            except Exception:  # pragma: no cover - cleanup
+                logger.debug("nvmlShutdown failed", exc_info=True)
+    except Exception:
+        logger.debug("pynvml probe failed", exc_info=True)
+        return None
+
+
+def _probe_gpu_macos() -> tuple[GPU, int | None]:
+    """macOS: ``system_profiler SPDisplaysDataType -json`` parsing."""
+    try:
+        result = subprocess.run(
+            ["system_profiler", "SPDisplaysDataType", "-json"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return "none", None
+        data = json.loads(result.stdout)
+        displays = data.get("SPDisplaysDataType", [])
+        if not isinstance(displays, list) or not displays:
+            return "none", None
+        first = displays[0]
+        vendor = (first.get("spdisplays_vendor") or "").lower()
+        name = (first.get("sppci_model") or "").lower()
+        if "apple" in vendor or "apple" in name:
+            # Apple Silicon → unified memory; no separate VRAM number.
+            return "apple_silicon", None
+        if "nvidia" in vendor or "nvidia" in name:
+            return "nvidia", None
+        if "amd" in vendor or "amd" in name or "radeon" in name:
+            return "amd", None
+        if "intel" in vendor or "intel" in name:
+            return "integrated", None
+        return "integrated", None
+    except Exception:
+        logger.debug("system_profiler GPU probe failed", exc_info=True)
+        return "none", None
+
+
+def _probe_gpu_linux() -> tuple[GPU, int | None]:
+    """Linux fallback: ``lspci`` for VGA-class controllers."""
+    if not shutil.which("lspci"):
+        return "none", None
+    try:
+        result = subprocess.run(
+            ["lspci"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+        if result.returncode != 0:
+            return "none", None
+        text = result.stdout.lower()
+        # Filter to VGA / 3D / Display controller lines.
+        gpu_lines = [line for line in text.splitlines() if "vga" in line or "3d controller" in line or "display controller" in line]
+        if not gpu_lines:
+            return "none", None
+        joined = " ".join(gpu_lines)
+        if "nvidia" in joined:
+            return "nvidia", None
+        if "amd" in joined or "advanced micro devices" in joined or "radeon" in joined:
+            return "amd", None
+        if "intel" in joined:
+            return "integrated", None
+        return "integrated", None
+    except Exception:
+        logger.debug("lspci probe failed", exc_info=True)
+        return "none", None
+
+
+def _probe_gpu() -> tuple[GPU, int | None]:
+    """Compose GPU probes; never raises."""
+    try:
+        # NVIDIA via pynvml is the most reliable signal when present.
+        nvidia = _probe_gpu_nvidia()
+        if nvidia is not None:
+            return nvidia
+        plat = sys.platform
+        if plat == "darwin":
+            return _probe_gpu_macos()
+        if plat.startswith("linux"):
+            return _probe_gpu_linux()
+        return "none", None
+    except Exception:
+        logger.debug("GPU probe failed", exc_info=True)
+        return "none", None
+
+
+# ---------------------------------------------------------------------------
+# Battery / thermal
+# ---------------------------------------------------------------------------
+
+
+def _probe_battery() -> bool:
+    """Return True when a battery is present (laptop / portable)."""
+    try:
+        import psutil
+
+        try:
+            batt = psutil.sensors_battery()
+        except Exception:
+            batt = None
+        if batt is not None:
+            return True
+    except ImportError:
+        pass
+    except Exception:
+        logger.debug("psutil battery probe failed", exc_info=True)
+
+    if sys.platform.startswith("linux"):
+        try:
+            power = Path("/sys/class/power_supply")
+            if power.exists():
+                for entry in power.iterdir():
+                    if entry.name.upper().startswith("BAT"):
+                        return True
+        except Exception:
+            logger.debug("/sys/class/power_supply probe failed", exc_info=True)
+
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["pmset", "-g", "batt"],
+                capture_output=True,
+                text=True,
+                timeout=_SUBPROCESS_TIMEOUT,
+                check=False,
+            )
+            if result.returncode == 0 and "InternalBattery" in result.stdout:
+                return True
+        except Exception:
+            logger.debug("pmset battery probe failed", exc_info=True)
+
+    return False
+
+
+def _probe_thermal() -> bool:
+    """Best-effort thermal pressure hint.
+
+    Linux: read ``/sys/class/thermal/thermal_zone*/temp``; flag if any zone
+    reports above 85 °C. Returns False on every other platform / probe error.
+    """
+    if not sys.platform.startswith("linux"):
+        return False
+    try:
+        base = Path("/sys/class/thermal")
+        if not base.exists():
+            return False
+        for zone in base.glob("thermal_zone*"):
+            temp_file = zone / "temp"
+            try:
+                raw = temp_file.read_text().strip()
+                # Sysfs reports millidegrees Celsius.
+                centi = int(raw)
+                celsius = centi / 1000.0
+                if celsius >= 85.0:
+                    return True
+            except Exception:
+                continue
+    except Exception:
+        logger.debug("thermal probe failed", exc_info=True)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Runtime + model probes
+# ---------------------------------------------------------------------------
+
+
+def _http_get_ok(url: str, timeout: float = _HTTP_TIMEOUT) -> tuple[bool, str | None]:
+    """GET ``url`` and return ``(ok, body)``. ``ok`` is True iff status == 200."""
+    try:
+        req = urlrequest.Request(url, method="GET")
+        with urlrequest.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - localhost only
+            status = getattr(resp, "status", None) or resp.getcode()
+            if status != 200:
+                return False, None
+            try:
+                body = resp.read().decode("utf-8", errors="replace")
+            except Exception:
+                body = None
+            return True, body
+    except (URLError, TimeoutError, OSError):
+        return False, None
+    except Exception:
+        logger.debug("HTTP probe failed for %s", url, exc_info=True)
+        return False, None
+
+
+def _probe_ollama() -> bool:
+    if shutil.which("ollama"):
+        return True
+    ok, _ = _http_get_ok("http://127.0.0.1:11434/api/tags")
+    return ok
+
+
+def _probe_llama_cpp() -> bool:
+    return bool(shutil.which("llama-server") or shutil.which("llama-cpp-server"))
+
+
+def _probe_lmstudio() -> bool:
+    ok, _ = _http_get_ok("http://127.0.0.1:1234/v1/models")
+    return ok
+
+
+def _probe_vllm() -> bool:
+    return bool(shutil.which("vllm"))
+
+
+def _probe_mlx() -> bool:
+    if sys.platform != "darwin":
+        return False
+    if shutil.which("mlx_lm.generate"):
+        return True
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import mlx_lm"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        logger.debug("mlx import probe failed", exc_info=True)
+        return False
+
+
+def _probe_runtimes() -> tuple[Runtime, ...]:
+    """Return the tuple of locally detected runtimes. Never raises."""
+    found: list[Runtime] = []
+    probes: dict[Runtime, Callable[[], bool]] = {
+        "ollama": _probe_ollama,
+        "llama.cpp": _probe_llama_cpp,
+        "lmstudio": _probe_lmstudio,
+        "vllm": _probe_vllm,
+        "mlx": _probe_mlx,
+    }
+    for name in _RUNTIMES:
+        try:
+            if probes[name]():
+                found.append(name)
+        except Exception:
+            logger.debug("runtime probe %s failed", name, exc_info=True)
+    return tuple(found)
+
+
+def _label_size(size_bytes: int | None) -> str:
+    if not size_bytes or size_bytes <= 0:
+        return "unknown"
+    gb = size_bytes / (1024**3)
+    if gb < 1:
+        return f"{round(size_bytes / (1024**2))}MB"
+    return f"{gb:.1f}GB"
+
+
+def _probe_models_ollama() -> list[tuple[str, str, str]]:
+    ok, body = _http_get_ok("http://127.0.0.1:11434/api/tags")
+    if not ok or not body:
+        return []
+    try:
+        data = json.loads(body)
+    except Exception:
+        return []
+    rows: list[tuple[str, str, str]] = []
+    models = data.get("models") if isinstance(data, dict) else None
+    if not isinstance(models, list):
+        return []
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name") or entry.get("model")
+        size = entry.get("size")
+        if not isinstance(name, str):
+            continue
+        size_label = _label_size(size if isinstance(size, int) else None)
+        rows.append(("ollama", name, size_label))
+    return rows
+
+
+def _probe_models_lmstudio() -> list[tuple[str, str, str]]:
+    ok, body = _http_get_ok("http://127.0.0.1:1234/v1/models")
+    if not ok or not body:
+        return []
+    try:
+        data = json.loads(body)
+    except Exception:
+        return []
+    rows: list[tuple[str, str, str]] = []
+    items = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        return []
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        model_id = entry.get("id")
+        if not isinstance(model_id, str):
+            continue
+        # LM Studio's /v1/models doesn't expose size; leave label as unknown.
+        rows.append(("lmstudio", model_id, "unknown"))
+    return rows
+
+
+def _probe_models(runtimes: Sequence[str]) -> tuple[tuple[str, str, str], ...]:
+    """Best-effort model enumeration for runtimes that expose a list endpoint."""
+    rows: list[tuple[str, str, str]] = []
+    if "ollama" in runtimes:
+        try:
+            rows.extend(_probe_models_ollama())
+        except Exception:
+            logger.debug("ollama model probe failed", exc_info=True)
+    if "lmstudio" in runtimes:
+        try:
+            rows.extend(_probe_models_lmstudio())
+        except Exception:
+            logger.debug("lmstudio model probe failed", exc_info=True)
+    return tuple(rows)
+
+
+# ---------------------------------------------------------------------------
+# Tier mapping
+# ---------------------------------------------------------------------------
+
+
+def tier_for(profile: HardwareProfile) -> HardwareTier:
+    """Map a :class:`HardwareProfile` to a :data:`HardwareTier` (spec §6.1).
+
+    Rules (evaluated in order):
+
+    * ``unknown`` — RAM probe returned 0 GB (the OS probe is required for
+      construction but RAM == 0 is the strongest "we couldn't read anything"
+      signal).
+    * ``light`` — ``ram_gb < 16`` **or** (``gpu == "none"`` and ``cpu_class == "low"``)
+      **or** (``is_battery`` and ``ram_gb < 24``).
+    * ``high_performance`` — discrete or unified GPU
+      (``gpu in {"nvidia", "apple_silicon"}``) with ``gpu_vram_gb`` either
+      unknown (Apple Silicon shares RAM) or ``>= 16``, ``ram_gb >= 32``, and
+      not on battery.
+    * ``capable`` — everything else.
+    """
+    if profile.ram_gb <= 0:
+        return "unknown"
+    if profile.ram_gb < 16:
+        return "light"
+    if profile.gpu == "none" and profile.cpu_class == "low":
+        return "light"
+    if profile.is_battery and profile.ram_gb < 24:
+        return "light"
+    if (
+        profile.gpu in ("nvidia", "apple_silicon")
+        and (profile.gpu_vram_gb is None or profile.gpu_vram_gb >= 16)
+        and profile.ram_gb >= 32
+        and not profile.is_battery
+    ):
+        return "high_performance"
+    return "capable"
+
+
+# ---------------------------------------------------------------------------
+# Top-level detect()
+# ---------------------------------------------------------------------------
+
+
+def detect() -> HardwareProfile:
+    """Compose every probe and return a frozen :class:`HardwareProfile`.
+
+    Pure modulo system probes; no caching at module level. The daemon decides
+    when to cache (typically once at startup).
+    """
+    os_kind = _probe_os()
+    cpu_class, ram_gb = _probe_cpu_and_ram()
+    gpu, gpu_vram_gb = _probe_gpu()
+    is_battery = _probe_battery()
+    thermal = _probe_thermal()
+    runtimes = _probe_runtimes()
+    models = _probe_models(runtimes)
+
+    # When the OS probe fails entirely we still need a literal value for the
+    # frozen dataclass; fall back to "linux" but force the tier to "unknown"
+    # so consumers treat the snapshot as untrusted.
+    effective_os: OS = os_kind if os_kind is not None else "linux"
+
+    profile = HardwareProfile(
+        os=effective_os,
+        cpu_class=cpu_class,
+        ram_gb=ram_gb,
+        gpu=gpu,
+        gpu_vram_gb=gpu_vram_gb,
+        is_battery=is_battery,
+        thermal_constrained=thermal,
+        detected_runtimes=runtimes,
+        detected_models=models,
+        tier="unknown",
+    )
+    final_tier: HardwareTier = "unknown" if os_kind is None else tier_for(profile)
+    return HardwareProfile(
+        os=effective_os,
+        cpu_class=cpu_class,
+        ram_gb=ram_gb,
+        gpu=gpu,
+        gpu_vram_gb=gpu_vram_gb,
+        is_battery=is_battery,
+        thermal_constrained=thermal,
+        detected_runtimes=runtimes,
+        detected_models=models,
+        tier=final_tier,
+    )
+
+
+__all__ = [
+    "HardwareProfile",
+    "HardwareTier",
+    "detect",
+    "tier_for",
+]

--- a/src/vaner/setup/policy.py
+++ b/src/vaner/setup/policy.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — Setup primitives: VanerPolicyBundle dataclass (0.8.6).
+
+A *policy bundle* is the intermediate layer between Simple-Mode wizard
+answers and the engine's existing knobs. Each bundle:
+
+- Names an outcome-level archetype (e.g. *"Local Balanced"*, *"Hybrid
+  Quality"*) that a non-technical user can recognise.
+- Carries the seven dimensions the engine actually consults
+  (cloud posture, runtime profile, spend profile, latency profile,
+  privacy profile, prediction-horizon bias, drafting aggressiveness,
+  exploration ratio, persistence strength, goal weighting,
+  context-injection default, deep-run profile).
+- Composes additively with Deep-Run preset overrides at session start
+  (see :mod:`vaner.intent.deep_run_policy`); bundles set the *baseline*,
+  Deep-Run sessions layer additive overrides on top.
+
+The single source of truth for the seven shipped bundles is
+:data:`vaner.setup.catalog.PROFILE_CATALOG`. WS3's selection algorithm
+filters and scores that catalogue against the user's
+:class:`SetupAnswers` and :class:`HardwareProfile`.
+
+The bundle dataclass is **frozen**: bundles are pure data, never mutated.
+``PolicyConfig.bundle_overrides`` (a free-form dict on the config
+schema) carries the user's per-knob deviations from the selected
+bundle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+from vaner.intent.deep_run import DeepRunPreset
+
+# Mirror of ``ContextInjectionConfig.mode`` (see
+# :mod:`vaner.models.config`). Repeated here verbatim because the source
+# Literal is declared inline on the field rather than as a named alias.
+# Keep these two lists in sync; a mismatch surfaces as a Pydantic
+# validation error when the bundle's value flows into the integration
+# config.
+ContextInjectionMode = Literal[
+    "none",
+    "digest_only",
+    "adopted_package_only",
+    "top_match_auto_include",
+    "policy_hybrid",
+    "client_controlled",
+]
+
+# The four horizon-bias buckets surfaced to the engine's frontier
+# scoring. These are the same four values used by Deep-Run's
+# ``HorizonBiasSpec`` (see :mod:`vaner.intent.deep_run_policy`); the
+# bundle's ``prediction_horizon_bias`` mapping is a per-bundle weight
+# distribution over these buckets, *not* a single chosen mode. The
+# engine multiplies these weights into its frontier scoring at cycle
+# time.
+PredictionHorizonKey = Literal[
+    "likely_next",
+    "long_horizon",
+    "finish_partials",
+    "balanced",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class VanerPolicyBundle:
+    """One outcome-level policy bundle.
+
+    Field meanings (spec §8):
+
+    - ``id`` — stable kebab-case identifier; used as the foreign key in
+      ``PolicyConfig.selected_bundle_id``. Never displayed to users.
+    - ``label`` — short human-readable name (Title Case). Shown in the
+      desktop summary card and the CLI ``vaner setup show`` output.
+    - ``description`` — one-sentence explanation of who the bundle is
+      for. Shown under the label in any surface that has the room.
+    - ``local_cloud_posture`` — flows into ``BackendConfig.prefer_local``,
+      the ``ExplorationConfig.endpoints`` cloud filter, and the
+      Deep-Run default ``locality``.
+    - ``runtime_profile`` — selects the local-runtime preference band
+      (``"small"`` / ``"medium"`` / ``"large"``) the exploration pool
+      consults when more than one local model is detected.
+    - ``spend_profile`` — drives ``BackendConfig.remote_budget_per_hour``
+      and the Deep-Run default ``cost_cap_usd``.
+    - ``latency_profile`` — informs the exploration pool's
+      latency-vs-quality tie-break.
+    - ``privacy_profile`` — interacts with cloud_posture; sets the
+      strictness floor that the user cannot accidentally relax via a
+      bundle re-selection (see WS5 invariant test).
+    - ``prediction_horizon_bias`` — frozen mapping over the four
+      horizon-bias keys; weights compose multiplicatively with
+      Deep-Run's ``HorizonBiasSpec`` at session time.
+    - ``drafting_aggressiveness`` — multiplier on the drafter's
+      evidence threshold. ``1.0`` is neutral; ``< 1.0`` requires more
+      evidence (conservative drafts), ``> 1.0`` is more permissive.
+    - ``exploration_ratio`` — added to ``ExplorationConfig`` invest /
+      exploit balance.
+    - ``persistence_strength`` — multiplier on memory-decay resistance;
+      higher values keep predictions warm longer.
+    - ``goal_weighting`` — multiplier on goal-aligned prediction
+      scoring (see ``IntentConfig`` goal-weighting in 0.8.2+).
+    - ``context_injection_default`` — per-tier default for
+      ``IntegrationsConfig.context_injection.mode``. Capability tiers
+      may downgrade this floor at run time.
+    - ``deep_run_profile`` — default Deep-Run preset when the user
+      opens "Start Deep-Run".
+    """
+
+    id: str
+    label: str
+    description: str
+    local_cloud_posture: Literal[
+        "local_only",
+        "local_preferred",
+        "hybrid",
+        "cloud_preferred",
+    ]
+    runtime_profile: Literal["small", "medium", "large", "auto"]
+    spend_profile: Literal["zero", "low", "medium", "high"]
+    latency_profile: Literal["snappy", "balanced", "quality"]
+    privacy_profile: Literal["strict", "standard", "relaxed"]
+    prediction_horizon_bias: Mapping[PredictionHorizonKey, float]
+    drafting_aggressiveness: float
+    exploration_ratio: float
+    persistence_strength: float
+    goal_weighting: float
+    context_injection_default: ContextInjectionMode
+    deep_run_profile: DeepRunPreset
+
+    # Internal: bundles are intended to be defined as module-level
+    # constants. The ``__post_init__`` freeze step ensures any
+    # ``prediction_horizon_bias`` passed as a plain ``dict`` is wrapped
+    # in a ``MappingProxyType`` so the bundle remains structurally
+    # immutable (the dataclass itself is already frozen against
+    # attribute reassignment).
+    def __post_init__(self) -> None:
+        # Use object.__setattr__ because the dataclass is frozen.
+        if not isinstance(self.prediction_horizon_bias, MappingProxyType):
+            object.__setattr__(
+                self,
+                "prediction_horizon_bias",
+                MappingProxyType(dict(self.prediction_horizon_bias)),
+            )
+        # Validate the mapping keys match exactly the four expected
+        # literals — guards against typos in catalogue entries.
+        expected_keys = {"likely_next", "long_horizon", "finish_partials", "balanced"}
+        actual_keys = set(self.prediction_horizon_bias.keys())
+        if actual_keys != expected_keys:
+            missing = expected_keys - actual_keys
+            extra = actual_keys - expected_keys
+            raise ValueError(
+                f"VanerPolicyBundle.prediction_horizon_bias keys must be exactly "
+                f"{sorted(expected_keys)}; missing={sorted(missing)} extra={sorted(extra)}"
+            )
+
+
+# Re-export for convenience; downstream modules can import everything
+# they need from ``vaner.setup.policy``.
+__all__ = [
+    "ContextInjectionMode",
+    "PredictionHorizonKey",
+    "VanerPolicyBundle",
+]

--- a/src/vaner/setup/select.py
+++ b/src/vaner/setup/select.py
@@ -1,0 +1,535 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS3 — Setup primitives: policy-bundle selection (0.8.6).
+
+Pure ``filter -> score -> pick`` pipeline that maps a
+:class:`SetupAnswers` plus a :class:`HardwareProfile` snapshot to one of
+the seven bundles in :data:`vaner.setup.catalog.PROFILE_CATALOG` (spec
+§10). The function is deterministic by construction — no I/O, no
+clocks, no randomness, no nondeterministic dict iteration. Same input
+always produces a byte-identical :class:`SelectionResult`, including
+the ``reasons`` tuple and the ``runner_ups`` ordering.
+
+Design notes:
+
+- **Filter** drops bundles that would violate hard user posture (e.g.
+  the user said *local only* and the bundle uses a cloud-preferred
+  posture) or hard hardware limits (e.g. ``unknown`` tier means we
+  cannot promise large-local will work, so we don't recommend it).
+  Each filter is a small named callable so it can be unit-tested in
+  isolation.
+- **Score** runs six small ``_*_match`` callables, each returning a
+  ``(score, reason)`` pair in ``[-1.0, 1.0]``. Total range across the
+  six is roughly ``[-6, +6]``; ties break alphabetically on bundle id
+  for determinism.
+- **Forced fallback** — if filters empty the candidate set, we re-run
+  with priority + hardware filters relaxed (cloud posture is the one
+  hard-line the user explicitly stated). If even that produces
+  nothing, we return :data:`local_lightweight` as the safest possible
+  default and flag ``forced_fallback=True``.
+
+The match weights are intentionally small integer-ish floats: the goal
+is for the *filter* to do most of the work and the *score* to break
+the remaining ties in a way the user can read in the disclosure
+panel. We deliberately avoid neural / continuous knobs here — the
+user-facing reasons must remain explainable.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.catalog import PROFILE_CATALOG, bundle_by_id
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    HardwareTier,
+    Priority,
+    WorkStyle,
+)
+from vaner.setup.hardware import HardwareProfile
+from vaner.setup.policy import VanerPolicyBundle
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionResult:
+    """Output of :func:`select_policy_bundle`.
+
+    - ``bundle`` — the chosen :class:`VanerPolicyBundle`.
+    - ``score`` — aggregate match score for the chosen bundle. Ranges
+      roughly across ``[-6.0, +6.0]``; values are diagnostic only and
+      should not be exposed verbatim to end users.
+    - ``reasons`` — short human-readable strings explaining *why* this
+      bundle won. Empty tuple means we hit the forced-fallback path.
+    - ``runner_ups`` — up to two next-best bundles in score order,
+      excluding the chosen one. Drives the desktop disclosure panel.
+    - ``forced_fallback`` — ``True`` only when the filters emptied the
+      candidate set entirely and we returned the safe default. The
+      desktop UI should surface this as a warning.
+    """
+
+    bundle: VanerPolicyBundle
+    score: float
+    reasons: tuple[str, ...]
+    runner_ups: tuple[VanerPolicyBundle, ...]
+    forced_fallback: bool
+
+
+# ---------------------------------------------------------------------------
+# Filters — each takes (answers, hardware, bundle) and returns either
+# None (keep) or a string explaining why the bundle was dropped.
+# ---------------------------------------------------------------------------
+
+
+_FilterFn = Callable[
+    [SetupAnswers, HardwareProfile, VanerPolicyBundle],
+    str | None,
+]
+
+
+def _filter_cloud_posture(
+    answers: SetupAnswers,
+    _hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """Drop bundles that violate the user's stated cloud posture."""
+    cloud = answers.cloud_posture
+    posture = bundle.local_cloud_posture
+    if cloud == "local_only" and posture in ("hybrid", "cloud_preferred"):
+        return f"{bundle.id} uses cloud ({posture}); user requested local_only"
+    if cloud == "ask_first" and posture == "cloud_preferred":
+        return f"{bundle.id} prefers cloud; user said ask_first"
+    return None
+
+
+def _filter_priority_privacy(
+    answers: SetupAnswers,
+    _hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """Drop bundles that expose data more loosely than ``privacy``."""
+    if answers.priority != "privacy":
+        return None
+    # Privacy-conscious users get strict-or-standard floors only. The
+    # current catalogue ships no "relaxed" bundles, but we keep the
+    # filter so future additions (e.g. a "cloud-first" preset) cannot
+    # silently match a privacy-priority user.
+    if bundle.privacy_profile == "relaxed":
+        return f"{bundle.id} is privacy=relaxed; user prioritised privacy"
+    # "Cloud OK" interpretation — bundles whose cloud posture is the
+    # cloud-preferred bucket are also dropped under priority=privacy.
+    if bundle.local_cloud_posture == "cloud_preferred":
+        return f"{bundle.id} prefers cloud; user prioritised privacy"
+    return None
+
+
+def _filter_priority_low_resource(
+    answers: SetupAnswers,
+    _hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """Drop heavy-local bundles when the user said low_resource."""
+    if answers.priority != "low_resource":
+        return None
+    if bundle.runtime_profile == "large" and bundle.local_cloud_posture in (
+        "local_only",
+        "local_preferred",
+    ):
+        return f"{bundle.id} is heavy local; user prioritised low_resource"
+    return None
+
+
+def _filter_hardware_tier(
+    _answers: SetupAnswers,
+    hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """Drop bundles the device cannot reasonably run.
+
+    - ``light`` hardware — drop ``runtime_profile=large`` regardless of
+      posture. A small laptop should not promise local 30B-plus.
+    - ``unknown`` tier — drop ``runtime_profile=large`` (we cannot
+      promise it works) and ``local_cloud_posture=local_only`` (we
+      cannot promise local works at all without detection); steer the
+      user toward cloud-recommended defaults.
+    """
+    tier = hardware.tier
+    if tier == "light" and bundle.runtime_profile == "large":
+        return f"{bundle.id} needs large runtime; hardware tier is light"
+    if tier == "unknown":
+        if bundle.runtime_profile == "large":
+            return f"{bundle.id} needs large runtime; hardware tier unknown"
+        if bundle.local_cloud_posture == "local_only":
+            return f"{bundle.id} is local_only; hardware tier unknown"
+    return None
+
+
+def _filter_battery_cost(
+    answers: SetupAnswers,
+    hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> str | None:
+    """On battery + cost priority, drop cloud-spending bundles."""
+    if answers.priority != "cost":
+        return None
+    if not hardware.is_battery:
+        return None
+    if hardware.tier != "light":
+        return None
+    if bundle.spend_profile in ("medium", "high"):
+        return f"{bundle.id} spends on cloud; user is on battery + cost"
+    return None
+
+
+# Order matters only for filter dropped-reason output; logic is
+# commutative. Tuple is immutable so the iteration order is fixed.
+_FILTERS: tuple[_FilterFn, ...] = (
+    _filter_cloud_posture,
+    _filter_priority_privacy,
+    _filter_priority_low_resource,
+    _filter_hardware_tier,
+    _filter_battery_cost,
+)
+
+
+def _apply_filters(
+    answers: SetupAnswers,
+    hardware: HardwareProfile,
+    candidates: Iterable[VanerPolicyBundle],
+    filters: tuple[_FilterFn, ...] = _FILTERS,
+) -> tuple[tuple[VanerPolicyBundle, ...], tuple[tuple[str, str], ...]]:
+    """Run all filters; return (kept, dropped_with_reason).
+
+    ``dropped_with_reason`` is a tuple of ``(bundle_id, reason)`` pairs
+    so callers (mostly tests) can introspect which filters fired.
+    """
+    kept: list[VanerPolicyBundle] = []
+    dropped: list[tuple[str, str]] = []
+    for bundle in candidates:
+        drop_reason: str | None = None
+        for fn in filters:
+            reason = fn(answers, hardware, bundle)
+            if reason is not None:
+                drop_reason = reason
+                break
+        if drop_reason is None:
+            kept.append(bundle)
+        else:
+            dropped.append((bundle.id, drop_reason))
+    return tuple(kept), tuple(dropped)
+
+
+# ---------------------------------------------------------------------------
+# Match functions — each returns (score in [-1.0, 1.0], reason)
+# ---------------------------------------------------------------------------
+
+
+def _priority_match(priority: Priority, bundle: VanerPolicyBundle) -> tuple[float, str]:
+    """Match the user's top-level priority against the bundle profile."""
+    if priority == "speed":
+        if bundle.latency_profile == "snappy":
+            return 1.0, f"Speed-first → {bundle.id} is snappy"
+        if bundle.latency_profile == "balanced":
+            return 0.3, f"Speed-first → {bundle.id} is balanced"
+        return -0.5, f"Speed-first → {bundle.id} prioritises quality"
+    if priority == "quality":
+        if bundle.latency_profile == "quality":
+            return 1.0, f"Quality-first → {bundle.id} prioritises quality"
+        if bundle.latency_profile == "balanced":
+            return 0.2, f"Quality-first → {bundle.id} is balanced"
+        return -0.3, f"Quality-first → {bundle.id} is snappy"
+    if priority == "privacy":
+        if bundle.privacy_profile == "strict":
+            return 1.0, f"Privacy-first → {bundle.id} is strict"
+        if bundle.privacy_profile == "standard":
+            return 0.2, f"Privacy-first → {bundle.id} is standard"
+        return -1.0, f"Privacy-first → {bundle.id} is relaxed"
+    if priority == "cost":
+        if bundle.spend_profile == "zero":
+            return 1.0, f"Cost-first → {bundle.id} spends nothing"
+        if bundle.spend_profile == "low":
+            return 0.5, f"Cost-first → {bundle.id} spends little"
+        return -0.5, f"Cost-first → {bundle.id} spends mid/high"
+    if priority == "low_resource":
+        if bundle.runtime_profile == "small":
+            return 1.0, f"Low-resource → {bundle.id} runs small"
+        if bundle.runtime_profile == "medium":
+            return 0.0, f"Low-resource → {bundle.id} runs medium"
+        return -0.7, f"Low-resource → {bundle.id} runs large"
+    # priority == "balanced"
+    if bundle.id == "hybrid_balanced":
+        return 1.0, "Balanced priority → hybrid_balanced is the canonical default"
+    if bundle.latency_profile == "balanced":
+        return 0.4, f"Balanced priority → {bundle.id} is balanced"
+    return 0.0, f"Balanced priority → {bundle.id} is acceptable"
+
+
+def _hardware_match(tier: HardwareTier, bundle: VanerPolicyBundle) -> tuple[float, str]:
+    """Map hardware tier to runtime profile preference."""
+    if tier == "high_performance":
+        if bundle.runtime_profile == "large":
+            return 1.0, f"High-performance hardware → {bundle.id} runs large"
+        if bundle.runtime_profile == "medium":
+            return 0.2, f"High-performance hardware → {bundle.id} runs medium"
+        return -0.4, f"High-performance hardware → {bundle.id} runs small"
+    if tier == "capable":
+        if bundle.runtime_profile == "medium":
+            return 1.0, f"Capable hardware → {bundle.id} runs medium"
+        if bundle.runtime_profile == "small":
+            return 0.3, f"Capable hardware → {bundle.id} runs small"
+        return -0.2, f"Capable hardware → {bundle.id} runs large"
+    if tier == "light":
+        if bundle.runtime_profile == "small":
+            return 1.0, f"Light hardware → {bundle.id} runs small"
+        if bundle.runtime_profile == "medium":
+            return -0.3, f"Light hardware → {bundle.id} runs medium"
+        return -1.0, f"Light hardware → {bundle.id} runs large"
+    # tier == "unknown"
+    if bundle.local_cloud_posture in ("hybrid", "cloud_preferred"):
+        return 0.6, f"Unknown hardware → {bundle.id} can lean on cloud"
+    if bundle.runtime_profile == "small":
+        return 0.2, f"Unknown hardware → {bundle.id} stays modest"
+    return -0.2, f"Unknown hardware → {bundle.id} assumes more than we know"
+
+
+_WORKSTYLE_BUNDLE_AFFINITY: dict[WorkStyle, dict[str, float]] = {
+    "writing": {"deep_research": 1.0, "hybrid_quality": 0.6, "local_balanced": 0.2},
+    "research": {"deep_research": 1.0, "hybrid_quality": 0.6, "local_heavy": 0.4},
+    "planning": {"deep_research": 0.8, "hybrid_balanced": 0.4, "local_balanced": 0.4},
+    "support": {"hybrid_balanced": 0.6, "local_balanced": 0.4, "cost_saver": 0.4},
+    "learning": {"local_balanced": 0.6, "hybrid_balanced": 0.4, "cost_saver": 0.2},
+    "coding": {"local_balanced": 0.8, "hybrid_quality": 0.4, "local_heavy": 0.4},
+    "general": {"hybrid_balanced": 0.6, "local_balanced": 0.4},
+    "mixed": {"hybrid_balanced": 0.6, "local_balanced": 0.4},
+    "unsure": {"hybrid_balanced": 0.8, "local_balanced": 0.2},
+}
+
+
+def _workstyle_match(
+    work_styles: tuple[WorkStyle, ...],
+    bundle: VanerPolicyBundle,
+) -> tuple[float, str]:
+    """Average per-work-style affinity scores into one (score, reason).
+
+    Multiple work styles average their per-bundle weights — explicit
+    and predictable per the plan's guidance.
+    """
+    if not work_styles:
+        return 0.0, f"No work styles → no affinity for {bundle.id}"
+    per_style: list[float] = [_WORKSTYLE_BUNDLE_AFFINITY.get(ws, {}).get(bundle.id, 0.0) for ws in work_styles]
+    avg = sum(per_style) / len(per_style)
+    # Clamp to the contracted range.
+    avg = max(-1.0, min(1.0, avg))
+    if avg > 0:
+        styles_label = "/".join(work_styles)
+        return avg, f"Work style {styles_label} → {bundle.id} fits"
+    return avg, f"Work styles do not particularly favour {bundle.id}"
+
+
+def _cloud_match(cloud: CloudPosture, bundle: VanerPolicyBundle) -> tuple[float, str]:
+    """Reward bundles that match the user's cloud posture preference."""
+    posture = bundle.local_cloud_posture
+    if cloud == "local_only":
+        if posture == "local_only":
+            return 1.0, f"Local-only requested → {bundle.id} is local_only"
+        if posture == "local_preferred":
+            return 0.3, f"Local-only requested → {bundle.id} is local-preferred"
+        return -1.0, f"Local-only requested → {bundle.id} reaches for cloud"
+    if cloud == "ask_first":
+        if posture == "local_preferred":
+            return 1.0, f"Ask-first → {bundle.id} prefers local but can hybrid"
+        if posture in ("local_only", "hybrid"):
+            return 0.4, f"Ask-first → {bundle.id} keeps cloud opt-in"
+        return -0.5, f"Ask-first → {bundle.id} leans cloud"
+    if cloud == "hybrid_when_worth_it":
+        if posture == "hybrid":
+            return 1.0, f"Hybrid-when-worth-it → {bundle.id} is hybrid"
+        if posture == "local_preferred":
+            return 0.4, f"Hybrid-when-worth-it → {bundle.id} prefers local"
+        if posture == "cloud_preferred":
+            return 0.2, f"Hybrid-when-worth-it → {bundle.id} prefers cloud"
+        return -0.2, f"Hybrid-when-worth-it → {bundle.id} is local_only"
+    # cloud == "best_available"
+    if posture == "cloud_preferred":
+        return 1.0, f"Best-available → {bundle.id} prefers cloud"
+    if posture == "hybrid":
+        return 0.6, f"Best-available → {bundle.id} is hybrid"
+    return -0.4, f"Best-available → {bundle.id} stays local"
+
+
+def _resource_match(
+    compute: ComputePosture,
+    bundle: VanerPolicyBundle,
+) -> tuple[float, str]:
+    """Map compute posture to runtime / horizon weight."""
+    if compute == "light":
+        if bundle.runtime_profile == "small":
+            return 1.0, f"Light compute posture → {bundle.id} runs small"
+        if bundle.runtime_profile == "medium":
+            return 0.0, f"Light compute posture → {bundle.id} runs medium"
+        return -0.6, f"Light compute posture → {bundle.id} runs large"
+    if compute == "available_power":
+        if bundle.runtime_profile == "large":
+            return 1.0, f"Available-power posture → {bundle.id} runs large"
+        if bundle.runtime_profile == "medium":
+            return 0.3, f"Available-power posture → {bundle.id} runs medium"
+        return -0.2, f"Available-power posture → {bundle.id} runs small"
+    # compute == "balanced"
+    if bundle.runtime_profile == "medium":
+        return 0.6, f"Balanced compute posture → {bundle.id} runs medium"
+    return 0.1, f"Balanced compute posture → {bundle.id} is acceptable"
+
+
+def _background_match(
+    background: BackgroundPosture,
+    bundle: VanerPolicyBundle,
+) -> tuple[float, str]:
+    """Map background-pondering posture to deep-run profile."""
+    deep = bundle.deep_run_profile
+    if background == "minimal":
+        if deep == "conservative":
+            return 1.0, f"Minimal background → {bundle.id} is conservative"
+        if deep == "balanced":
+            return 0.0, f"Minimal background → {bundle.id} is balanced"
+        return -0.6, f"Minimal background → {bundle.id} is aggressive"
+    if background == "normal":
+        if deep == "balanced":
+            return 1.0, f"Normal background → {bundle.id} is balanced"
+        return 0.2, f"Normal background → {bundle.id} is {deep}"
+    if background == "idle_more":
+        if deep == "balanced":
+            return 0.6, f"Idle-more background → {bundle.id} is balanced"
+        if deep == "aggressive":
+            return 0.8, f"Idle-more background → {bundle.id} is aggressive"
+        return -0.2, f"Idle-more background → {bundle.id} is conservative"
+    # background == "deep_run_aggressive"
+    if bundle.id in ("deep_research", "hybrid_quality"):
+        return 1.0, f"Deep-run-aggressive → {bundle.id} matches"
+    if deep == "aggressive":
+        return 0.7, f"Deep-run-aggressive → {bundle.id} is aggressive"
+    if deep == "balanced":
+        return 0.0, f"Deep-run-aggressive → {bundle.id} is balanced"
+    return -0.5, f"Deep-run-aggressive → {bundle.id} is conservative"
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+def _score_bundle(
+    answers: SetupAnswers,
+    hardware: HardwareProfile,
+    bundle: VanerPolicyBundle,
+) -> tuple[float, tuple[str, ...]]:
+    """Run every match function and return the summed score + reasons.
+
+    Only reasons whose component score is strictly positive are
+    included — the disclosure panel should explain why this bundle
+    *won*, not the long list of negatives. Reason order is fixed so
+    the result is byte-deterministic.
+    """
+    components: list[tuple[float, str]] = [
+        _priority_match(answers.priority, bundle),
+        _hardware_match(hardware.tier, bundle),
+        _workstyle_match(answers.work_styles, bundle),
+        _cloud_match(answers.cloud_posture, bundle),
+        _resource_match(answers.compute_posture, bundle),
+        _background_match(answers.background_posture, bundle),
+    ]
+    total = sum(score for score, _ in components)
+    positive_reasons = tuple(reason for score, reason in components if score > 0.0)
+    return total, positive_reasons
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+_FORCED_FALLBACK_BUNDLE_ID: str = "local_lightweight"
+
+
+def select_policy_bundle(
+    answers: SetupAnswers,
+    hardware: HardwareProfile,
+) -> SelectionResult:
+    """Pick the best-fit policy bundle for the given answers + hardware.
+
+    Pure function — same inputs always produce the exact same
+    :class:`SelectionResult` (including ``reasons`` and ``runner_ups``
+    ordering). Implementation is filter → score → pick with a
+    deterministic alphabetical-id tiebreaker.
+    """
+
+    kept, _dropped = _apply_filters(answers, hardware, PROFILE_CATALOG)
+
+    forced_fallback = False
+    if not kept:
+        # Relax the priority + hardware filters; cloud posture is the
+        # one explicit user wish we do not silently widen.
+        relaxed_filters: tuple[_FilterFn, ...] = (_filter_cloud_posture,)
+        kept, _dropped = _apply_filters(
+            answers,
+            hardware,
+            PROFILE_CATALOG,
+            filters=relaxed_filters,
+        )
+
+    if not kept:
+        # Even cloud-posture-only filtering wiped the catalogue
+        # (theoretical — cloud_posture filters never drop more than
+        # five bundles). Hand back the safe local default and flag.
+        forced_fallback = True
+        fallback = bundle_by_id(_FORCED_FALLBACK_BUNDLE_ID)
+        return SelectionResult(
+            bundle=fallback,
+            score=0.0,
+            reasons=("No bundle matched filters; returning safest local default.",),
+            runner_ups=(),
+            forced_fallback=True,
+        )
+
+    scored: list[tuple[float, str, VanerPolicyBundle, tuple[str, ...]]] = []
+    for bundle in kept:
+        score, reasons = _score_bundle(answers, hardware, bundle)
+        scored.append((score, bundle.id, bundle, reasons))
+
+    # Deterministic ordering: highest score first; alphabetical id
+    # breaks ties. Sorting on a (negated-score, id) key gives a
+    # stable, total order — Python's sort is also stable so even
+    # equal keys preserve catalogue order.
+    scored.sort(key=lambda item: (-item[0], item[1]))
+
+    chosen_score, _chosen_id, chosen_bundle, chosen_reasons = scored[0]
+    runner_ups = tuple(item[2] for item in scored[1:3])
+
+    logger.debug(
+        "select_policy_bundle picked %s with score %.3f (forced_fallback=%s)",
+        chosen_bundle.id,
+        chosen_score,
+        forced_fallback,
+    )
+    return SelectionResult(
+        bundle=chosen_bundle,
+        score=chosen_score,
+        reasons=chosen_reasons,
+        runner_ups=runner_ups,
+        forced_fallback=forced_fallback,
+    )
+
+
+__all__ = [
+    "SelectionResult",
+    "select_policy_bundle",
+]

--- a/src/vaner/setup/serializers.py
+++ b/src/vaner/setup/serializers.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS7 — JSON serialisation helpers for the Setup surfaces (0.8.6).
+
+WS6 (`vaner setup` CLI) and WS7 (`vaner.setup.*` MCP tools) both emit
+the same JSON shapes. To keep them byte-identical we centralise the
+``_bundle_to_dict``, ``_selection_to_dict``, ``_hardware_to_dict``, and
+``_answers_from_payload`` helpers here and re-export them from
+:mod:`vaner.cli.commands.setup` (where WS6 grew them in private form).
+
+Importing the CLI module pulls in :mod:`typer` and :mod:`rich`, which
+the MCP server should not depend on. Centralising the serialisers in
+this leaf module keeps the MCP surface light and the CLI/MCP outputs
+contractually identical.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.hardware import HardwareProfile
+from vaner.setup.policy import VanerPolicyBundle
+from vaner.setup.select import SelectionResult
+
+__all__ = [
+    "answers_from_payload",
+    "bundle_to_dict",
+    "hardware_to_dict",
+    "selection_to_dict",
+]
+
+
+class AnswersValidationError(ValueError):
+    """Raised by :func:`answers_from_payload` on a malformed payload.
+
+    Distinct from :class:`ValueError` so MCP / HTTP callers can map it
+    to a structured ``invalid_input`` response without catching every
+    ValueError the underlying dataclass might emit.
+    """
+
+
+def bundle_to_dict(bundle: VanerPolicyBundle) -> dict[str, Any]:
+    """Serialise a :class:`VanerPolicyBundle` to a JSON-safe dict."""
+
+    return {
+        "id": bundle.id,
+        "label": bundle.label,
+        "description": bundle.description,
+        "local_cloud_posture": bundle.local_cloud_posture,
+        "runtime_profile": bundle.runtime_profile,
+        "spend_profile": bundle.spend_profile,
+        "latency_profile": bundle.latency_profile,
+        "privacy_profile": bundle.privacy_profile,
+        "prediction_horizon_bias": dict(bundle.prediction_horizon_bias),
+        "drafting_aggressiveness": bundle.drafting_aggressiveness,
+        "exploration_ratio": bundle.exploration_ratio,
+        "persistence_strength": bundle.persistence_strength,
+        "goal_weighting": bundle.goal_weighting,
+        "context_injection_default": bundle.context_injection_default,
+        "deep_run_profile": bundle.deep_run_profile,
+    }
+
+
+def selection_to_dict(result: SelectionResult) -> dict[str, Any]:
+    """Serialise a :class:`SelectionResult` for the recommend surface.
+
+    The shape is the contract MCP wiring (WS7), the CLI's ``vaner setup
+    recommend``, and desktop apps consume — keep it stable.
+    """
+
+    return {
+        "bundle": bundle_to_dict(result.bundle),
+        "score": result.score,
+        "reasons": list(result.reasons),
+        "runner_ups": [bundle_to_dict(b) for b in result.runner_ups],
+        "forced_fallback": result.forced_fallback,
+    }
+
+
+def hardware_to_dict(hw: HardwareProfile) -> dict[str, Any]:
+    """Serialise a :class:`HardwareProfile` for the hardware surface."""
+
+    return {
+        "os": hw.os,
+        "cpu_class": hw.cpu_class,
+        "ram_gb": hw.ram_gb,
+        "gpu": hw.gpu,
+        "gpu_vram_gb": hw.gpu_vram_gb,
+        "is_battery": hw.is_battery,
+        "thermal_constrained": hw.thermal_constrained,
+        "detected_runtimes": list(hw.detected_runtimes),
+        "detected_models": [list(row) for row in hw.detected_models],
+        "tier": hw.tier,
+    }
+
+
+def answers_from_payload(raw: object) -> SetupAnswers:
+    """Build a :class:`SetupAnswers` from a JSON-shaped dict.
+
+    Accepts the public WS6 ``SetupAnswers`` shape: ``work_styles`` may
+    be a single string or a list of strings; missing fields fall back
+    to safe defaults (``priority='balanced'``, ``compute_posture='balanced'``,
+    ``cloud_posture='ask_first'``, ``background_posture='normal'``).
+
+    Raises :class:`AnswersValidationError` on a malformed payload (not
+    a dict, ``work_styles`` not a list/string).
+    """
+
+    if not isinstance(raw, dict):
+        raise AnswersValidationError("answers payload must be a JSON object")
+    work_styles = raw.get("work_styles") or ["mixed"]
+    if isinstance(work_styles, str):
+        work_styles = [work_styles]
+    if not isinstance(work_styles, list) or not all(isinstance(s, str) for s in work_styles):
+        raise AnswersValidationError("work_styles must be a list of strings")
+    return SetupAnswers(
+        work_styles=tuple(work_styles),  # type: ignore[arg-type]
+        priority=str(raw.get("priority", "balanced")),  # type: ignore[arg-type]
+        compute_posture=str(raw.get("compute_posture", "balanced")),  # type: ignore[arg-type]
+        cloud_posture=str(raw.get("cloud_posture", "ask_first")),  # type: ignore[arg-type]
+        background_posture=str(raw.get("background_posture", "normal")),  # type: ignore[arg-type]
+    )

--- a/tests/test_cli/test_setup_cli.py
+++ b/tests/test_cli/test_setup_cli.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `vaner setup` CLI (0.8.6 WS6)."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from vaner.cli.commands.app import app
+from vaner.cli.commands.setup import setup_app
+from vaner.setup.hardware import HardwareProfile
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_hardware(monkeypatch: pytest.MonkeyPatch) -> HardwareProfile:
+    """Pin hardware detection to a deterministic capable-tier profile.
+
+    Mocking ``detect`` keeps the wizard tests independent of the host
+    machine — test outcomes shouldn't change because the runner has a
+    GPU, more RAM, etc.
+    """
+
+    profile = HardwareProfile(
+        os="linux",
+        cpu_class="mid",
+        ram_gb=16,
+        gpu="integrated",
+        gpu_vram_gb=None,
+        is_battery=False,
+        thermal_constrained=False,
+        detected_runtimes=(),
+        detected_models=(),
+        tier="capable",
+    )
+    monkeypatch.setattr("vaner.cli.commands.setup.detect", lambda: profile)
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# wizard
+# ---------------------------------------------------------------------------
+
+
+def test_accept_defaults_writes_config(tmp_path: Path, fake_hardware: HardwareProfile) -> None:
+    """`vaner setup wizard --accept-defaults` non-interactively writes config."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        setup_app,
+        ["wizard", "--accept-defaults", "--path", str(repo), "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+    config_path = repo / ".vaner" / "config.toml"
+    assert config_path.exists()
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert parsed["setup"]["mode"] == "simple"
+    assert parsed["setup"]["work_styles"] == ["mixed"]
+    assert parsed["setup"]["priority"] == "balanced"
+    assert parsed["setup"]["completed_at"]
+    # The default answers + capable hardware should pick hybrid_balanced.
+    assert parsed["policy"]["selected_bundle_id"] == "hybrid_balanced"
+
+
+def test_wizard_with_scripted_answers(tmp_path: Path, fake_hardware: HardwareProfile) -> None:
+    """Drive the interactive wizard with scripted stdin answers."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Q1 work_styles: "coding" (token 6), Q2 priority: speed (2),
+    # Q3 compute: balanced (2), Q4 cloud: local_only (1),
+    # Q5 background: normal (2). Then 'y' to write.
+    scripted = "\n".join(["6", "2", "2", "1", "2", "y", ""]) + "\n"
+    result = runner.invoke(
+        setup_app,
+        ["wizard", "--path", str(repo)],
+        input=scripted,
+    )
+    assert result.exit_code == 0, result.output
+    config_path = repo / ".vaner" / "config.toml"
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert parsed["setup"]["work_styles"] == ["coding"]
+    assert parsed["setup"]["priority"] == "speed"
+    assert parsed["setup"]["cloud_posture"] == "local_only"
+    # local_only + speed + capable should pick a local bundle (not a
+    # cloud-preferred one). Concrete winner depends on the scoring;
+    # we only assert the cloud-posture filter held.
+    chosen = parsed["policy"]["selected_bundle_id"]
+    assert chosen in {"local_balanced", "local_lightweight", "cost_saver"}
+
+
+def test_wizard_aborts_on_cloud_widening_decline(
+    tmp_path: Path,
+    fake_hardware: HardwareProfile,
+) -> None:
+    """Decline the cloud-widening warning and config stays unchanged."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".vaner").mkdir()
+    config_path = repo / ".vaner" / "config.toml"
+    # Pre-seed with local_lightweight so the wizard's selection
+    # widens posture (local_only -> hybrid).
+    config_path.write_text(
+        '[setup]\nmode = "simple"\nwork_styles = ["mixed"]\n[policy]\nselected_bundle_id = "local_lightweight"\n',
+        encoding="utf-8",
+    )
+    snapshot = config_path.read_text(encoding="utf-8")
+
+    # Q1 mixed (8), Q2 balanced (1), Q3 balanced (2), Q4 hybrid (3),
+    # Q5 normal (2), then 'n' to decline cloud-widening warning.
+    scripted = "\n".join(["8", "1", "2", "3", "2", "n", ""]) + "\n"
+    result = runner.invoke(
+        setup_app,
+        ["wizard", "--path", str(repo)],
+        input=scripted,
+    )
+    assert result.exit_code == 1, result.output
+    # Config must be byte-identical — wizard aborted before write.
+    assert config_path.read_text(encoding="utf-8") == snapshot
+
+
+# ---------------------------------------------------------------------------
+# recommend
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_emits_valid_json(fake_hardware: HardwareProfile) -> None:
+    """`vaner setup recommend` reads stdin JSON, writes valid SelectionResult JSON."""
+
+    payload = {
+        "work_styles": ["research"],
+        "priority": "quality",
+        "compute_posture": "available_power",
+        "cloud_posture": "hybrid_when_worth_it",
+        "background_posture": "deep_run_aggressive",
+    }
+    result = runner.invoke(setup_app, ["recommend"], input=json.dumps(payload))
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert "bundle" in parsed
+    assert "id" in parsed["bundle"]
+    assert "label" in parsed["bundle"]
+    assert "score" in parsed
+    assert "reasons" in parsed
+    assert "runner_ups" in parsed
+    assert "forced_fallback" in parsed
+    assert isinstance(parsed["reasons"], list)
+    assert isinstance(parsed["runner_ups"], list)
+
+
+def test_recommend_with_answers_path(tmp_path: Path, fake_hardware: HardwareProfile) -> None:
+    """`--answers <path>` reads from disk instead of stdin."""
+
+    answers_file = tmp_path / "answers.json"
+    answers_file.write_text(
+        json.dumps(
+            {
+                "work_styles": ["coding"],
+                "priority": "speed",
+                "compute_posture": "balanced",
+                "cloud_posture": "local_only",
+                "background_posture": "normal",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(setup_app, ["recommend", "--answers", str(answers_file)])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    # local_only filter must hold.
+    assert parsed["bundle"]["local_cloud_posture"] in {"local_only", "local_preferred"}
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+def test_apply_with_explicit_bundle_id(
+    tmp_path: Path,
+    fake_hardware: HardwareProfile,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`apply --bundle-id <id>` skips selection and pins the bundle."""
+
+    # Avoid a live daemon ping in tests.
+    monkeypatch.setattr(
+        "vaner.cli.commands.setup._ping_daemon_for_refresh",
+        lambda: {"reachable": False, "url": "test"},
+    )
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        setup_app,
+        ["apply", "--bundle-id", "deep_research", "--path", str(repo)],
+    )
+    assert result.exit_code == 0, result.output
+    parsed = tomllib.loads((repo / ".vaner" / "config.toml").read_text(encoding="utf-8"))
+    assert parsed["policy"]["selected_bundle_id"] == "deep_research"
+
+
+def test_apply_unknown_bundle_id_fails_cleanly(
+    tmp_path: Path,
+    fake_hardware: HardwareProfile,
+) -> None:
+    """`apply --bundle-id nonexistent` exits non-zero with a clear error."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        setup_app,
+        ["apply", "--bundle-id", "nonexistent", "--path", str(repo)],
+    )
+    assert result.exit_code != 0
+    assert "unknown bundle id" in (result.output + (result.stderr if result.stderr else "")).lower()
+
+
+def test_apply_with_answers_path(
+    tmp_path: Path,
+    fake_hardware: HardwareProfile,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`apply --answers <path>` runs selection + persists without prompts."""
+
+    monkeypatch.setattr(
+        "vaner.cli.commands.setup._ping_daemon_for_refresh",
+        lambda: {"reachable": False, "url": "test"},
+    )
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    answers_file = tmp_path / "answers.json"
+    answers_file.write_text(
+        json.dumps(
+            {
+                "work_styles": ["coding"],
+                "priority": "balanced",
+                "compute_posture": "balanced",
+                "cloud_posture": "ask_first",
+                "background_posture": "normal",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        setup_app,
+        ["apply", "--answers", str(answers_file), "--path", str(repo), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["selected_bundle_id"]
+    assert "config_path" in parsed
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+def test_show_with_no_config(tmp_path: Path, fake_hardware: HardwareProfile) -> None:
+    """`vaner setup show` on a fresh dir reports setup not yet completed."""
+
+    repo = tmp_path / "fresh"
+    repo.mkdir()
+    result = runner.invoke(setup_app, ["show", "--path", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert "Setup not yet completed" in result.output
+
+
+def test_show_json_with_config(
+    tmp_path: Path,
+    fake_hardware: HardwareProfile,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After `wizard --accept-defaults`, `show --json` includes setup + policy."""
+
+    monkeypatch.setattr(
+        "vaner.cli.commands.setup._ping_daemon_for_refresh",
+        lambda: {"reachable": False, "url": "test"},
+    )
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runner.invoke(
+        setup_app,
+        ["wizard", "--accept-defaults", "--path", str(repo), "--yes"],
+    )
+    result = runner.invoke(setup_app, ["show", "--path", str(repo), "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["setup"]["mode"] == "simple"
+    assert parsed["policy"]["selected_bundle_id"] == "hybrid_balanced"
+    assert parsed["hardware"]["tier"] == "capable"
+    assert parsed["applied_policy"]["bundle_id"] == "hybrid_balanced"
+
+
+# ---------------------------------------------------------------------------
+# hardware
+# ---------------------------------------------------------------------------
+
+
+def test_hardware_subcommand_does_not_raise(fake_hardware: HardwareProfile) -> None:
+    """`vaner setup hardware` runs `detect()` once and prints OS/CPU/RAM lines."""
+
+    result = runner.invoke(setup_app, ["hardware"])
+    assert result.exit_code == 0, result.output
+    assert "Linux" in result.output or "linux" in result.output
+    assert "CPU class" in result.output
+    assert "RAM" in result.output
+
+
+def test_hardware_json(fake_hardware: HardwareProfile) -> None:
+    """`vaner setup hardware --json` emits valid JSON with the expected fields."""
+
+    result = runner.invoke(setup_app, ["hardware", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["os"] == "linux"
+    assert parsed["cpu_class"] == "mid"
+    assert parsed["ram_gb"] == 16
+    assert parsed["tier"] == "capable"
+
+
+# ---------------------------------------------------------------------------
+# init chaining
+# ---------------------------------------------------------------------------
+
+
+def test_init_chains_into_wizard_when_interactive(
+    tmp_path: Path,
+    fake_hardware: HardwareProfile,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drive `vaner init` interactively; confirm wizard runs and persists."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Avoid touching ~/.claude during MCP wiring; init's primer / MCP
+    # config code paths create files there. Pin HOME to a tmp dir.
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+
+    # Track whether the wizard was invoked. We monkeypatch the wizard
+    # callable that init imports lazily.
+    wizard_calls: list[str] = []
+
+    def _fake_wizard(path: str | None = None, **_kwargs: object) -> None:
+        wizard_calls.append(path or "")
+
+    monkeypatch.setattr("vaner.cli.commands.setup.wizard_cmd", _fake_wizard)
+
+    # Scripted answers for init's existing prompts:
+    # - Step 1 backend: "7" → "skip" (but backend_preset stays None; downstream
+    #   compute prompt still fires because the check is `backend_preset != "skip"`)
+    # - Step 2 compute: "1" → background
+    # - Shell completion confirm: "n" (skip subprocess install)
+    # - Wizard chain confirm: "y" (we want to chain in)
+    scripted = "\n".join(["7", "1", "n", "y", ""]) + "\n"
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--path",
+            str(repo),
+            "--interactive",
+            "--no-mcp",
+            "--no-primer",
+        ],
+        input=scripted,
+    )
+    assert result.exit_code == 0, result.output
+    assert wizard_calls, "vaner init did not chain into the setup wizard"
+
+
+def test_init_does_not_chain_when_non_interactive(
+    tmp_path: Path,
+    fake_hardware: HardwareProfile,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`vaner init --no-interactive` does not invoke the wizard."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+
+    wizard_calls: list[str] = []
+
+    def _fake_wizard(path: str | None = None, **_kwargs: object) -> None:
+        wizard_calls.append(path or "")
+
+    monkeypatch.setattr("vaner.cli.commands.setup.wizard_cmd", _fake_wizard)
+
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--path",
+            str(repo),
+            "--no-interactive",
+            "--backend-preset",
+            "skip",
+            "--no-mcp",
+            "--no-primer",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert not wizard_calls

--- a/tests/test_daemon/test_setup_endpoints.py
+++ b/tests/test_daemon/test_setup_endpoints.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS8 — Daemon HTTP /setup/* + /policy/* + /hardware/* endpoint tests (0.8.6).
+
+Covers the seven endpoints WS8 adds:
+
+- ``GET /setup/questions`` — static five-question payload.
+- ``POST /setup/recommend`` — pure read; SetupAnswers in, SelectionResult out.
+- ``POST /setup/apply`` — persists, with cloud-widening guard + dry-run.
+- ``GET /setup/status`` — composite read (setup + policy + hardware).
+- ``GET /policy/current`` — applied-policy summary + bundle.
+- ``GET /hardware/profile`` — cached hardware probe.
+- ``POST /policy/refresh`` — engine hot-reload trigger.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+from vaner.cli.commands.config import load_config
+from vaner.cli.commands.init import init_repo
+from vaner.daemon.http import create_daemon_http_app
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return repo
+
+
+@pytest.fixture
+def client(repo_root: Path) -> TestClient:
+    init_repo(repo_root)
+    config = load_config(repo_root)
+    app = create_daemon_http_app(config)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# /setup/questions
+# ---------------------------------------------------------------------------
+
+
+def test_get_setup_questions_returns_five(client: TestClient) -> None:
+    resp = client.get("/setup/questions")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["version"] == 1
+    questions = payload["questions"]
+    assert isinstance(questions, list)
+    assert len(questions) == 5
+    ids = [q["id"] for q in questions]
+    assert ids == [
+        "work_styles",
+        "priority",
+        "compute_posture",
+        "cloud_posture",
+        "background_posture",
+    ]
+    # Each question carries kind + default + choices
+    for q in questions:
+        assert "title" in q and isinstance(q["title"], str)
+        assert q["kind"] in ("single", "multi")
+        assert "default" in q
+        assert isinstance(q["choices"], list) and len(q["choices"]) >= 2
+        for choice in q["choices"]:
+            assert "value" in choice and "label" in choice
+    # work_styles is the only multi-select
+    assert questions[0]["kind"] == "multi"
+
+
+# ---------------------------------------------------------------------------
+# /setup/recommend
+# ---------------------------------------------------------------------------
+
+
+def _good_answers() -> dict:
+    return {
+        "work_styles": ["writing", "research"],
+        "priority": "balanced",
+        "compute_posture": "balanced",
+        "cloud_posture": "ask_first",
+        "background_posture": "normal",
+    }
+
+
+def test_post_setup_recommend_happy_path(client: TestClient) -> None:
+    resp = client.post("/setup/recommend", json=_good_answers())
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert "bundle" in payload
+    assert payload["bundle"]["id"]
+    assert "score" in payload
+    assert isinstance(payload["reasons"], list)
+    assert isinstance(payload["runner_ups"], list)
+    assert "forced_fallback" in payload
+
+
+def test_post_setup_recommend_invalid_body(client: TestClient) -> None:
+    # Malformed JSON body
+    resp = client.post(
+        "/setup/recommend",
+        content="not json {{{",
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+def test_post_setup_recommend_invalid_work_styles(client: TestClient) -> None:
+    bad = _good_answers()
+    bad["work_styles"] = [1, 2, 3]  # not strings
+    resp = client.post("/setup/recommend", json=bad)
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /setup/apply
+# ---------------------------------------------------------------------------
+
+
+def test_post_setup_apply_dry_run(client: TestClient, repo_root: Path) -> None:
+    config_path = repo_root / ".vaner" / "config.toml"
+    before = config_path.read_text(encoding="utf-8")
+    resp = client.post(
+        "/setup/apply",
+        json={"answers": _good_answers(), "dry_run": True},
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["written"] is False
+    assert payload["dry_run"] is True
+    assert payload["selected_bundle_id"]
+    assert "applied_policy" in payload
+    assert payload["bundle"]["id"] == payload["selected_bundle_id"]
+    after = config_path.read_text(encoding="utf-8")
+    assert after == before, "dry_run must not modify config.toml"
+
+
+def test_post_setup_apply_blocks_on_widening(client: TestClient, repo_root: Path) -> None:
+    """When the new bundle would widen cloud posture and the caller did
+    not pass confirm_cloud_widening=true, the endpoint must return 200
+    with widens_cloud_posture=true and written=false.
+    """
+
+    # Seed a local-only baseline so any non-local bundle widens.
+    seed = client.post(
+        "/setup/apply",
+        json={
+            "answers": {
+                "work_styles": ["coding"],
+                "priority": "privacy",
+                "compute_posture": "balanced",
+                "cloud_posture": "local_only",
+                "background_posture": "normal",
+            },
+            "confirm_cloud_widening": True,
+        },
+    )
+    assert seed.status_code == 200, seed.text
+    assert seed.json()["written"] is True
+
+    # Now try to apply a bundle that widens to hybrid/cloud — without confirm.
+    config_path = repo_root / ".vaner" / "config.toml"
+    before = config_path.read_text(encoding="utf-8")
+    resp = client.post(
+        "/setup/apply",
+        json={
+            "bundle_id": "hybrid_balanced",
+            "confirm_cloud_widening": False,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["widens_cloud_posture"] is True
+    assert payload["written"] is False
+    after = config_path.read_text(encoding="utf-8")
+    assert after == before, "blocked apply must not write config.toml"
+
+
+def test_post_setup_apply_proceeds_with_confirm(client: TestClient, repo_root: Path) -> None:
+    # Seed local-only.
+    client.post(
+        "/setup/apply",
+        json={
+            "answers": {
+                "work_styles": ["coding"],
+                "priority": "privacy",
+                "compute_posture": "balanced",
+                "cloud_posture": "local_only",
+                "background_posture": "normal",
+            },
+            "confirm_cloud_widening": True,
+        },
+    )
+    resp = client.post(
+        "/setup/apply",
+        json={
+            "bundle_id": "hybrid_balanced",
+            "confirm_cloud_widening": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["written"] is True
+    assert payload["selected_bundle_id"] == "hybrid_balanced"
+    config_path = repo_root / ".vaner" / "config.toml"
+    text = config_path.read_text(encoding="utf-8")
+    assert "selected_bundle_id" in text
+    assert "hybrid_balanced" in text
+
+
+def test_post_setup_apply_unknown_bundle_400(client: TestClient) -> None:
+    resp = client.post("/setup/apply", json={"bundle_id": "no_such_bundle_xyz"})
+    assert resp.status_code == 400
+
+
+def test_post_setup_apply_no_answers_no_section(client: TestClient) -> None:
+    resp = client.post("/setup/apply", json={})
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /setup/status
+# ---------------------------------------------------------------------------
+
+
+def test_get_setup_status_well_formed(client: TestClient) -> None:
+    resp = client.get("/setup/status")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    # Keys required by the contract:
+    for key in (
+        "mode",
+        "completed",
+        "selected_bundle_id",
+        "applied_policy",
+        "bundle",
+        "hardware",
+        "setup",
+        "policy",
+    ):
+        assert key in payload, f"missing key {key!r} in {payload!r}"
+    # Hardware shape mirrors WS6's _hardware_to_dict.
+    hw = payload["hardware"]
+    for key in ("os", "cpu_class", "ram_gb", "tier"):
+        assert key in hw
+
+
+def test_get_setup_status_after_apply_marks_completed(
+    client: TestClient,
+) -> None:
+    apply_resp = client.post(
+        "/setup/apply",
+        json={"answers": _good_answers(), "confirm_cloud_widening": True},
+    )
+    assert apply_resp.status_code == 200, apply_resp.text
+    assert apply_resp.json()["written"] is True
+
+    status = client.get("/setup/status").json()
+    assert status["completed"] is True
+    assert status["mode"] == "simple"
+    assert status["selected_bundle_id"]
+
+
+# ---------------------------------------------------------------------------
+# /policy/current
+# ---------------------------------------------------------------------------
+
+
+def test_get_policy_current_includes_overrides(client: TestClient) -> None:
+    resp = client.get("/policy/current")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert "selected_bundle_id" in payload
+    assert "bundle" in payload
+    assert payload["bundle"]["id"] == payload["selected_bundle_id"]
+    assert "applied_policy" in payload
+    applied = payload["applied_policy"]
+    assert "bundle_id" in applied
+    assert "overrides_applied" in applied
+    assert isinstance(applied["overrides_applied"], list)
+    assert "engine_wired" in payload
+    assert payload["engine_wired"] is False
+
+
+# ---------------------------------------------------------------------------
+# /hardware/profile (caches)
+# ---------------------------------------------------------------------------
+
+
+def test_get_hardware_profile_caches(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """First call probes detect(); second call within process lifetime
+    returns the cached profile without re-probing.
+    """
+
+    # Reset cache so we know the first call is the cold path.
+    client.app.state.reset_hardware_cache()
+
+    import vaner.setup.hardware as hardware_module
+
+    counter = {"n": 0}
+    original_detect = hardware_module.detect
+
+    def _counting_detect():
+        counter["n"] += 1
+        return original_detect()
+
+    monkeypatch.setattr(hardware_module, "detect", _counting_detect)
+
+    r1 = client.get("/hardware/profile")
+    assert r1.status_code == 200, r1.text
+    body1 = r1.json()
+    for key in ("os", "tier", "ram_gb", "cpu_class"):
+        assert key in body1
+
+    r2 = client.get("/hardware/profile")
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body1 == body2
+    # Cold start probed once. Warm read must not re-probe.
+    assert counter["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /policy/refresh
+# ---------------------------------------------------------------------------
+
+
+def test_post_policy_refresh_503_when_engine_missing(client: TestClient) -> None:
+    """The default fixture does not wire an engine; refresh must 503."""
+
+    resp = client.post("/policy/refresh", json={})
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["code"] in ("engine_unavailable", "engine_unsupported")
+
+
+def test_post_policy_refresh_happy_path(repo_root: Path) -> None:
+    """When an engine with _refresh_policy_bundle_state is wired, the
+    endpoint fires the hook and returns a well-formed envelope.
+    """
+
+    init_repo(repo_root)
+    config = load_config(repo_root)
+
+    class FakeApplied:
+        bundle_id = "hybrid_balanced"
+        overrides_applied = ("info: refreshed",)
+
+    class FakeEngine:
+        def __init__(self) -> None:
+            self.refresh_calls = 0
+            self._applied_policy = FakeApplied()
+
+        def _refresh_policy_bundle_state(self) -> None:
+            self.refresh_calls += 1
+
+        async def initialize(self) -> None:  # required by lifespan
+            return None
+
+        async def precompute_cycle(self) -> int:  # required by lifespan loop
+            return 0
+
+    fake = FakeEngine()
+    app = create_daemon_http_app(config, engine=fake)
+    # Skip the lifespan's precompute task by using TestClient without
+    # entering the context manager — endpoints work on the raw app.
+    client = TestClient(app)
+    resp = client.post("/policy/refresh", json={})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["refreshed"] is True
+    assert body["applied_policy_summary"]["bundle_id"] == "hybrid_balanced"
+    assert "info: refreshed" in body["applied_policy_summary"]["overrides_applied"]
+    assert fake.refresh_calls == 1
+
+
+def test_post_policy_refresh_503_on_engine_exception(repo_root: Path) -> None:
+    init_repo(repo_root)
+    config = load_config(repo_root)
+
+    class BoomEngine:
+        def _refresh_policy_bundle_state(self) -> None:
+            raise RuntimeError("kaboom")
+
+        async def initialize(self) -> None:
+            return None
+
+        async def precompute_cycle(self) -> int:
+            return 0
+
+    app = create_daemon_http_app(config, engine=BoomEngine())
+    client = TestClient(app)
+    resp = client.post("/policy/refresh", json={})
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["code"] == "refresh_failed"
+    assert "kaboom" in body["message"]

--- a/tests/test_intent/test_work_style_priors.py
+++ b/tests/test_intent/test_work_style_priors.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS4 — Work-style intent prior tests (0.8.6).
+
+Pure-data invariants on :data:`WORK_STYLE_PRIORS` plus the
+:func:`adjustments_for` averaging helper, the
+:func:`compose_with_deep_run_preset` math, and the engine-level
+no-op-by-default invariant.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+
+from vaner.intent.work_style_priors import (
+    WORK_STYLE_PRIORS,
+    IntentPriorAdjustments,
+    adjustments_for,
+    compose_with_deep_run_preset,
+    default_adjustments,
+)
+from vaner.setup.enums import WorkStyle
+
+# ---------------------------------------------------------------------------
+# Table invariants
+# ---------------------------------------------------------------------------
+
+
+def test_table_keys_match_workstyle_literal() -> None:
+    """Every value in the WorkStyle Literal MUST have an entry in
+    :data:`WORK_STYLE_PRIORS`. Adding a new style without populating
+    the table is the kind of silent gap WS4 was built to prevent.
+    """
+
+    literal_values = set(get_args(WorkStyle))
+    table_keys = set(WORK_STYLE_PRIORS.keys())
+    assert table_keys == literal_values, (
+        f"WORK_STYLE_PRIORS drift: missing={literal_values - table_keys}, extra={table_keys - literal_values}"
+    )
+
+
+@pytest.mark.parametrize("style", list(get_args(WorkStyle)))
+def test_multipliers_inside_conservative_range(style: WorkStyle) -> None:
+    """Spec §7 fixes the multiplier range at ``[0.7, 1.5]`` and the
+    drafting floor at ``[0.0, 0.6]``. Drift past these edges means the
+    table has gone from explainable nudges to a tuning monster — fail
+    fast so the reviewer notices.
+    """
+
+    spec = WORK_STYLE_PRIORS[style]
+    assert 0.7 <= spec.artefact_alignment_weight_multiplier <= 1.5
+    assert 0.7 <= spec.long_horizon_bonus_multiplier <= 1.5
+    assert 0.7 <= spec.possible_branch_bonus_multiplier <= 1.5
+    assert 0.7 <= spec.drafting_volatility_ceiling_multiplier <= 1.5
+    assert 0.0 <= spec.drafting_evidence_floor <= 0.6
+
+
+def test_mixed_is_neutral() -> None:
+    """``adjustments_for(("mixed",))`` MUST return the identity element.
+
+    Engines on default ``setup.work_styles == ["mixed"]`` configs MUST
+    see byte-identical behaviour to pre-WS4. This is the load-bearing
+    invariant for the whole work-style layer.
+    """
+
+    adj = adjustments_for(("mixed",))
+    assert adj.artefact_alignment_weight_multiplier == 1.0
+    assert adj.long_horizon_bonus_multiplier == 1.0
+    assert adj.possible_branch_bonus_multiplier == 1.0
+    assert adj.drafting_evidence_floor == 0.0
+    assert adj.drafting_volatility_ceiling_multiplier == 1.0
+    assert adj.preferred_artefact_templates == ()
+
+
+def test_default_adjustments_equals_mixed() -> None:
+    """``default_adjustments()`` must be the mixed identity element."""
+
+    assert default_adjustments() == adjustments_for(("mixed",))
+
+
+def test_empty_input_falls_back_to_default() -> None:
+    """Empty work_styles list → default identity (defensive)."""
+
+    assert adjustments_for(()) == default_adjustments()
+    assert adjustments_for([]) == default_adjustments()
+
+
+# ---------------------------------------------------------------------------
+# Averaging
+# ---------------------------------------------------------------------------
+
+
+def test_averaging_two_styles() -> None:
+    """``adjustments_for(("research","planning"))`` MUST return the
+    arithmetic mean of the per-style multipliers — not the geometric
+    mean, not "first wins". Checked numerically on one field so the
+    test fails on accidental policy drift.
+    """
+
+    adj = adjustments_for(("research", "planning"))
+    research = WORK_STYLE_PRIORS["research"]
+    planning = WORK_STYLE_PRIORS["planning"]
+    expected = (research.artefact_alignment_weight_multiplier + planning.artefact_alignment_weight_multiplier) / 2
+    assert adj.artefact_alignment_weight_multiplier == pytest.approx(expected)
+
+
+def test_averaging_is_order_independent() -> None:
+    """Averaging must commute — the user's selection order doesn't
+    affect the resulting prior."""
+
+    a = adjustments_for(("research", "planning"))
+    b = adjustments_for(("planning", "research"))
+    assert a == b
+
+
+def test_template_union() -> None:
+    """``adjustments_for(("planning","support"))`` MUST union the
+    per-style template tuples, deduplicated and sorted (deterministic
+    output regardless of input order).
+    """
+
+    adj = adjustments_for(("planning", "support"))
+    expected = tuple(
+        sorted(
+            set(WORK_STYLE_PRIORS["planning"].preferred_artefact_templates) | set(WORK_STYLE_PRIORS["support"].preferred_artefact_templates)
+        )
+    )
+    assert adj.preferred_artefact_templates == expected
+    # Sorted contract: list is monotonically non-decreasing.
+    assert list(adj.preferred_artefact_templates) == sorted(adj.preferred_artefact_templates)
+
+
+def test_unknown_style_raises_keyerror() -> None:
+    """Unknown style names indicate a schema-migration bug, not a
+    runtime concern. The averaging helper must surface it loudly."""
+
+    with pytest.raises(KeyError):
+        adjustments_for(("not_a_real_style",))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Composition with deep-run preset
+# ---------------------------------------------------------------------------
+
+
+def test_compose_with_preset_is_multiplicative() -> None:
+    """Pure math: base 1.5 × work-style 1.2 == 1.8. The composition
+    must be multiplicative so it associates with the existing
+    HorizonBiasSpec convention."""
+
+    work_style = IntentPriorAdjustments(
+        artefact_alignment_weight_multiplier=1.2,
+        long_horizon_bonus_multiplier=1.0,
+        possible_branch_bonus_multiplier=1.0,
+        drafting_evidence_floor=0.0,
+        drafting_volatility_ceiling_multiplier=1.0,
+        preferred_artefact_templates=(),
+    )
+    aa, lh, pb = compose_with_deep_run_preset(
+        work_style,
+        base_artefact_alignment=1.5,
+        base_long_horizon=2.0,
+        base_possible_branch=0.5,
+    )
+    assert aa == pytest.approx(1.5 * 1.2)
+    assert lh == pytest.approx(2.0 * 1.0)
+    assert pb == pytest.approx(0.5 * 1.0)
+
+
+def test_compose_no_op_for_mixed() -> None:
+    """Composing the mixed identity with any base must leave the base
+    unchanged. The frontier scoring path can rely on this without a
+    null check at the call site."""
+
+    base = (1.7, 0.8, 1.3)
+    aa, lh, pb = compose_with_deep_run_preset(
+        default_adjustments(),
+        base_artefact_alignment=base[0],
+        base_long_horizon=base[1],
+        base_possible_branch=base[2],
+    )
+    assert (aa, lh, pb) == base
+
+
+# ---------------------------------------------------------------------------
+# Engine-level no-op-by-default invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_engine_no_op_when_default(temp_repo) -> None:  # type: ignore[no-untyped-def]
+    """With ``setup.work_styles == ["mixed"]`` (the default), the engine's
+    cached adjustments MUST be the identity element and the briefing
+    assembler MUST receive an empty preferred-template tuple. This is
+    the load-bearing invariant: any byte-of-behaviour change to default
+    configs would surface here as a failing assertion.
+    """
+
+    from vaner.engine import VanerEngine
+    from vaner.intent.adapter import CodeRepoAdapter
+
+    engine = VanerEngine(adapter=CodeRepoAdapter(temp_repo))
+    # Invariant 1: cached adjustments are the identity element.
+    adj = engine._cycle_work_style_adjustments
+    assert adj.artefact_alignment_weight_multiplier == 1.0
+    assert adj.long_horizon_bonus_multiplier == 1.0
+    assert adj.possible_branch_bonus_multiplier == 1.0
+    assert adj.drafting_evidence_floor == 0.0
+    assert adj.drafting_volatility_ceiling_multiplier == 1.0
+    assert adj.preferred_artefact_templates == ()
+
+    # Invariant 2: briefing assembler sees no preferred templates.
+    assert engine._briefing_assembler.preferred_artefact_templates == ()
+
+    # Invariant 3: refresh is idempotent under the default config —
+    # repeated calls keep the identity element.
+    engine._refresh_work_style_adjustments()
+    assert engine._cycle_work_style_adjustments == default_adjustments()
+
+
+@pytest.mark.asyncio
+async def test_engine_picks_up_non_default_work_style(temp_repo) -> None:  # type: ignore[no-untyped-def]
+    """When the config picks a non-mixed work style, the engine refresh
+    MUST flow it through to both the cached adjustments and the
+    briefing assembler's preferred-template tuple.
+    """
+
+    from vaner.engine import VanerEngine
+    from vaner.intent.adapter import CodeRepoAdapter
+
+    engine = VanerEngine(adapter=CodeRepoAdapter(temp_repo))
+    engine.config.setup.work_styles = ["planning"]
+    engine._refresh_work_style_adjustments()
+
+    expected = WORK_STYLE_PRIORS["planning"]
+    assert engine._cycle_work_style_adjustments == expected
+    assert engine._briefing_assembler.preferred_artefact_templates == expected.preferred_artefact_templates

--- a/tests/test_mcp/test_protocol_roundtrip.py
+++ b/tests/test_mcp/test_protocol_roundtrip.py
@@ -79,6 +79,12 @@ def test_mcp_protocol_roundtrip(temp_repo: Path, monkeypatch: pytest.MonkeyPatch
                 "vaner.deep_run.status",
                 "vaner.deep_run.list",
                 "vaner.deep_run.show",
+                # 0.8.6 WS7: Setup-surface MCP tools.
+                "vaner.setup.questions",
+                "vaner.setup.recommend",
+                "vaner.setup.apply",
+                "vaner.setup.status",
+                "vaner.policy.show",
             }
 
             status = await session.call_tool("vaner.status", {})

--- a/tests/test_mcp/test_scenario_tools.py
+++ b/tests/test_mcp/test_scenario_tools.py
@@ -81,6 +81,12 @@ def test_mcp_tools_list_and_scenario_flow(temp_repo, monkeypatch):
             "vaner.deep_run.status",
             "vaner.deep_run.list",
             "vaner.deep_run.show",
+            # 0.8.6 WS7: Setup-surface MCP tools.
+            "vaner.setup.questions",
+            "vaner.setup.recommend",
+            "vaner.setup.apply",
+            "vaner.setup.status",
+            "vaner.policy.show",
         }
 
         monkeypatch.setattr("vaner.mcp.server.aprecompute", lambda *args, **kwargs: asyncio.sleep(0, result=1))

--- a/tests/test_mcp/test_server_boot.py
+++ b/tests/test_mcp/test_server_boot.py
@@ -22,8 +22,9 @@ def test_server_boot_initialize_lists_tools_and_status(temp_repo) -> None:
             # WS7 added 4 goal tools → 16. 0.8.2 WS1 adds 4 artefact
             # tools + 1 sources.status → 21. 0.8.3 WS4 adds 5 deep_run
             # tools → 26. 0.8.5 WS5 adds vaner.predictions.dashboard → 27.
+            # 0.8.6 WS7 adds 5 vaner.setup.* / vaner.policy.show tools → 32.
             # Exact set is asserted in test_protocol_roundtrip.
-            assert len(names) == 27
+            assert len(names) == 32
             assert "vaner.status" in names
             assert "vaner.predictions.active" in names
             assert "vaner.predictions.adopt" in names
@@ -33,6 +34,11 @@ def test_server_boot_initialize_lists_tools_and_status(temp_repo) -> None:
             assert "vaner.artefacts.influence" in names
             assert "vaner.sources.status" in names
             assert "vaner.deep_run.start" in names
+            assert "vaner.setup.questions" in names
+            assert "vaner.setup.recommend" in names
+            assert "vaner.setup.apply" in names
+            assert "vaner.setup.status" in names
+            assert "vaner.policy.show" in names
             resolve_schema = schemas["vaner.resolve"]
             assert set(resolve_schema["properties"]) >= {
                 "query",

--- a/tests/test_mcp/test_setup_tools.py
+++ b/tests/test_mcp/test_setup_tools.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS7 — `vaner.setup.*` and `vaner.policy.show` MCP tool tests (0.8.6)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+pytest.importorskip("mcp")
+from mcp.types import CallToolRequest, ListToolsRequest
+
+from vaner.mcp.server import build_server
+
+
+def _seed_repo(repo_root) -> None:
+    (repo_root / ".vaner").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".vaner" / "config.toml").write_text(
+        '[backend]\nbase_url = "http://127.0.0.1:11434/v1"\nmodel = "llama3.2:3b"\n',
+        encoding="utf-8",
+    )
+
+
+def _payload(result) -> dict:
+    return json.loads(result.root.content[0].text)
+
+
+def _call(server, name: str, arguments: dict | None = None) -> dict:
+    handler = server.request_handlers[CallToolRequest]
+    arguments = arguments or {}
+
+    async def _run() -> dict:
+        resp = await handler(CallToolRequest(method="tools/call", params={"name": name, "arguments": arguments}))
+        return {"isError": bool(resp.root.isError), "payload": _payload(resp)}
+
+    return asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# vaner.setup.questions
+# ---------------------------------------------------------------------------
+
+
+def test_questions_returns_five_questions(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.questions")
+    assert out["isError"] is False
+    questions = out["payload"]["questions"]
+    assert isinstance(questions, list)
+    assert len(questions) == 5
+    ids = [q["id"] for q in questions]
+    assert ids == [
+        "work_styles",
+        "priority",
+        "compute_posture",
+        "cloud_posture",
+        "background_posture",
+    ]
+    # work_styles is multi-select; the rest are single-select.
+    by_id = {q["id"]: q for q in questions}
+    assert by_id["work_styles"]["kind"] == "multi"
+    assert by_id["priority"]["kind"] == "single"
+    # Each question has at least two options with value+label.
+    for q in questions:
+        assert len(q["options"]) >= 2
+        for opt in q["options"]:
+            assert "value" in opt
+            assert "label" in opt
+
+
+# ---------------------------------------------------------------------------
+# vaner.setup.recommend
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_happy_path(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(
+        server,
+        "vaner.setup.recommend",
+        {
+            "work_styles": ["coding", "research"],
+            "priority": "balanced",
+            "compute_posture": "balanced",
+            "cloud_posture": "ask_first",
+            "background_posture": "normal",
+        },
+    )
+    assert out["isError"] is False
+    payload = out["payload"]
+    assert "bundle" in payload
+    assert isinstance(payload["bundle"]["id"], str)
+    # The id must match a known catalog id.
+    from vaner.setup.catalog import PROFILE_CATALOG
+
+    known_ids = {b.id for b in PROFILE_CATALOG}
+    assert payload["bundle"]["id"] in known_ids
+    assert "score" in payload
+    assert isinstance(payload["reasons"], list)
+    assert isinstance(payload["runner_ups"], list)
+    assert isinstance(payload["forced_fallback"], bool)
+
+
+def test_recommend_missing_fields_uses_defaults(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.recommend", {})
+    assert out["isError"] is False
+    payload = out["payload"]
+    assert "bundle" in payload
+    # Default work_styles=["mixed"] + balanced/ask_first/normal — selection
+    # must produce a real bundle, not fall back to forced_fallback.
+    assert isinstance(payload["bundle"]["id"], str)
+    assert payload["bundle"]["id"]
+
+
+def test_recommend_accepts_single_string_work_style(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.recommend", {"work_styles": "coding"})
+    assert out["isError"] is False
+    assert out["payload"]["bundle"]["id"]
+
+
+# ---------------------------------------------------------------------------
+# vaner.setup.apply
+# ---------------------------------------------------------------------------
+
+
+def test_apply_dry_run_does_not_persist(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    config_path = temp_repo / ".vaner" / "config.toml"
+    before = config_path.read_text(encoding="utf-8")
+    server = build_server(temp_repo)
+    out = _call(
+        server,
+        "vaner.setup.apply",
+        {
+            "answers": {
+                "work_styles": ["coding"],
+                "priority": "balanced",
+                "compute_posture": "balanced",
+                "cloud_posture": "ask_first",
+                "background_posture": "normal",
+            },
+            "dry_run": True,
+        },
+    )
+    assert out["isError"] is False
+    payload = out["payload"]
+    assert payload["written"] is False
+    assert payload["block_reason"] is not None
+    assert "dry_run" in payload["block_reason"]
+    # File must be byte-identical.
+    assert config_path.read_text(encoding="utf-8") == before
+
+
+def test_apply_blocks_on_widening_without_confirm(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    # First pin a local-only bundle.
+    out1 = _call(
+        server,
+        "vaner.setup.apply",
+        {"bundle_id": "local_lightweight"},
+    )
+    assert out1["isError"] is False
+    assert out1["payload"]["written"] is True
+    # Now ask for a hybrid bundle without confirming the widening.
+    out2 = _call(
+        server,
+        "vaner.setup.apply",
+        {"bundle_id": "hybrid_balanced"},
+    )
+    assert out2["isError"] is False
+    payload = out2["payload"]
+    assert payload["widens_cloud_posture"] is True
+    assert payload["written"] is False
+    assert payload["block_reason"] is not None
+    assert "WIDENS_CLOUD_POSTURE" in payload["block_reason"]
+
+
+def test_apply_proceeds_with_confirm(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    _call(server, "vaner.setup.apply", {"bundle_id": "local_lightweight"})
+    out = _call(
+        server,
+        "vaner.setup.apply",
+        {"bundle_id": "hybrid_balanced", "confirm_cloud_widening": True},
+    )
+    assert out["isError"] is False
+    payload = out["payload"]
+    assert payload["widens_cloud_posture"] is True
+    assert payload["written"] is True
+    assert payload["block_reason"] is None
+    # Verify the on-disk policy section reflects the new id.
+    text = (temp_repo / ".vaner" / "config.toml").read_text(encoding="utf-8")
+    assert 'selected_bundle_id = "hybrid_balanced"' in text
+
+
+def test_apply_explicit_bundle_id(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.apply", {"bundle_id": "cost_saver"})
+    assert out["isError"] is False
+    payload = out["payload"]
+    assert payload["bundle_id"] == "cost_saver"
+    assert payload["written"] is True
+    text = (temp_repo / ".vaner" / "config.toml").read_text(encoding="utf-8")
+    assert 'selected_bundle_id = "cost_saver"' in text
+
+
+def test_apply_unknown_bundle_id_errors(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.apply", {"bundle_id": "definitely_not_real"})
+    assert out["isError"] is True
+    assert out["payload"]["code"] == "unknown_bundle_id"
+
+
+def test_apply_requires_answers_or_bundle_id(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.apply", {})
+    assert out["isError"] is True
+    assert out["payload"]["code"] == "invalid_input"
+
+
+# ---------------------------------------------------------------------------
+# vaner.setup.status
+# ---------------------------------------------------------------------------
+
+
+def test_status_returns_well_formed(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.status")
+    assert out["isError"] is False
+    payload = out["payload"]
+    for key in ("mode", "selected_bundle_id", "completed_at", "applied_policy", "hardware"):
+        assert key in payload
+    assert payload["mode"] in ("simple", "advanced")
+    assert isinstance(payload["selected_bundle_id"], str)
+    assert isinstance(payload["applied_policy"], dict)
+    assert "bundle_id" in payload["applied_policy"]
+    assert "overrides_applied" in payload["applied_policy"]
+    assert isinstance(payload["hardware"], dict)
+    for hw_key in ("os", "tier", "cpu_class", "ram_gb"):
+        assert hw_key in payload["hardware"]
+
+
+def test_status_after_apply_reflects_new_bundle(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    _call(server, "vaner.setup.apply", {"bundle_id": "cost_saver"})
+    out = _call(server, "vaner.setup.status")
+    assert out["isError"] is False
+    assert out["payload"]["selected_bundle_id"] == "cost_saver"
+
+
+# ---------------------------------------------------------------------------
+# vaner.policy.show
+# ---------------------------------------------------------------------------
+
+
+def test_policy_show_includes_overrides(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.policy.show")
+    assert out["isError"] is False
+    payload = out["payload"]
+    assert "bundle" in payload
+    assert "overrides_applied" in payload
+    assert isinstance(payload["overrides_applied"], list)
+    # Bundle JSON includes the WS6 stable shape.
+    bundle = payload["bundle"]
+    for key in (
+        "id",
+        "label",
+        "description",
+        "local_cloud_posture",
+        "runtime_profile",
+        "spend_profile",
+        "context_injection_default",
+        "deep_run_profile",
+    ):
+        assert key in bundle
+
+
+def test_policy_show_after_apply_reflects_chosen_bundle(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    _call(server, "vaner.setup.apply", {"bundle_id": "local_lightweight"})
+    out = _call(server, "vaner.policy.show")
+    assert out["isError"] is False
+    assert out["payload"]["bundle"]["id"] == "local_lightweight"
+
+
+# ---------------------------------------------------------------------------
+# Tool list contains all five new tools.
+# ---------------------------------------------------------------------------
+
+
+def test_setup_tools_are_advertised(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    list_handler = server.request_handlers[ListToolsRequest]
+
+    async def _run() -> set[str]:
+        listed = await list_handler(ListToolsRequest(method="tools/list"))
+        return {t.name for t in listed.root.tools}
+
+    names = asyncio.run(_run())
+    for tool_name in (
+        "vaner.setup.questions",
+        "vaner.setup.recommend",
+        "vaner.setup.apply",
+        "vaner.setup.status",
+        "vaner.policy.show",
+    ):
+        assert tool_name in names

--- a/tests/test_setup/test_answers.py
+++ b/tests/test_setup/test_answers.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — SetupAnswers dataclass tests (0.8.6)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from vaner.setup.answers import SetupAnswers
+
+
+def _valid_answers() -> SetupAnswers:
+    return SetupAnswers(
+        work_styles=("writing", "research"),
+        priority="quality",
+        compute_posture="balanced",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="idle_more",
+    )
+
+
+def test_round_trip_preserves_fields() -> None:
+    answers = _valid_answers()
+    assert answers.work_styles == ("writing", "research")
+    assert answers.priority == "quality"
+    assert answers.compute_posture == "balanced"
+    assert answers.cloud_posture == "hybrid_when_worth_it"
+    assert answers.background_posture == "idle_more"
+
+
+def test_empty_work_styles_raises() -> None:
+    with pytest.raises(ValueError, match="work_styles must contain"):
+        SetupAnswers(
+            work_styles=(),
+            priority="balanced",
+            compute_posture="balanced",
+            cloud_posture="ask_first",
+            background_posture="normal",
+        )
+
+
+def test_dataclass_is_frozen() -> None:
+    answers = _valid_answers()
+    with pytest.raises(FrozenInstanceError):
+        answers.priority = "speed"  # type: ignore[misc]
+
+
+def test_single_work_style_is_valid() -> None:
+    answers = SetupAnswers(
+        work_styles=("mixed",),
+        priority="balanced",
+        compute_posture="balanced",
+        cloud_posture="ask_first",
+        background_posture="normal",
+    )
+    assert answers.work_styles == ("mixed",)
+
+
+def test_setup_answers_is_hashable() -> None:
+    # Frozen + tuple work_styles means SetupAnswers is hashable.
+    # Important for cache keys in the selection algorithm.
+    a1 = _valid_answers()
+    a2 = _valid_answers()
+    assert hash(a1) == hash(a2)
+    assert a1 == a2

--- a/tests/test_setup/test_apply.py
+++ b/tests/test_setup/test_apply.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``vaner.setup.apply`` — WS5 policy-bundle application (0.8.6)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vaner.models.config import (
+    ExplorationConfig,
+    ExplorationEndpoint,
+    PolicyConfig,
+    VanerConfig,
+)
+from vaner.setup.apply import (
+    WIDENS_CLOUD_POSTURE_SENTINEL,
+    AppliedPolicy,
+    apply_policy_bundle,
+)
+from vaner.setup.catalog import PROFILE_CATALOG, bundle_by_id
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(tmp_path: Path, **overrides) -> VanerConfig:
+    base = {
+        "repo_root": tmp_path / "repo",
+        "store_path": tmp_path / "store.db",
+        "telemetry_path": tmp_path / "telemetry.db",
+    }
+    base.update(overrides)
+    return VanerConfig(**base)
+
+
+# ---------------------------------------------------------------------------
+# Pure-function contract
+# ---------------------------------------------------------------------------
+
+
+def test_pure_function(tmp_path: Path) -> None:
+    """Same input -> same output, and original config is untouched."""
+
+    cfg = _make_config(tmp_path)
+    bundle = bundle_by_id("local_balanced")
+
+    snapshot_prefer_local = cfg.backend.prefer_local
+    snapshot_remote_budget = cfg.backend.remote_budget_per_hour
+    snapshot_ci_mode = cfg.integrations.context_injection.mode
+    snapshot_bundle_id = cfg.policy.selected_bundle_id
+
+    out1 = apply_policy_bundle(cfg, bundle)
+    out2 = apply_policy_bundle(cfg, bundle)
+
+    # Original config unchanged.
+    assert cfg.backend.prefer_local == snapshot_prefer_local
+    assert cfg.backend.remote_budget_per_hour == snapshot_remote_budget
+    assert cfg.integrations.context_injection.mode == snapshot_ci_mode
+    assert cfg.policy.selected_bundle_id == snapshot_bundle_id
+
+    # Same input -> same output.
+    assert out1.bundle_id == out2.bundle_id == bundle.id
+    assert out1.overrides_applied == out2.overrides_applied
+    assert out1.config.backend.prefer_local == out2.config.backend.prefer_local
+    assert out1.config.backend.remote_budget_per_hour == out2.config.backend.remote_budget_per_hour
+
+
+# ---------------------------------------------------------------------------
+# Cloud-widening guard
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_widening_cloud_posture_flagged(tmp_path: Path) -> None:
+    """Going from local_only -> hybrid must surface the WIDENS sentinel."""
+
+    cfg = _make_config(
+        tmp_path,
+        policy=PolicyConfig(selected_bundle_id="local_lightweight"),
+    )
+    new_bundle = bundle_by_id("hybrid_balanced")
+
+    result = apply_policy_bundle(cfg, new_bundle)
+
+    flagged = [s for s in result.overrides_applied if s.startswith(WIDENS_CLOUD_POSTURE_SENTINEL)]
+    assert len(flagged) == 1, f"expected exactly one widening sentinel, got: {result.overrides_applied}"
+    assert "local_only" in flagged[0]
+    assert "hybrid" in flagged[0]
+
+
+def test_no_widening_when_same_posture(tmp_path: Path) -> None:
+    """Applying the same bundle twice does not flag widening."""
+
+    cfg = _make_config(
+        tmp_path,
+        policy=PolicyConfig(selected_bundle_id="hybrid_balanced"),
+    )
+    bundle = bundle_by_id("hybrid_balanced")
+
+    result = apply_policy_bundle(cfg, bundle)
+
+    flagged = [s for s in result.overrides_applied if s.startswith(WIDENS_CLOUD_POSTURE_SENTINEL)]
+    assert flagged == []
+
+
+def test_no_widening_when_narrowing(tmp_path: Path) -> None:
+    """Going from cloud_preferred -> local_only must NOT flag widening."""
+
+    cfg = _make_config(
+        tmp_path,
+        policy=PolicyConfig(selected_bundle_id="hybrid_quality"),  # cloud_preferred
+    )
+    new_bundle = bundle_by_id("local_lightweight")  # local_only
+
+    result = apply_policy_bundle(cfg, new_bundle)
+
+    flagged = [s for s in result.overrides_applied if s.startswith(WIDENS_CLOUD_POSTURE_SENTINEL)]
+    assert flagged == []
+
+
+# ---------------------------------------------------------------------------
+# Per-bundle smoke tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bundle", PROFILE_CATALOG, ids=[b.id for b in PROFILE_CATALOG])
+def test_seven_bundles_each_apply_cleanly(tmp_path: Path, bundle) -> None:
+    """Every catalogued bundle applies without raising and yields an AppliedPolicy."""
+
+    cfg = _make_config(tmp_path)
+
+    result = apply_policy_bundle(cfg, bundle)
+
+    assert isinstance(result, AppliedPolicy)
+    assert result.bundle_id == bundle.id
+    assert result.config.policy.selected_bundle_id == bundle.id
+    assert result.config.backend.prefer_local == (bundle.local_cloud_posture in ("local_only", "local_preferred"))
+    # remote_budget_per_hour matches the bundle's spend-profile band.
+    expected_budgets = {"zero": 0, "low": 30, "medium": 60, "high": 120}
+    assert result.config.backend.remote_budget_per_hour == expected_budgets[bundle.spend_profile]
+
+
+# ---------------------------------------------------------------------------
+# User overrides
+# ---------------------------------------------------------------------------
+
+
+def test_user_override_wins_over_bundle_default(tmp_path: Path) -> None:
+    """User's context_injection_mode override beats the bundle default."""
+
+    cfg = _make_config(tmp_path)
+    bundle = bundle_by_id("local_lightweight")  # bundle default = digest_only
+
+    # User's preferred mode is none — and they keep it across bundle changes.
+    result = apply_policy_bundle(
+        cfg,
+        bundle,
+        user_overrides={"context_injection_mode": "none"},
+    )
+
+    assert result.config.integrations.context_injection.mode == "none"
+    # No line writing the bundle default in the audit list — the user
+    # override wins.
+    assert not any(
+        f"context_injection.mode: {bundle.context_injection_default}" == s
+        or s.endswith(f"context_injection.mode: {bundle.context_injection_default}")
+        for s in result.overrides_applied
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default bundle is a no-op against a fresh config
+# ---------------------------------------------------------------------------
+
+
+def test_no_op_for_default_hybrid_balanced(tmp_path: Path) -> None:
+    """Applying hybrid_balanced (the default) to a fresh VanerConfig is
+    safe — no widening sentinel, no autonomy-expanding flags, and the
+    only mutations are the documented bundle-default writes.
+
+    The bundle's ``low`` spend profile and ``hybrid`` posture do not
+    perfectly mirror the bare :class:`BackendConfig` defaults
+    (``prefer_local=True``, ``remote_budget_per_hour=60``); applying
+    the default bundle nudges those toward the bundle's outcome
+    semantics. The assertion is that the diff is bounded and
+    explainable, not that it is empty.
+    """
+
+    cfg = _make_config(tmp_path)
+    bundle = bundle_by_id("hybrid_balanced")
+
+    result = apply_policy_bundle(cfg, bundle)
+
+    # No widening — same posture as the prior selection.
+    flagged = [s for s in result.overrides_applied if s.startswith(WIDENS_CLOUD_POSTURE_SENTINEL)]
+    assert flagged == []
+
+    # Default bundle id stays the same -> no PolicyConfig mutation line.
+    assert result.config.policy.selected_bundle_id == bundle.id
+    assert not any(s.startswith("PolicyConfig.") for s in result.overrides_applied)
+
+    # Allowed mutation lines are exactly the documented BackendConfig
+    # tweaks. No ExplorationConfig / IntegrationsConfig writes.
+    backend_mutations = [s for s in result.overrides_applied if s.startswith("BackendConfig.")]
+    assert all(
+        s.startswith("BackendConfig.prefer_local") or s.startswith("BackendConfig.remote_budget_per_hour") for s in backend_mutations
+    ), backend_mutations
+
+    assert not any(s.startswith("ExplorationConfig.") for s in result.overrides_applied)
+    assert not any(s.startswith("IntegrationsConfig.") for s in result.overrides_applied)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint filter under local_only
+# ---------------------------------------------------------------------------
+
+
+def test_local_only_filters_remote_endpoints(tmp_path: Path) -> None:
+    """A local_only bundle drops non-localhost exploration endpoints."""
+
+    cfg = _make_config(
+        tmp_path,
+        exploration=ExplorationConfig(
+            endpoints=[
+                ExplorationEndpoint(url="http://127.0.0.1:8000/v1", model="local-a"),
+                ExplorationEndpoint(url="https://api.openai.com/v1", model="gpt-4o"),
+                ExplorationEndpoint(url="http://localhost:11434", model="ollama-tag"),
+            ],
+        ),
+    )
+    bundle = bundle_by_id("local_lightweight")  # local_only
+
+    result = apply_policy_bundle(cfg, bundle)
+
+    kept_urls = [ep.url for ep in result.config.exploration.endpoints]
+    assert "https://api.openai.com/v1" not in kept_urls
+    assert "http://127.0.0.1:8000/v1" in kept_urls
+    assert "http://localhost:11434" in kept_urls
+    # Original config is untouched.
+    assert len(cfg.exploration.endpoints) == 3
+
+
+# ---------------------------------------------------------------------------
+# Apply does not cross prepare/promote/adopt/execute boundary
+# ---------------------------------------------------------------------------
+
+
+def test_apply_no_autonomy(tmp_path: Path) -> None:
+    """``apply_policy_bundle`` must never set knobs that cross the
+    prepare/promote/adopt/execute boundary.
+
+    Concretely: we assert the function does not invent ``auto_adopt``
+    / ``auto_execute`` flags on any config block, does not write a
+    ``cost_cap_usd`` or any Deep-Run session field, and does not
+    mutate fields outside the documented set.
+    """
+
+    cfg = _make_config(tmp_path)
+    # Try every bundle — each must respect the boundary.
+    forbidden_substrings = (
+        "auto_adopt",
+        "auto_execute",
+        "auto_apply",
+        "cost_cap_usd",
+        "DeepRunSession",
+    )
+    for bundle in PROFILE_CATALOG:
+        result = apply_policy_bundle(cfg, bundle)
+        for line in result.overrides_applied:
+            # ``info:`` lines may *mention* spend_profile or
+            # cost_cap_usd as a hint; mutation lines must not.
+            if line.startswith("info:"):
+                continue
+            for needle in forbidden_substrings:
+                assert needle not in line, f"forbidden token {needle!r} in mutation line: {line}"
+        # Engine-knob fields the function is allowed to touch are a
+        # closed set — verify nothing else changed by sampling.
+        cfg_dump = result.config.model_dump()
+        baseline_dump = cfg.model_dump()
+        # Top-level blocks the function may rewrite.
+        allowed_blocks = {"backend", "exploration", "integrations", "policy"}
+        for block_name in baseline_dump:
+            if block_name in allowed_blocks:
+                continue
+            assert cfg_dump[block_name] == baseline_dump[block_name], f"bundle {bundle.id} unexpectedly mutated config block {block_name!r}"
+
+
+# ---------------------------------------------------------------------------
+# Engine integration
+# ---------------------------------------------------------------------------
+
+
+def test_engine_init_applies_bundle(tmp_path: Path) -> None:
+    """The engine materialises the selected bundle at init time."""
+
+    from vaner.engine import VanerEngine
+    from vaner.intent.adapter import CodeRepoAdapter
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def hi(): return 'hi'\n")
+
+    async def _stub_llm(_prompt: str) -> str:
+        return '{"ranked_files": [], "semantic_intent": "", "confidence": 0.0, "follow_on": []}'
+
+    engine = VanerEngine(adapter=CodeRepoAdapter(repo), llm=_stub_llm)
+    # Default bundle is "hybrid_balanced" — applied policy is non-None
+    # and reflects the selected id.
+    assert engine._applied_policy is not None  # noqa: SLF001
+    assert engine._applied_policy.bundle_id == "hybrid_balanced"  # noqa: SLF001
+
+    # Now flip the selected bundle and re-refresh; the engine picks it up.
+    engine.config.policy = PolicyConfig(selected_bundle_id="local_lightweight")
+    engine._refresh_policy_bundle_state()  # noqa: SLF001
+
+    assert engine._applied_policy.bundle_id == "local_lightweight"  # noqa: SLF001
+    # local_lightweight is local_only -> prefer_local True, remote_budget 0.
+    assert engine._applied_policy.config.backend.prefer_local is True  # noqa: SLF001
+    assert engine._applied_policy.config.backend.remote_budget_per_hour == 0  # noqa: SLF001
+
+
+def test_engine_unknown_bundle_id_falls_back_safely(tmp_path: Path) -> None:
+    """An unknown bundle id is logged and the engine continues without applied policy."""
+
+    from vaner.engine import VanerEngine
+    from vaner.intent.adapter import CodeRepoAdapter
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def hi(): return 'hi'\n")
+
+    async def _stub_llm(_prompt: str) -> str:
+        return '{"ranked_files": [], "semantic_intent": "", "confidence": 0.0, "follow_on": []}'
+
+    engine = VanerEngine(adapter=CodeRepoAdapter(repo), llm=_stub_llm)
+    engine.config.policy = PolicyConfig(selected_bundle_id="this_does_not_exist")
+    engine._refresh_policy_bundle_state()  # noqa: SLF001
+
+    # No raise; applied_policy is None.
+    assert engine._applied_policy is None  # noqa: SLF001

--- a/tests/test_setup/test_catalog.py
+++ b/tests/test_setup/test_catalog.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — PROFILE_CATALOG tests (0.8.6)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vaner.setup.catalog import PROFILE_CATALOG, bundle_by_id
+from vaner.setup.policy import VanerPolicyBundle
+
+
+def test_catalog_has_seven_bundles() -> None:
+    assert len(PROFILE_CATALOG) == 7
+
+
+def test_catalog_ids_are_unique() -> None:
+    ids = [bundle.id for bundle in PROFILE_CATALOG]
+    assert len(ids) == len(set(ids))
+
+
+def test_catalog_ids_match_spec() -> None:
+    expected = {
+        "local_lightweight",
+        "local_balanced",
+        "local_heavy",
+        "hybrid_balanced",
+        "hybrid_quality",
+        "cost_saver",
+        "deep_research",
+    }
+    actual = {bundle.id for bundle in PROFILE_CATALOG}
+    assert actual == expected
+
+
+def test_bundle_by_id_returns_correct_bundle() -> None:
+    bundle = bundle_by_id("hybrid_balanced")
+    assert isinstance(bundle, VanerPolicyBundle)
+    assert bundle.id == "hybrid_balanced"
+    assert bundle.label == "Hybrid Balanced"
+
+
+def test_bundle_by_id_unknown_raises_keyerror() -> None:
+    with pytest.raises(KeyError, match="unknown bundle id"):
+        bundle_by_id("nonexistent")
+
+
+def test_every_bundle_has_complete_horizon_bias_mapping() -> None:
+    for bundle in PROFILE_CATALOG:
+        assert set(bundle.prediction_horizon_bias.keys()) == {
+            "likely_next",
+            "long_horizon",
+            "finish_partials",
+            "balanced",
+        }, f"bundle {bundle.id} has incomplete horizon-bias mapping"
+
+
+def test_every_bundle_has_nonempty_label_and_description() -> None:
+    for bundle in PROFILE_CATALOG:
+        assert bundle.label, f"bundle {bundle.id} has empty label"
+        assert bundle.description, f"bundle {bundle.id} has empty description"

--- a/tests/test_setup/test_config_schema.py
+++ b/tests/test_setup/test_config_schema.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — VanerConfig schema tests (0.8.6).
+
+Confirms the new ``[setup]`` and ``[policy]`` sections exist on
+:class:`VanerConfig`, round-trip through Pydantic JSON, and that the
+``IntentConfig.domain`` field is removed outright (no compat shim).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaner.models.config import (
+    IntentConfig,
+    PolicyConfig,
+    SetupConfig,
+    VanerConfig,
+)
+
+
+def _make_config(tmp_path: Path) -> VanerConfig:
+    return VanerConfig(
+        repo_root=tmp_path,
+        store_path=tmp_path / "store.db",
+        telemetry_path=tmp_path / "telemetry.db",
+    )
+
+
+def test_vaner_config_includes_setup_and_policy_sections(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert isinstance(cfg.setup, SetupConfig)
+    assert isinstance(cfg.policy, PolicyConfig)
+
+
+def test_setup_defaults(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert cfg.setup.mode == "simple"
+    assert cfg.setup.work_styles == ["mixed"]
+    assert cfg.setup.priority == "balanced"
+    assert cfg.setup.compute_posture == "balanced"
+    assert cfg.setup.cloud_posture == "ask_first"
+    assert cfg.setup.background_posture == "normal"
+    assert cfg.setup.completed_at is None
+    assert cfg.setup.version == 1
+
+
+def test_policy_defaults(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    assert cfg.policy.selected_bundle_id == "hybrid_balanced"
+    assert cfg.policy.bundle_overrides == {}
+    assert cfg.policy.auto_select is True
+
+
+def test_intent_config_no_longer_has_domain_field() -> None:
+    # The 0.8.6 WS1 removal — verify the field is gone outright.
+    assert "domain" not in IntentConfig.model_fields
+
+
+def test_config_round_trips_through_json(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    payload = cfg.model_dump_json()
+    parsed = json.loads(payload)
+    assert "setup" in parsed
+    assert "policy" in parsed
+    # Reconstruct from the dumped JSON and verify equivalence.
+    cfg2 = VanerConfig.model_validate_json(payload)
+    assert cfg2.setup.mode == cfg.setup.mode
+    assert cfg2.policy.selected_bundle_id == cfg.policy.selected_bundle_id
+
+
+def test_setup_config_completed_at_accepts_datetime(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    when = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    cfg = SetupConfig(completed_at=when)
+    payload = cfg.model_dump_json()
+    parsed = SetupConfig.model_validate_json(payload)
+    assert parsed.completed_at == when

--- a/tests/test_setup/test_enums.py
+++ b/tests/test_setup/test_enums.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — enum literal alias tests (0.8.6).
+
+The aliases themselves are ``Literal`` types and have no runtime
+behaviour to test directly. We exercise their interaction with the
+``SetupConfig`` Pydantic model: every valid value round-trips, and an
+invalid value raises :class:`pydantic.ValidationError`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from vaner.models.config import SetupConfig
+from vaner.setup.enums import (
+    BackgroundPosture,
+    CloudPosture,
+    ComputePosture,
+    HardwareTier,
+    Priority,
+    WorkStyle,
+)
+
+# ---------------------------------------------------------------------------
+# Literal-membership checks. ``Literal`` doesn't expose its args via a
+# stable public API; we use ``typing.get_args`` which is documented and
+# stable across 3.11+.
+# ---------------------------------------------------------------------------
+
+
+def _literal_values(alias: object) -> tuple[str, ...]:
+    from typing import get_args
+
+    return tuple(get_args(alias))
+
+
+def test_work_style_values() -> None:
+    assert set(_literal_values(WorkStyle)) == {
+        "writing",
+        "research",
+        "planning",
+        "support",
+        "learning",
+        "coding",
+        "general",
+        "mixed",
+        "unsure",
+    }
+
+
+def test_priority_values() -> None:
+    assert set(_literal_values(Priority)) == {
+        "balanced",
+        "speed",
+        "quality",
+        "privacy",
+        "cost",
+        "low_resource",
+    }
+
+
+def test_compute_posture_values() -> None:
+    assert set(_literal_values(ComputePosture)) == {"light", "balanced", "available_power"}
+
+
+def test_cloud_posture_values() -> None:
+    assert set(_literal_values(CloudPosture)) == {
+        "local_only",
+        "ask_first",
+        "hybrid_when_worth_it",
+        "best_available",
+    }
+
+
+def test_background_posture_values() -> None:
+    assert set(_literal_values(BackgroundPosture)) == {
+        "minimal",
+        "normal",
+        "idle_more",
+        "deep_run_aggressive",
+    }
+
+
+def test_hardware_tier_values() -> None:
+    assert set(_literal_values(HardwareTier)) == {
+        "light",
+        "capable",
+        "high_performance",
+        "unknown",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pydantic validation: each enum value works as a SetupConfig field
+# value; invalid values raise ValidationError.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", _literal_values(WorkStyle))
+def test_setup_config_accepts_each_work_style(value: str) -> None:
+    cfg = SetupConfig(work_styles=[value])  # type: ignore[list-item]
+    assert cfg.work_styles == [value]
+
+
+@pytest.mark.parametrize("value", _literal_values(Priority))
+def test_setup_config_accepts_each_priority(value: str) -> None:
+    cfg = SetupConfig(priority=value)  # type: ignore[arg-type]
+    assert cfg.priority == value
+
+
+def test_setup_config_rejects_invalid_priority() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(priority="not-a-priority")  # type: ignore[arg-type]
+
+
+def test_setup_config_rejects_invalid_work_style() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(work_styles=["not-a-work-style"])  # type: ignore[list-item]
+
+
+def test_setup_config_rejects_invalid_cloud_posture() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(cloud_posture="not-a-cloud-posture")  # type: ignore[arg-type]
+
+
+def test_setup_config_rejects_invalid_background_posture() -> None:
+    with pytest.raises(ValidationError):
+        SetupConfig(background_posture="not-a-background-posture")  # type: ignore[arg-type]

--- a/tests/test_setup/test_hardware.py
+++ b/tests/test_setup/test_hardware.py
@@ -1,0 +1,283 @@
+"""Tests for vaner.setup.hardware.
+
+All probes are mocked so the tests run identically on any platform / CI.
+A single optional smoke test (``test_real_detect_smoke``) exercises the real
+machine when ``VANER_HW_REAL`` is set.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from vaner.setup import hardware as hw
+
+
+def _make_profile(**overrides: Any) -> hw.HardwareProfile:
+    """Build a HardwareProfile with sane defaults for tier_for tests."""
+    base: dict[str, Any] = {
+        "os": "linux",
+        "cpu_class": "mid",
+        "ram_gb": 16,
+        "gpu": "integrated",
+        "gpu_vram_gb": None,
+        "is_battery": False,
+        "thermal_constrained": False,
+        "detected_runtimes": (),
+        "detected_models": (),
+        "tier": "unknown",
+    }
+    base.update(overrides)
+    profile = hw.HardwareProfile(**base)
+    return dataclasses.replace(profile, tier=hw.tier_for(profile))
+
+
+# ---------------------------------------------------------------------------
+# tier_for() table
+# ---------------------------------------------------------------------------
+
+
+def test_tier_unknown_when_os_missing() -> None:
+    """detect() routes through tier="unknown" when probes fail entirely."""
+    with (
+        patch.object(hw, "_probe_os", return_value=None),
+        patch.object(hw, "_probe_cpu_and_ram", return_value=("low", 0)),
+        patch.object(hw, "_probe_gpu", return_value=("none", None)),
+        patch.object(hw, "_probe_battery", return_value=False),
+        patch.object(hw, "_probe_thermal", return_value=False),
+        patch.object(hw, "_probe_runtimes", return_value=()),
+        patch.object(hw, "_probe_models", return_value=()),
+    ):
+        profile = hw.detect()
+    assert profile.tier == "unknown"
+
+
+def test_tier_light_low_ram_no_gpu() -> None:
+    profile = _make_profile(ram_gb=8, gpu="none", cpu_class="low")
+    assert profile.tier == "light"
+
+
+def test_tier_high_perf_workstation() -> None:
+    profile = _make_profile(
+        ram_gb=64,
+        gpu="nvidia",
+        gpu_vram_gb=24,
+        cpu_class="high",
+        is_battery=False,
+    )
+    assert profile.tier == "high_performance"
+
+
+def test_tier_capable_default() -> None:
+    profile = _make_profile(
+        ram_gb=32,
+        gpu="integrated",
+        gpu_vram_gb=None,
+        cpu_class="mid",
+        is_battery=False,
+    )
+    assert profile.tier == "capable"
+
+
+def test_battery_low_ram_demotes_to_light() -> None:
+    """16GB on battery is below the 24GB battery cutoff → light."""
+    profile = _make_profile(
+        ram_gb=16,
+        gpu="integrated",
+        cpu_class="mid",
+        is_battery=True,
+    )
+    assert profile.tier == "light"
+
+
+def test_apple_silicon_unified_memory() -> None:
+    """Apple Silicon reports VRAM as None and still maps to high_performance."""
+    profile = _make_profile(
+        os="darwin",
+        ram_gb=64,
+        gpu="apple_silicon",
+        gpu_vram_gb=None,
+        cpu_class="high",
+        is_battery=False,
+    )
+    assert profile.tier == "high_performance"
+
+
+def test_apple_silicon_on_battery_blocks_high_perf() -> None:
+    """Battery flag is dispositive: even Apple Silicon laptops drop tier."""
+    profile = _make_profile(
+        os="darwin",
+        ram_gb=32,
+        gpu="apple_silicon",
+        gpu_vram_gb=None,
+        cpu_class="high",
+        is_battery=True,
+    )
+    # 32GB ≥ 24GB battery cutoff → not light, but battery blocks high_perf.
+    assert profile.tier == "capable"
+
+
+def test_tier_for_unknown_zero_ram() -> None:
+    profile = hw.HardwareProfile(
+        os="linux",
+        cpu_class="low",
+        ram_gb=0,
+        gpu="none",
+        gpu_vram_gb=None,
+        is_battery=False,
+        thermal_constrained=False,
+        detected_runtimes=(),
+        detected_models=(),
+        tier="unknown",
+    )
+    assert hw.tier_for(profile) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Probe fail-safety
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_probe_fails_safe() -> None:
+    """subprocess timeout inside a runtime probe must not bubble up."""
+    err = subprocess.TimeoutExpired(cmd="anything", timeout=1)
+    with (
+        patch.object(hw.shutil, "which", return_value=None),
+        patch.object(hw, "_http_get_ok", return_value=(False, None)),
+        patch.object(hw.subprocess, "run", side_effect=err),
+    ):
+        result = hw._probe_runtimes()
+    assert result == ()
+
+
+def test_ollama_http_probe_returns_404() -> None:
+    """A non-200 from /api/tags + no binary on PATH means ollama not detected."""
+    with (
+        patch.object(hw.shutil, "which", return_value=None),
+        patch.object(hw, "_http_get_ok", return_value=(False, None)),
+    ):
+        assert hw._probe_ollama() is False
+
+
+def test_ollama_detected_when_binary_present() -> None:
+    with patch.object(hw.shutil, "which", return_value="/usr/bin/ollama"):
+        assert hw._probe_ollama() is True
+
+
+def test_lmstudio_detected_via_http() -> None:
+    with patch.object(hw, "_http_get_ok", return_value=(True, '{"data":[]}')):
+        assert hw._probe_lmstudio() is True
+
+
+def test_models_ollama_parses_size() -> None:
+    body = '{"models":[{"name":"qwen3:8b","size":5368709120}]}'
+    with patch.object(hw, "_http_get_ok", return_value=(True, body)):
+        rows = hw._probe_models_ollama()
+    assert rows == [("ollama", "qwen3:8b", "5.0GB")]
+
+
+def test_models_ollama_handles_bad_json() -> None:
+    with patch.object(hw, "_http_get_ok", return_value=(True, "not json")):
+        assert hw._probe_models_ollama() == []
+
+
+def test_models_lmstudio_parses_ids() -> None:
+    body = '{"data":[{"id":"llama-3-8b"},{"id":"mistral-7b"}]}'
+    with patch.object(hw, "_http_get_ok", return_value=(True, body)):
+        rows = hw._probe_models_lmstudio()
+    assert rows == [
+        ("lmstudio", "llama-3-8b", "unknown"),
+        ("lmstudio", "mistral-7b", "unknown"),
+    ]
+
+
+def test_thermal_probe_returns_false_off_linux() -> None:
+    with patch.object(hw.sys, "platform", "darwin"):
+        assert hw._probe_thermal() is False
+
+
+def test_battery_probe_no_psutil_no_sys() -> None:
+    """No psutil, no /sys/class/power_supply, not macOS → False."""
+    with (
+        patch.dict("sys.modules", {"psutil": None}),
+        patch.object(hw.sys, "platform", "win32"),
+    ):
+        assert hw._probe_battery() is False
+
+
+def test_gpu_probe_handles_subprocess_failure() -> None:
+    """Combined GPU probe must never raise."""
+    err = subprocess.TimeoutExpired(cmd="lspci", timeout=1)
+    with (
+        patch.object(hw, "_probe_gpu_nvidia", return_value=None),
+        patch.object(hw.shutil, "which", return_value="/usr/bin/lspci"),
+        patch.object(hw.subprocess, "run", side_effect=err),
+        patch.object(hw.sys, "platform", "linux"),
+    ):
+        gpu, vram = hw._probe_gpu()
+    assert gpu == "none"
+    assert vram is None
+
+
+# ---------------------------------------------------------------------------
+# detect() composition
+# ---------------------------------------------------------------------------
+
+
+def test_detect_returns_frozen_profile() -> None:
+    """detect() returns an immutable dataclass."""
+    with (
+        patch.object(hw, "_probe_os", return_value="linux"),
+        patch.object(hw, "_probe_cpu_and_ram", return_value=("mid", 16)),
+        patch.object(hw, "_probe_gpu", return_value=("integrated", None)),
+        patch.object(hw, "_probe_battery", return_value=False),
+        patch.object(hw, "_probe_thermal", return_value=False),
+        patch.object(hw, "_probe_runtimes", return_value=()),
+        patch.object(hw, "_probe_models", return_value=()),
+    ):
+        profile = hw.detect()
+    assert profile.tier == "capable"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        profile.ram_gb = 99  # type: ignore[misc]
+
+
+def test_detect_threads_runtimes_into_models_probe() -> None:
+    """The set of detected runtimes must be passed into _probe_models."""
+    captured: list[Any] = []
+
+    def fake_models(runtimes: Any) -> tuple[tuple[str, str, str], ...]:
+        captured.append(runtimes)
+        return (("ollama", "qwen3:8b", "5.0GB"),)
+
+    with (
+        patch.object(hw, "_probe_os", return_value="linux"),
+        patch.object(hw, "_probe_cpu_and_ram", return_value=("high", 64)),
+        patch.object(hw, "_probe_gpu", return_value=("nvidia", 24)),
+        patch.object(hw, "_probe_battery", return_value=False),
+        patch.object(hw, "_probe_thermal", return_value=False),
+        patch.object(hw, "_probe_runtimes", return_value=("ollama",)),
+        patch.object(hw, "_probe_models", side_effect=fake_models),
+    ):
+        profile = hw.detect()
+    assert captured == [("ollama",)]
+    assert profile.detected_models == (("ollama", "qwen3:8b", "5.0GB"),)
+    assert profile.tier == "high_performance"
+
+
+# ---------------------------------------------------------------------------
+# Optional CI smoke test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("VANER_HW_REAL"),
+    reason="real hardware probe smoke test (set VANER_HW_REAL=1 to enable)",
+)
+def test_real_detect_smoke() -> None:
+    profile = hw.detect()
+    assert profile.tier in {"light", "capable", "high_performance", "unknown"}

--- a/tests/test_setup/test_policy.py
+++ b/tests/test_setup/test_policy.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WS1 — VanerPolicyBundle dataclass tests (0.8.6)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from types import MappingProxyType
+
+import pytest
+
+from vaner.setup.policy import VanerPolicyBundle
+
+
+def _valid_bundle() -> VanerPolicyBundle:
+    return VanerPolicyBundle(
+        id="test_bundle",
+        label="Test Bundle",
+        description="for unit tests",
+        local_cloud_posture="local_preferred",
+        runtime_profile="medium",
+        spend_profile="zero",
+        latency_profile="balanced",
+        privacy_profile="standard",
+        prediction_horizon_bias={
+            "likely_next": 1.0,
+            "long_horizon": 1.0,
+            "finish_partials": 1.0,
+            "balanced": 1.0,
+        },
+        drafting_aggressiveness=1.0,
+        exploration_ratio=0.0,
+        persistence_strength=1.0,
+        goal_weighting=1.0,
+        context_injection_default="policy_hybrid",
+        deep_run_profile="balanced",
+    )
+
+
+def test_bundle_is_frozen() -> None:
+    bundle = _valid_bundle()
+    with pytest.raises(FrozenInstanceError):
+        bundle.id = "different_id"  # type: ignore[misc]
+
+
+def test_horizon_bias_keys_must_be_exact() -> None:
+    with pytest.raises(ValueError, match="prediction_horizon_bias"):
+        VanerPolicyBundle(
+            id="x",
+            label="x",
+            description="x",
+            local_cloud_posture="local_preferred",
+            runtime_profile="medium",
+            spend_profile="zero",
+            latency_profile="balanced",
+            privacy_profile="standard",
+            # Missing "balanced" key.
+            prediction_horizon_bias={
+                "likely_next": 1.0,
+                "long_horizon": 1.0,
+                "finish_partials": 1.0,
+            },
+            drafting_aggressiveness=1.0,
+            exploration_ratio=0.0,
+            persistence_strength=1.0,
+            goal_weighting=1.0,
+            context_injection_default="policy_hybrid",
+            deep_run_profile="balanced",
+        )
+
+
+def test_horizon_bias_extra_keys_rejected() -> None:
+    with pytest.raises(ValueError, match="prediction_horizon_bias"):
+        VanerPolicyBundle(
+            id="x",
+            label="x",
+            description="x",
+            local_cloud_posture="local_preferred",
+            runtime_profile="medium",
+            spend_profile="zero",
+            latency_profile="balanced",
+            privacy_profile="standard",
+            prediction_horizon_bias={
+                "likely_next": 1.0,
+                "long_horizon": 1.0,
+                "finish_partials": 1.0,
+                "balanced": 1.0,
+                "unexpected": 1.0,
+            },
+            drafting_aggressiveness=1.0,
+            exploration_ratio=0.0,
+            persistence_strength=1.0,
+            goal_weighting=1.0,
+            context_injection_default="policy_hybrid",
+            deep_run_profile="balanced",
+        )
+
+
+def test_horizon_bias_is_immutable_view() -> None:
+    bundle = _valid_bundle()
+    # The mapping is wrapped as a MappingProxyType and so cannot be
+    # mutated after construction.
+    assert isinstance(bundle.prediction_horizon_bias, MappingProxyType)
+    with pytest.raises(TypeError):
+        bundle.prediction_horizon_bias["likely_next"] = 99.0  # type: ignore[index]
+
+
+def test_horizon_bias_keys_are_exactly_the_four_expected() -> None:
+    bundle = _valid_bundle()
+    assert set(bundle.prediction_horizon_bias.keys()) == {
+        "likely_next",
+        "long_horizon",
+        "finish_partials",
+        "balanced",
+    }

--- a/tests/test_setup/test_select.py
+++ b/tests/test_setup/test_select.py
@@ -1,0 +1,398 @@
+"""Tests for ``vaner.setup.select`` — WS3 policy-bundle selection (0.8.6)."""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, get_args
+
+import pytest
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.catalog import PROFILE_CATALOG
+from vaner.setup.enums import (
+    CloudPosture,
+    HardwareTier,
+    Priority,
+)
+from vaner.setup.hardware import HardwareProfile
+from vaner.setup.select import (
+    SelectionResult,
+    select_policy_bundle,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers — direct construction, no real probes.
+# ---------------------------------------------------------------------------
+
+
+def _make_answers(**overrides: Any) -> SetupAnswers:
+    base: dict[str, Any] = {
+        "work_styles": ("mixed",),
+        "priority": "balanced",
+        "compute_posture": "balanced",
+        "cloud_posture": "ask_first",
+        "background_posture": "normal",
+    }
+    base.update(overrides)
+    return SetupAnswers(**base)
+
+
+def _make_hardware(**overrides: Any) -> HardwareProfile:
+    base: dict[str, Any] = {
+        "os": "linux",
+        "cpu_class": "mid",
+        "ram_gb": 16,
+        "gpu": "integrated",
+        "gpu_vram_gb": None,
+        "is_battery": False,
+        "thermal_constrained": False,
+        "detected_runtimes": (),
+        "detected_models": (),
+        "tier": "capable",
+    }
+    base.update(overrides)
+    return HardwareProfile(**base)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_pure_function_determinism() -> None:
+    """Same inputs → equal SelectionResult (including reasons + runner_ups)."""
+    answers = _make_answers(
+        work_styles=("research", "writing"),
+        priority="quality",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="idle_more",
+    )
+    hardware = _make_hardware(tier="high_performance", ram_gb=64, gpu="nvidia", gpu_vram_gb=24)
+
+    result_a = select_policy_bundle(answers, hardware)
+    result_b = select_policy_bundle(answers, hardware)
+    assert result_a == result_b
+    # Sanity: result is a SelectionResult dataclass.
+    assert isinstance(result_a, SelectionResult)
+
+
+# ---------------------------------------------------------------------------
+# Filter behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_local_only_filters_cloud_bundles() -> None:
+    """local_only must exclude cloud-leaning bundles entirely."""
+    answers = _make_answers(cloud_posture="local_only")
+    hardware = _make_hardware(tier="capable")
+    result = select_policy_bundle(answers, hardware)
+
+    cloud_postures = {"hybrid", "cloud_preferred"}
+    assert result.bundle.local_cloud_posture not in cloud_postures
+    for runner in result.runner_ups:
+        assert runner.local_cloud_posture not in cloud_postures
+    assert not result.forced_fallback
+
+
+def test_high_perf_workstation_picks_heavy_or_deep_research() -> None:
+    """High-perf workstation + research/planning steers to heavy bundles."""
+    answers = _make_answers(
+        work_styles=("research", "planning"),
+        priority="quality",
+        compute_posture="available_power",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="deep_run_aggressive",
+    )
+    hardware = _make_hardware(
+        tier="high_performance",
+        ram_gb=64,
+        gpu="nvidia",
+        gpu_vram_gb=24,
+        cpu_class="high",
+    )
+    result = select_policy_bundle(answers, hardware)
+    assert result.bundle.id in {"local_heavy", "deep_research", "hybrid_quality"}
+
+
+def test_light_battery_picks_local_lightweight_or_cost_saver() -> None:
+    """Light + battery + cost prefers a small footprint."""
+    answers = _make_answers(
+        work_styles=("general",),
+        priority="cost",
+        compute_posture="light",
+        cloud_posture="ask_first",
+        background_posture="minimal",
+    )
+    hardware = _make_hardware(
+        tier="light",
+        ram_gb=8,
+        cpu_class="low",
+        gpu="none",
+        is_battery=True,
+    )
+    result = select_policy_bundle(answers, hardware)
+    assert result.bundle.id in {"local_lightweight", "cost_saver"}
+
+
+def test_capable_balanced_default() -> None:
+    """The canonical default: capable hardware + balanced priority → hybrid_balanced."""
+    answers = _make_answers(
+        work_styles=("mixed",),
+        priority="balanced",
+        compute_posture="balanced",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="normal",
+    )
+    hardware = _make_hardware(tier="capable", ram_gb=16, gpu="integrated")
+    result = select_policy_bundle(answers, hardware)
+    assert result.bundle.id == "hybrid_balanced"
+
+
+def test_unknown_tier_avoids_heavy_local() -> None:
+    """Unknown tier never recommends a large-runtime bundle."""
+    answers = _make_answers(cloud_posture="hybrid_when_worth_it")
+    hardware = _make_hardware(tier="unknown", ram_gb=0, gpu="none")
+    result = select_policy_bundle(answers, hardware)
+    # Must not pick a large-runtime bundle on unknown tier.
+    assert result.bundle.runtime_profile != "large"
+    # Implementation also drops local_only on unknown tier.
+    assert result.bundle.local_cloud_posture != "local_only"
+
+
+def test_forced_fallback_when_filters_empty() -> None:
+    """An impossible combination triggers the safe-fallback path.
+
+    Construct a contradiction the cloud filter cannot satisfy: tier
+    unknown (drops local_only bundles + large-runtime bundles), plus
+    cloud_posture local_only (drops hybrid + cloud_preferred bundles),
+    plus priority privacy + low_resource (drops standard + medium /
+    large local bundles too). After the relaxed retry, the cloud
+    filter still wipes everything because it kept ``local_only``
+    requirement intact, so we land in the absolute-fallback branch.
+    """
+    answers = _make_answers(
+        work_styles=("mixed",),
+        priority="low_resource",
+        compute_posture="light",
+        cloud_posture="local_only",
+        background_posture="minimal",
+    )
+    # tier=unknown → strict filter drops ALL local_only bundles AND
+    # all large-runtime bundles. Combined with cloud_posture=local_only
+    # (cloud filter drops everything that isn't local_only or
+    # local_preferred) this can wipe the candidate set. The relaxed
+    # retry only keeps the cloud_posture filter — but
+    # cloud_posture=local_only still drops hybrid + cloud_preferred.
+    # The remaining candidates must satisfy local_only OR
+    # local_preferred AND be valid.
+    hardware = _make_hardware(tier="unknown", ram_gb=0, gpu="none", cpu_class="low")
+    result = select_policy_bundle(answers, hardware)
+    # The strict-filter pass empties (unknown tier drops local_only
+    # bundles; the cloud filter drops the hybrid/cloud_preferred
+    # bundles). Relaxed retry restores local-only candidates.
+    # Either way, low-resource + local must yield a small/medium
+    # local bundle; if forced_fallback is set the bundle id must be
+    # local_lightweight per contract.
+    assert isinstance(result, SelectionResult)
+    if result.forced_fallback:
+        assert result.bundle.id == "local_lightweight"
+        assert len(result.reasons) == 1
+        assert "safest local default" in result.reasons[0].lower() or "filter" in result.reasons[0].lower()
+    else:
+        assert result.bundle.local_cloud_posture in ("local_only", "local_preferred")
+
+
+def test_forced_fallback_explicit_path() -> None:
+    """Drive the absolute fallback by stubbing the catalogue to empty.
+
+    The relaxed retry branch can only fully empty if the cloud filter
+    drops every bundle. We approximate this by exercising the same
+    code path through the public API: feed the impossible combination
+    above and verify the contract holds.
+    """
+    # Build a synthetic test for the deepest fallback path: monkey
+    # patch PROFILE_CATALOG via a relaxed filter that always drops.
+    from vaner.setup import select as sel  # noqa: PLC0415 — local import for monkey patch
+
+    def _always_drop(answers: SetupAnswers, hardware: HardwareProfile, bundle: Any) -> str | None:
+        return f"drop {bundle.id}"
+
+    answers = _make_answers()
+    hardware = _make_hardware(tier="capable")
+
+    kept, _ = sel._apply_filters(answers, hardware, PROFILE_CATALOG, filters=(_always_drop,))
+    assert kept == ()
+
+
+def test_runner_ups_excludes_chosen() -> None:
+    """The chosen bundle is never repeated in runner_ups."""
+    answers = _make_answers(work_styles=("research",), priority="quality")
+    hardware = _make_hardware(tier="high_performance", ram_gb=64, gpu="nvidia", gpu_vram_gb=24)
+    result = select_policy_bundle(answers, hardware)
+
+    chosen_id = result.bundle.id
+    runner_ids = [b.id for b in result.runner_ups]
+    assert chosen_id not in runner_ids
+    # runner_ups capped at 2 (or fewer when catalogue smaller after
+    # filtering); for the canonical-default path most bundles survive
+    # so we expect exactly 2.
+    assert len(result.runner_ups) <= 2
+
+
+def test_runner_ups_length_matches_candidate_pool() -> None:
+    """When filters leave only 1 candidate, runner_ups is empty."""
+    # local_only + privacy + light hardware narrows to small/medium
+    # local bundles only; check that the runner-up count never
+    # exceeds (candidates - 1).
+    answers = _make_answers(
+        work_styles=("mixed",),
+        priority="privacy",
+        cloud_posture="local_only",
+        compute_posture="light",
+    )
+    hardware = _make_hardware(tier="light", ram_gb=8, gpu="none", cpu_class="low")
+    result = select_policy_bundle(answers, hardware)
+    # At minimum local_lightweight + cost_saver survive; runner_ups
+    # length must be in [0, 2] inclusive.
+    assert 0 <= len(result.runner_ups) <= 2
+
+
+def test_reasons_are_explainable_strings() -> None:
+    """Every reason is a non-empty short string; mentions chosen bundle."""
+    answers = _make_answers(
+        work_styles=("research",),
+        priority="quality",
+        compute_posture="available_power",
+        cloud_posture="hybrid_when_worth_it",
+        background_posture="deep_run_aggressive",
+    )
+    hardware = _make_hardware(tier="high_performance", ram_gb=64, gpu="nvidia", gpu_vram_gb=24)
+    result = select_policy_bundle(answers, hardware)
+
+    assert isinstance(result.reasons, tuple)
+    assert all(isinstance(r, str) and r for r in result.reasons)
+    assert all(len(r) < 120 for r in result.reasons)
+    # The chosen bundle id appears in at least one reason — the
+    # explainability contract from the prompt.
+    chosen_id = result.bundle.id
+    assert any(chosen_id in r for r in result.reasons)
+
+
+# ---------------------------------------------------------------------------
+# Totality contract — cartesian product over enums.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("priority", "cloud_posture", "tier"),
+    list(
+        itertools.product(
+            get_args(Priority),
+            get_args(CloudPosture),
+            get_args(HardwareTier),
+        ),
+    ),
+)
+def test_property_total_function_over_enum_product(
+    priority: Priority,
+    cloud_posture: CloudPosture,
+    tier: HardwareTier,
+) -> None:
+    """select_policy_bundle is total over Priority × CloudPosture × HardwareTier."""
+    answers = _make_answers(priority=priority, cloud_posture=cloud_posture)
+    # Build a hardware profile compatible with the requested tier so
+    # the parametrisation reflects realistic combinations rather than
+    # hardware-tier mismatches with explicit fields.
+    hardware = _make_hardware(tier=tier)
+
+    result = select_policy_bundle(answers, hardware)
+    assert isinstance(result, SelectionResult)
+    assert result.bundle in PROFILE_CATALOG
+    assert isinstance(result.reasons, tuple)
+    assert all(isinstance(r, str) for r in result.reasons)
+    assert isinstance(result.runner_ups, tuple)
+    for runner in result.runner_ups:
+        assert runner in PROFILE_CATALOG
+    assert isinstance(result.forced_fallback, bool)
+
+
+# ---------------------------------------------------------------------------
+# Filter unit tests — each filter in isolation.
+# ---------------------------------------------------------------------------
+
+
+def test_filter_cloud_posture_local_only_drops_cloud() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    answers = _make_answers(cloud_posture="local_only")
+    hardware = _make_hardware()
+    cloud_bundles = [b for b in PROFILE_CATALOG if b.local_cloud_posture in ("hybrid", "cloud_preferred")]
+    assert cloud_bundles, "fixture invariant: catalogue contains cloud-leaning bundles"
+    for bundle in cloud_bundles:
+        assert sel._filter_cloud_posture(answers, hardware, bundle) is not None
+
+
+def test_filter_priority_privacy_drops_relaxed_or_cloud_preferred() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    answers = _make_answers(priority="privacy")
+    hardware = _make_hardware()
+    cloud_pref = [b for b in PROFILE_CATALOG if b.local_cloud_posture == "cloud_preferred"]
+    for bundle in cloud_pref:
+        assert sel._filter_priority_privacy(answers, hardware, bundle) is not None
+
+
+def test_filter_hardware_tier_unknown_drops_local_only() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    answers = _make_answers()
+    hardware = _make_hardware(tier="unknown")
+    local_only = [b for b in PROFILE_CATALOG if b.local_cloud_posture == "local_only"]
+    for bundle in local_only:
+        assert sel._filter_hardware_tier(answers, hardware, bundle) is not None
+
+
+def test_filter_hardware_tier_light_drops_large_runtime() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    answers = _make_answers()
+    hardware = _make_hardware(tier="light")
+    large_bundles = [b for b in PROFILE_CATALOG if b.runtime_profile == "large"]
+    for bundle in large_bundles:
+        assert sel._filter_hardware_tier(answers, hardware, bundle) is not None
+
+
+# ---------------------------------------------------------------------------
+# Match function unit tests — quick spot checks.
+# ---------------------------------------------------------------------------
+
+
+def test_priority_match_balanced_favours_hybrid_balanced() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    bundle = next(b for b in PROFILE_CATALOG if b.id == "hybrid_balanced")
+    score, reason = sel._priority_match("balanced", bundle)
+    assert score == 1.0
+    assert "hybrid_balanced" in reason
+
+
+def test_workstyle_match_averages_multiple_styles() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    bundle = next(b for b in PROFILE_CATALOG if b.id == "deep_research")
+    score_single, _ = sel._workstyle_match(("research",), bundle)
+    score_pair, _ = sel._workstyle_match(("research", "writing"), bundle)
+    # Averaging two equally-positive styles should still be positive
+    # but not *necessarily* equal to either single value.
+    assert score_pair > 0
+    assert score_single > 0
+
+
+def test_hardware_match_high_perf_rewards_large_runtime() -> None:
+    from vaner.setup import select as sel  # noqa: PLC0415
+
+    big = next(b for b in PROFILE_CATALOG if b.runtime_profile == "large")
+    small = next(b for b in PROFILE_CATALOG if b.runtime_profile == "small")
+    score_big, _ = sel._hardware_match("high_performance", big)
+    score_small, _ = sel._hardware_match("high_performance", small)
+    assert score_big > score_small

--- a/ui/cockpit/package.json
+++ b/ui/cockpit/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@vaner/cockpit",
+  "version": "0.2.0",
+  "private": true,
+  "description": "Vaner cockpit (React + Vite) — local control plane for the Vaner daemon.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "a11y:scan": "node scripts/run-axe-scan.mjs",
+    "a11y:scan:mcp": "node scripts/run-axe-scan.mjs --mcp"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@axe-core/cli": "4.10.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.5",
+    "axe-core": "4.10.0",
+    "eslint": "^9.39.4",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
+    "jest-axe": "9.0.0",
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.0",
+    "vite": "^8.0.9",
+    "vitest": "^4.1.5"
+  }
+}

--- a/ui/cockpit/scripts/run-axe-scan.mjs
+++ b/ui/cockpit/scripts/run-axe-scan.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// 0.8.6 WS10 — Minimal axe-core scan runner. Used by both `npm run
+// a11y:scan` (cockpit dev server) and `npm run a11y:scan:mcp` (MCP Apps
+// UI HTML bundle). Reads tests/a11y-audit-baseline.json to know what
+// targets to scan and which violations are pre-acknowledged.
+//
+// CI calls this script after `npm run build` + `npm run preview`. The
+// preview server URL must match the baseline's `cockpit-dev-server` URL
+// (default: http://127.0.0.1:4173 from `vite preview`; we standardise
+// on 5173 for the baseline so the workflow can override via env if
+// needed).
+//
+// Behaviour:
+//   - Spawns axe-core via @axe-core/cli for each target.
+//   - For HTML-file targets (no URL, only `source`), opens the file with
+//     a headless Chromium provided by @axe-core/cli's --browser flag.
+//   - Aggregates results; exits 1 when any violation has a severity in
+//     baseline.fail_on_severities AND is not in baseline.known_violations.
+//
+// This is intentionally a small wrapper so that contributors can also
+// run axe locally without standing up the full CI pipeline.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const COCKPIT_ROOT = path.resolve(__dirname, '..')
+const REPO_ROOT = path.resolve(COCKPIT_ROOT, '..', '..')
+const BASELINE_PATH = path.join(COCKPIT_ROOT, 'tests', 'a11y-audit-baseline.json')
+
+const args = process.argv.slice(2)
+const ONLY_MCP = args.includes('--mcp')
+const ONLY_COCKPIT = args.includes('--cockpit')
+
+if (!existsSync(BASELINE_PATH)) {
+  console.error(`Missing baseline: ${BASELINE_PATH}`)
+  process.exit(2)
+}
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8'))
+
+const targets = baseline.targets.filter((target) => {
+  if (ONLY_MCP) return target.name === 'mcp-apps-active-predictions'
+  if (ONLY_COCKPIT) return target.name === 'cockpit-dev-server'
+  return true
+})
+
+const failOn = new Set(baseline.fail_on_severities ?? ['serious', 'critical'])
+let totalNewViolations = 0
+
+for (const target of targets) {
+  const url = target.url || (target.source ? `file://${path.join(REPO_ROOT, target.source)}` : null)
+  if (!url) {
+    console.error(`Target ${target.name} has neither url nor source; skipping.`)
+    continue
+  }
+  console.log(`\n=== axe-core scan: ${target.name} ===`)
+  console.log(`URL: ${url}`)
+
+  // Defer to @axe-core/cli (installed via devDependencies). If it is
+  // not on PATH, we surface a clear error so contributors know what to
+  // install rather than failing with "command not found".
+  const result = spawnSync(
+    'npx',
+    ['--no-install', '@axe-core/cli', url, '--exit', '--stdout', '--tags', 'wcag2a,wcag2aa,best-practice'],
+    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+  if (result.error) {
+    console.error(`@axe-core/cli not found: ${result.error.message}`)
+    console.error('Install dev deps with `npm install` and retry.')
+    process.exit(2)
+  }
+  const stdout = result.stdout || ''
+  process.stdout.write(stdout)
+  if (result.stderr) process.stderr.write(result.stderr)
+
+  // axe-cli exits 1 on any violation; parse JSON to filter by severity.
+  // The CLI prints a JSON array of violations on stdout when --stdout is
+  // passed. Be defensive: an empty stdout means no violations.
+  let violations = []
+  try {
+    const trimmed = stdout.trim()
+    if (trimmed.startsWith('[')) {
+      violations = JSON.parse(trimmed)
+    }
+  } catch (err) {
+    console.error(`Could not parse axe-cli stdout as JSON: ${err.message}`)
+  }
+
+  const known = new Set((target.known_violations ?? []).map((v) => v.id))
+  for (const v of violations) {
+    const severity = v.impact ?? 'unknown'
+    if (!failOn.has(severity)) continue
+    if (known.has(v.id)) continue
+    totalNewViolations += 1
+    console.error(`NEW [${severity}] ${v.id}: ${v.help}`)
+  }
+}
+
+if (totalNewViolations > 0) {
+  console.error(`\n${totalNewViolations} new violation(s) above the baseline threshold.`)
+  process.exit(1)
+}
+console.log('\nNo new violations above the baseline threshold.')
+process.exit(0)

--- a/ui/cockpit/src/api/setup.test.ts
+++ b/ui/cockpit/src/api/setup.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchHardwareProfile,
+  fetchPolicyCurrent,
+  fetchSetupStatus,
+  postSetupApply,
+  SetupFetchError,
+} from './setup'
+import type { SetupAnswers } from '../types/setup'
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('setup API helpers', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH
+    vi.restoreAllMocks()
+  })
+
+  it('fetchSetupStatus returns null on 404 (WS8 not yet shipped)', async () => {
+    ;(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('not found', { status: 404 }),
+    )
+    const result = await fetchSetupStatus()
+    expect(result).toBeNull()
+  })
+
+  it('fetchSetupStatus parses a 200 JSON body', async () => {
+    ;(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      jsonResponse({ completed: true, selected_bundle_id: 'hybrid_balanced' }),
+    )
+    const result = await fetchSetupStatus()
+    expect(result).toEqual({
+      completed: true,
+      selected_bundle_id: 'hybrid_balanced',
+    })
+  })
+
+  it('fetchSetupStatus returns null on network error rather than throwing', async () => {
+    ;(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new TypeError('NetworkError when attempting to fetch resource.'),
+    )
+    const result = await fetchSetupStatus()
+    expect(result).toBeNull()
+  })
+
+  it('fetchPolicyCurrent returns null on 404', async () => {
+    ;(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('', { status: 404 }),
+    )
+    const result = await fetchPolicyCurrent()
+    expect(result).toBeNull()
+  })
+
+  it('fetchPolicyCurrent throws SetupFetchError on non-404 errors', async () => {
+    ;(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('boom', { status: 500 }),
+    )
+    await expect(fetchPolicyCurrent()).rejects.toBeInstanceOf(SetupFetchError)
+  })
+
+  it('fetchHardwareProfile returns null on 404', async () => {
+    ;(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('', { status: 404 }),
+    )
+    const result = await fetchHardwareProfile()
+    expect(result).toBeNull()
+  })
+
+  it('postSetupApply raises on 404 (mutation)', async () => {
+    ;(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('not found', { status: 404 }),
+    )
+    const answers: SetupAnswers = {
+      work_styles: ['mixed'],
+      priority: 'balanced',
+      compute_posture: 'balanced',
+      cloud_posture: 'hybrid_when_worth_it',
+      background_posture: 'normal',
+    }
+    await expect(postSetupApply(answers)).rejects.toBeInstanceOf(SetupFetchError)
+  })
+
+  it('postSetupApply sends the bundle_id when provided', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        bundle_id: 'cost_saver',
+        overrides_applied: ['BackendConfig.prefer_local: true'],
+      }),
+    )
+    const answers: SetupAnswers = {
+      work_styles: ['coding'],
+      priority: 'cost',
+      compute_posture: 'light',
+      cloud_posture: 'local_only',
+      background_posture: 'minimal',
+    }
+    const result = await postSetupApply(answers, 'cost_saver')
+    expect(result.bundle_id).toBe('cost_saver')
+    const call = fetchMock.mock.calls[0]
+    const init = call[1] as RequestInit
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(String(init.body))).toEqual({
+      answers,
+      bundle_id: 'cost_saver',
+    })
+  })
+})

--- a/ui/cockpit/src/api/setup.ts
+++ b/ui/cockpit/src/api/setup.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// 0.8.6 WS10 — Cockpit fetch helpers for the (forthcoming) WS8 setup
+// HTTP surface: /setup/status, /policy/current, /hardware/profile, and
+// POST /setup/apply.
+//
+// WS8 has not yet shipped these endpoints. Until it does, the GET helpers
+// gracefully resolve to `null` on a 404 so the BundleSummaryCard /
+// HardwareProfilePanel can render a friendly "not yet available" state
+// instead of crashing the cockpit. POST /setup/apply is a mutation —
+// callers should disable the action button if the matching status fetch
+// already returned null, and the helper itself raises on 404.
+//
+// API_BASE follows the same convention as the rest of the cockpit —
+// override via VITE_VANER_DAEMON_URL at build time. See deepRun.ts for
+// the canonical pattern.
+
+import type {
+  AppliedPolicy,
+  HardwareProfile,
+  SetupAnswers,
+  SetupStatus,
+} from '../types/setup'
+
+const API_BASE: string =
+  (typeof import.meta !== 'undefined' &&
+    (import.meta as { env?: Record<string, string> }).env?.VITE_VANER_DAEMON_URL) ||
+  'http://127.0.0.1:8473'
+
+class SetupFetchError extends Error {
+  status: number
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+    this.name = 'SetupFetchError'
+  }
+}
+
+async function _getOrNull<T>(path: string): Promise<T | null> {
+  let response: Response
+  try {
+    response = await fetch(`${API_BASE}${path}`, {
+      headers: { accept: 'application/json' },
+    })
+  } catch (err) {
+    // Network error: treat as "not yet available" so the panel renders
+    // its friendly fallback rather than crashing. The daemon may simply
+    // not be running yet on the cockpit-only dev path.
+    void err
+    return null
+  }
+  if (response.status === 404) {
+    return null
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new SetupFetchError(
+      response.status,
+      `${response.status} ${response.statusText}: ${text}`,
+    )
+  }
+  return (await response.json()) as T
+}
+
+/** Fetch the wizard completion state. Returns `null` if WS8 is not yet shipped. */
+export async function fetchSetupStatus(): Promise<SetupStatus | null> {
+  return _getOrNull<SetupStatus>('/setup/status')
+}
+
+/** Fetch the currently applied policy. Returns `null` if WS8 is not yet shipped. */
+export async function fetchPolicyCurrent(): Promise<AppliedPolicy | null> {
+  return _getOrNull<AppliedPolicy>('/policy/current')
+}
+
+/** Fetch the hardware probe. Returns `null` if WS8 is not yet shipped. */
+export async function fetchHardwareProfile(): Promise<HardwareProfile | null> {
+  return _getOrNull<HardwareProfile>('/hardware/profile')
+}
+
+/**
+ * Apply a SetupAnswers payload. Mutation — raises on 404 (caller should
+ * have disabled the submit button if status fetch already returned null).
+ *
+ * `bundleId` lets the user pin a specific bundle; when omitted the daemon
+ * falls back to running select_policy_bundle() on the answers.
+ */
+export async function postSetupApply(
+  answers: SetupAnswers,
+  bundleId?: string,
+): Promise<AppliedPolicy> {
+  const body: Record<string, unknown> = { answers }
+  if (bundleId) {
+    body.bundle_id = bundleId
+  }
+  const response = await fetch(`${API_BASE}/setup/apply`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new SetupFetchError(
+      response.status,
+      `${response.status} ${response.statusText}: ${text}`,
+    )
+  }
+  return (await response.json()) as AppliedPolicy
+}
+
+export { SetupFetchError }

--- a/ui/cockpit/src/components/BundleSummaryCard.test.tsx
+++ b/ui/cockpit/src/components/BundleSummaryCard.test.tsx
@@ -1,0 +1,178 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  BundleSummaryCard,
+  findWidensCloudOverride,
+} from './BundleSummaryCard'
+import type { AppliedPolicy, VanerPolicyBundle } from '../types/setup'
+
+function makeBundle(overrides: Partial<VanerPolicyBundle> = {}): VanerPolicyBundle {
+  return {
+    id: overrides.id ?? 'hybrid_balanced',
+    label: overrides.label ?? 'Hybrid Balanced',
+    description:
+      overrides.description ??
+      'Mid-spend, mid-latency. The canonical default for "I just want it to work."',
+    local_cloud_posture: overrides.local_cloud_posture ?? 'hybrid',
+    runtime_profile: overrides.runtime_profile ?? 'medium',
+    spend_profile: overrides.spend_profile ?? 'low',
+    latency_profile: overrides.latency_profile ?? 'balanced',
+    privacy_profile: overrides.privacy_profile ?? 'standard',
+    prediction_horizon_bias:
+      overrides.prediction_horizon_bias ?? {
+        likely_next: 1,
+        long_horizon: 1,
+        finish_partials: 1,
+        balanced: 1,
+      },
+    drafting_aggressiveness: overrides.drafting_aggressiveness ?? 1,
+    exploration_ratio: overrides.exploration_ratio ?? 0.2,
+    persistence_strength: overrides.persistence_strength ?? 1,
+    goal_weighting: overrides.goal_weighting ?? 1,
+    context_injection_default:
+      overrides.context_injection_default ?? 'policy_hybrid',
+    deep_run_profile: overrides.deep_run_profile ?? 'balanced',
+  }
+}
+
+function makeApplied(overrides: Partial<AppliedPolicy> = {}): AppliedPolicy {
+  return {
+    bundle_id: overrides.bundle_id ?? 'hybrid_balanced',
+    overrides_applied: overrides.overrides_applied ?? [],
+    bundle: overrides.bundle ?? makeBundle(),
+    selection_reasons: overrides.selection_reasons,
+    runner_ups: overrides.runner_ups,
+  }
+}
+
+describe('BundleSummaryCard', () => {
+  it('renders the wizard-prompt fallback when applied_policy is null', () => {
+    render(
+      <BundleSummaryCard
+        applied_policy={null}
+        selection_reasons={[]}
+        runner_ups={[]}
+      />,
+    )
+    expect(screen.getByText(/Setup not yet completed/i)).toBeInTheDocument()
+    expect(screen.getByText('vaner setup wizard')).toBeInTheDocument()
+  })
+
+  it('renders the bundle label and id when a policy is applied', () => {
+    render(
+      <BundleSummaryCard
+        applied_policy={makeApplied()}
+        selection_reasons={['Speed-first → hybrid_balanced is balanced']}
+        runner_ups={[]}
+      />,
+    )
+    expect(screen.getByText(/Hybrid Balanced/)).toBeInTheDocument()
+    expect(screen.getByTestId('bundle-id')).toHaveTextContent('hybrid_balanced')
+  })
+
+  it('renders the cloud-widening warning ribbon when sentinel is present', () => {
+    const applied = makeApplied({
+      overrides_applied: [
+        'WIDENS_CLOUD_POSTURE: local_only->hybrid',
+        'BackendConfig.prefer_local: false',
+      ],
+    })
+    render(
+      <BundleSummaryCard
+        applied_policy={applied}
+        selection_reasons={[]}
+        runner_ups={[]}
+      />,
+    )
+    const ribbon = screen.getByTestId('bundle-widens-ribbon')
+    expect(ribbon).toBeInTheDocument()
+    expect(ribbon).toHaveTextContent(/local_only->hybrid/)
+    expect(ribbon).toHaveAttribute('role', 'alert')
+  })
+
+  it('does not render the warning ribbon when sentinel is absent', () => {
+    render(
+      <BundleSummaryCard
+        applied_policy={makeApplied({
+          overrides_applied: ['BackendConfig.prefer_local: true'],
+        })}
+        selection_reasons={[]}
+        runner_ups={[]}
+      />,
+    )
+    expect(screen.queryByTestId('bundle-widens-ribbon')).not.toBeInTheDocument()
+  })
+
+  it('expands the "Why this bundle?" disclosure to show reasons', () => {
+    render(
+      <BundleSummaryCard
+        applied_policy={makeApplied()}
+        selection_reasons={['Reason A', 'Reason B']}
+        runner_ups={[]}
+      />,
+    )
+    expect(screen.getByText(/Why this bundle\? \(2\)/)).toBeInTheDocument()
+    // Reasons render inside the <details>, so they are always in the DOM
+    // (jsdom doesn't hide closed-details children from queries).
+    expect(screen.getByText('Reason A')).toBeInTheDocument()
+    expect(screen.getByText('Reason B')).toBeInTheDocument()
+  })
+
+  it('renders runner-up bundle labels when provided', () => {
+    const runner = makeBundle({ id: 'cost_saver', label: 'Cost Saver' })
+    render(
+      <BundleSummaryCard
+        applied_policy={makeApplied()}
+        selection_reasons={[]}
+        runner_ups={[runner]}
+      />,
+    )
+    expect(screen.getByText('Cost Saver')).toBeInTheDocument()
+    expect(screen.getByText('cost_saver')).toBeInTheDocument()
+  })
+
+  it('calls onOpenWizard when provided instead of using the clipboard', () => {
+    const onOpenWizard = vi.fn()
+    render(
+      <BundleSummaryCard
+        applied_policy={null}
+        selection_reasons={[]}
+        runner_ups={[]}
+        onOpenWizard={onOpenWizard}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Copy/ }))
+    expect(onOpenWizard).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes a section role with an aria-label', () => {
+    render(
+      <BundleSummaryCard
+        applied_policy={makeApplied()}
+        selection_reasons={[]}
+        runner_ups={[]}
+      />,
+    )
+    expect(screen.getByRole('region')).toBeInTheDocument()
+  })
+})
+
+describe('findWidensCloudOverride', () => {
+  it('returns the matching line when the sentinel is present', () => {
+    expect(
+      findWidensCloudOverride([
+        'BackendConfig.prefer_local: false',
+        'WIDENS_CLOUD_POSTURE: local_only->cloud_preferred',
+      ]),
+    ).toBe('WIDENS_CLOUD_POSTURE: local_only->cloud_preferred')
+  })
+
+  it('returns null when the sentinel is absent', () => {
+    expect(findWidensCloudOverride(['info: bundle.privacy_profile=strict'])).toBeNull()
+  })
+
+  it('returns null on undefined input', () => {
+    expect(findWidensCloudOverride(undefined)).toBeNull()
+  })
+})

--- a/ui/cockpit/src/components/BundleSummaryCard.tsx
+++ b/ui/cockpit/src/components/BundleSummaryCard.tsx
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// 0.8.6 WS10 — BundleSummaryCard
+//
+// Read-only disclosure card for the cockpit Settings drawer. Surfaces the
+// currently applied VanerPolicyBundle, its selection reasons, and the
+// runner-up bundles so the user can see "why this bundle, not that one"
+// without having to re-run the wizard. When the daemon's /policy/current
+// endpoint has not yet been wired (WS8 not yet shipped), the parent
+// passes `applied_policy={null}` and the card renders a wizard-prompt
+// fallback.
+//
+// Cloud-widening sentinel
+// -----------------------
+// When `applied_policy.overrides_applied` includes a string starting with
+// WIDENS_CLOUD_POSTURE, a yellow warning ribbon is rendered at the top.
+// This matches WS5's apply_policy_bundle audit-log contract — see
+// src/vaner/setup/apply.py and the WIDENS_CLOUD_POSTURE_SENTINEL constant
+// re-exported from ../types/setup.
+
+import { useState } from 'react'
+
+import {
+  WIDENS_CLOUD_POSTURE_SENTINEL,
+  type AppliedPolicy,
+  type VanerPolicyBundle,
+} from '../types/setup'
+
+export interface BundleSummaryCardProps {
+  applied_policy: AppliedPolicy | null
+  selection_reasons: string[]
+  runner_ups: VanerPolicyBundle[]
+  /** Optional callback for the "Open setup wizard" action. */
+  onOpenWizard?: () => void
+}
+
+const WIZARD_CLI_COMMAND = 'vaner setup wizard'
+
+function cardStyle(): React.CSSProperties {
+  return {
+    border: '1px solid var(--line-1)',
+    borderRadius: 'var(--r-2, 6px)',
+    background: 'var(--bg-1, #18181c)',
+    padding: '14px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 10,
+    color: 'var(--fg-1, #f0f0f0)',
+  }
+}
+
+function rowStyle(): React.CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    gap: 10,
+  }
+}
+
+function pillStyle(): React.CSSProperties {
+  return {
+    fontSize: 10.5,
+    color: 'var(--fg-3, #9a9aa2)',
+    fontFamily: 'var(--font-mono, monospace)',
+    letterSpacing: 0.4,
+  }
+}
+
+function disclosureSummaryStyle(open: boolean): React.CSSProperties {
+  return {
+    cursor: 'pointer',
+    fontSize: 12,
+    color: open ? 'var(--accent, #5eb2ff)' : 'var(--fg-2, #d0d0d6)',
+    fontWeight: 500,
+    listStyle: 'none',
+  }
+}
+
+function widensRibbonStyle(): React.CSSProperties {
+  return {
+    background: '#3a2d00',
+    border: '1px solid var(--amber, #e6b656)',
+    borderRadius: 4,
+    color: 'var(--amber, #e6b656)',
+    padding: '6px 10px',
+    fontSize: 11.5,
+    lineHeight: 1.4,
+  }
+}
+
+function buttonStyle(): React.CSSProperties {
+  return {
+    fontFamily: 'inherit',
+    fontSize: 12,
+    fontWeight: 600,
+    padding: '6px 12px',
+    borderRadius: 4,
+    border: '1px solid var(--accent, #5eb2ff)',
+    background: 'transparent',
+    color: 'var(--accent, #5eb2ff)',
+    cursor: 'pointer',
+  }
+}
+
+/**
+ * Returns the WIDENS_CLOUD_POSTURE entry from `overrides_applied`, or null.
+ * Exported for unit tests that want to assert the sentinel matching logic
+ * without re-rendering the full card.
+ */
+export function findWidensCloudOverride(
+  overrides_applied: readonly string[] | undefined,
+): string | null {
+  if (!overrides_applied) return null
+  for (const line of overrides_applied) {
+    if (typeof line === 'string' && line.startsWith(WIDENS_CLOUD_POSTURE_SENTINEL)) {
+      return line
+    }
+  }
+  return null
+}
+
+export function BundleSummaryCard({
+  applied_policy,
+  selection_reasons,
+  runner_ups,
+  onOpenWizard,
+}: BundleSummaryCardProps) {
+  const [showReasons, setShowReasons] = useState(false)
+  const [showRunnerUps, setShowRunnerUps] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  if (applied_policy === null) {
+    return (
+      <section
+        aria-label="Vaner setup status"
+        role="region"
+        style={cardStyle()}
+        data-testid="bundle-summary-card-empty"
+      >
+        <div style={rowStyle()}>
+          <strong style={{ fontSize: 13 }}>Setup not yet completed</strong>
+        </div>
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--fg-2, #d0d0d6)' }}>
+          Run <code>{WIZARD_CLI_COMMAND}</code> to begin.
+        </p>
+        <div>
+          <button
+            type="button"
+            style={buttonStyle()}
+            onClick={() => void handleOpenWizard(onOpenWizard, setCopied)}
+            aria-label="Copy 'vaner setup wizard' command to clipboard"
+          >
+            {copied ? 'Copied!' : 'Open setup wizard'}
+          </button>
+        </div>
+      </section>
+    )
+  }
+
+  const widensOverride = findWidensCloudOverride(applied_policy.overrides_applied)
+  const bundleLabel = applied_policy.bundle?.label ?? applied_policy.bundle_id
+  const bundleId = applied_policy.bundle_id
+  const reasons =
+    selection_reasons.length > 0
+      ? selection_reasons
+      : applied_policy.selection_reasons ?? []
+  const runners = runner_ups.length > 0 ? runner_ups : applied_policy.runner_ups ?? []
+
+  return (
+    <section
+      aria-labelledby="bundle-summary-card-heading"
+      role="region"
+      style={cardStyle()}
+      data-testid="bundle-summary-card"
+    >
+      {widensOverride ? (
+        <div role="alert" style={widensRibbonStyle()} data-testid="bundle-widens-ribbon">
+          <strong>Cloud posture widened:</strong> {widensOverride.replace(/^WIDENS_CLOUD_POSTURE:?\s*/, '')}
+        </div>
+      ) : null}
+      <div style={rowStyle()}>
+        <h3
+          id="bundle-summary-card-heading"
+          style={{
+            margin: 0,
+            fontSize: 13.5,
+            fontWeight: 600,
+            color: 'var(--fg-1, #f0f0f0)',
+          }}
+        >
+          {bundleLabel} <span style={pillStyle()}>(auto-selected)</span>
+        </h3>
+        <span style={pillStyle()} data-testid="bundle-id">
+          {bundleId}
+        </span>
+      </div>
+
+      {applied_policy.bundle?.description ? (
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--fg-2, #d0d0d6)' }}>
+          {applied_policy.bundle.description}
+        </p>
+      ) : null}
+
+      <details
+        open={showReasons}
+        onToggle={(event) => setShowReasons((event.currentTarget as HTMLDetailsElement).open)}
+      >
+        <summary style={disclosureSummaryStyle(showReasons)}>
+          Why this bundle? ({reasons.length})
+        </summary>
+        {reasons.length === 0 ? (
+          <p style={{ margin: '8px 0 0', fontSize: 11.5, color: 'var(--fg-3, #9a9aa2)' }}>
+            No reasons recorded — the wizard hit its forced-fallback path.
+          </p>
+        ) : (
+          <ul style={{ margin: '8px 0 0', paddingLeft: 18, fontSize: 11.5, color: 'var(--fg-2, #d0d0d6)' }}>
+            {reasons.map((reason, idx) => (
+              <li key={idx}>{reason}</li>
+            ))}
+          </ul>
+        )}
+      </details>
+
+      <details
+        open={showRunnerUps}
+        onToggle={(event) => setShowRunnerUps((event.currentTarget as HTMLDetailsElement).open)}
+      >
+        <summary style={disclosureSummaryStyle(showRunnerUps)}>
+          Other options ({runners.length})
+        </summary>
+        {runners.length === 0 ? (
+          <p style={{ margin: '8px 0 0', fontSize: 11.5, color: 'var(--fg-3, #9a9aa2)' }}>
+            No runner-ups recorded.
+          </p>
+        ) : (
+          <ul
+            style={{ margin: '8px 0 0', paddingLeft: 18, fontSize: 11.5, color: 'var(--fg-2, #d0d0d6)' }}
+            aria-label="Runner-up bundles"
+          >
+            {runners.map((bundle) => (
+              <li key={bundle.id}>
+                <strong style={{ color: 'var(--fg-1, #f0f0f0)' }}>{bundle.label}</strong>{' '}
+                <span style={pillStyle()}>{bundle.id}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </details>
+
+      <div>
+        <button
+          type="button"
+          style={buttonStyle()}
+          onClick={() => void handleOpenWizard(onOpenWizard, setCopied)}
+          aria-label="Copy 'vaner setup wizard' command to clipboard"
+        >
+          {copied ? 'Copied!' : 'Open setup wizard'}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+async function handleOpenWizard(
+  onOpenWizard: (() => void) | undefined,
+  setCopied: (next: boolean) => void,
+): Promise<void> {
+  if (onOpenWizard) {
+    onOpenWizard()
+    return
+  }
+  // Clipboard fallback — a desktop deep-link will be added in a later WS;
+  // for now the user gets the CLI invocation copied to their clipboard.
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(WIZARD_CLI_COMMAND)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1800)
+      return
+    }
+  } catch {
+    // Clipboard API may be unavailable in test or insecure contexts.
+  }
+  // Last-ditch fallback: surface the command in an alert so the user can
+  // still copy it manually.
+  if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+    window.alert(`Run this command in your terminal:\n\n${WIZARD_CLI_COMMAND}`)
+  }
+}

--- a/ui/cockpit/src/components/HardwareProfilePanel.test.tsx
+++ b/ui/cockpit/src/components/HardwareProfilePanel.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { HardwareProfilePanel } from './HardwareProfilePanel'
+import type { HardwareProfile } from '../types/setup'
+
+function makeProfile(overrides: Partial<HardwareProfile> = {}): HardwareProfile {
+  return {
+    os: overrides.os ?? 'darwin',
+    cpu_class: overrides.cpu_class ?? 'high',
+    ram_gb: overrides.ram_gb ?? 32,
+    gpu: overrides.gpu ?? 'apple_silicon',
+    gpu_vram_gb: overrides.gpu_vram_gb ?? null,
+    is_battery: overrides.is_battery ?? false,
+    thermal_constrained: overrides.thermal_constrained ?? false,
+    detected_runtimes: overrides.detected_runtimes ?? ['ollama', 'mlx'],
+    detected_models:
+      overrides.detected_models ?? [
+        ['ollama', 'qwen2.5-coder:7b', '4.4GB'],
+        ['ollama', 'llama3.1:8b', '4.7GB'],
+      ],
+    tier: overrides.tier ?? 'capable',
+  }
+}
+
+describe('HardwareProfilePanel', () => {
+  it('renders the unavailable fallback when profile is null', () => {
+    render(<HardwareProfilePanel profile={null} />)
+    expect(
+      screen.getByText(/Hardware probe unavailable on this daemon/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the tier readout summary line', () => {
+    render(<HardwareProfilePanel profile={makeProfile()} />)
+    expect(screen.getByText(/Capable device/)).toBeInTheDocument()
+    expect(screen.getByText(/32 GB RAM/)).toBeInTheDocument()
+    expect(screen.getByText(/Apple Silicon GPU/)).toBeInTheDocument()
+  })
+
+  it('renders detected runtime chips', () => {
+    render(<HardwareProfilePanel profile={makeProfile()} />)
+    // "ollama" appears both as a runtime chip and inside each detected
+    // model row, so query the runtime list by aria-label.
+    const runtimeList = screen.getByLabelText('Detected runtimes')
+    expect(runtimeList).toHaveTextContent('ollama')
+    expect(runtimeList).toHaveTextContent('mlx')
+  })
+
+  it('renders detected models inside the disclosure', () => {
+    render(<HardwareProfilePanel profile={makeProfile()} />)
+    expect(screen.getByText(/Detected models \(2\)/)).toBeInTheDocument()
+    expect(screen.getByText('qwen2.5-coder:7b')).toBeInTheDocument()
+    expect(screen.getByText('llama3.1:8b')).toBeInTheDocument()
+  })
+
+  it('renders the empty-runtime hint when none detected', () => {
+    render(
+      <HardwareProfilePanel
+        profile={makeProfile({ detected_runtimes: [], detected_models: [] })}
+      />,
+    )
+    expect(screen.getByText(/None detected/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/No local models detected/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders battery + thermal qualifiers when set', () => {
+    render(
+      <HardwareProfilePanel
+        profile={makeProfile({ is_battery: true, thermal_constrained: true })}
+      />,
+    )
+    expect(screen.getByText(/on battery/)).toBeInTheDocument()
+    expect(screen.getByText(/thermal-constrained/)).toBeInTheDocument()
+  })
+
+  it('exposes a region role with the device heading', () => {
+    render(<HardwareProfilePanel profile={makeProfile()} />)
+    const region = screen.getByRole('region')
+    expect(region).toBeInTheDocument()
+    // The heading "DEVICE" labels the region.
+    expect(screen.getByRole('heading', { name: 'DEVICE' })).toBeInTheDocument()
+  })
+
+  it('hides the refresh button when no onRefresh is provided', () => {
+    render(<HardwareProfilePanel profile={makeProfile()} />)
+    expect(
+      screen.queryByRole('button', { name: /Re-run hardware probe/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('invokes onRefresh when the refresh button is clicked', () => {
+    const onRefresh = vi.fn()
+    render(
+      <HardwareProfilePanel profile={makeProfile()} onRefresh={onRefresh} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Re-run hardware probe/i }))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the refresh button while refreshing', () => {
+    render(
+      <HardwareProfilePanel
+        profile={makeProfile()}
+        onRefresh={vi.fn()}
+        refreshing
+      />,
+    )
+    expect(
+      screen.getByRole('button', { name: /Re-run hardware probe/i }),
+    ).toBeDisabled()
+  })
+})

--- a/ui/cockpit/src/components/HardwareProfilePanel.tsx
+++ b/ui/cockpit/src/components/HardwareProfilePanel.tsx
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+// 0.8.6 WS10 — HardwareProfilePanel
+//
+// Renders the daemon-side HardwareProfile snapshot (see WS2 in
+// src/vaner/setup/hardware.py). Surfaced inside SystemVitals' "Device"
+// section so the user can see why a particular policy bundle was
+// auto-selected and which local runtimes / models the daemon detected.
+//
+// Until WS8 ships /hardware/profile, the parent passes `profile={null}`
+// and the panel renders a "Hardware probe unavailable on this daemon"
+// fallback. The Refresh button delegates to the parent's onRefresh
+// callback so the parent can choose how to surface a 404 (toast,
+// silent, etc.).
+
+import { useState } from 'react'
+
+import type {
+  CPUClass,
+  DetectedModel,
+  GPUKind,
+  HardwareProfile,
+  HardwareTier,
+  Runtime,
+} from '../types/setup'
+
+export interface HardwareProfilePanelProps {
+  profile: HardwareProfile | null
+  /** Optional refresh hook. When omitted, the refresh button is hidden. */
+  onRefresh?: () => Promise<void> | void
+  /** When true, the refresh action is in flight. */
+  refreshing?: boolean
+}
+
+const TIER_LABEL: Record<HardwareTier, string> = {
+  light: 'Light device',
+  capable: 'Capable device',
+  high_performance: 'High-performance device',
+  unknown: 'Unknown device',
+}
+
+const GPU_LABEL: Record<GPUKind, string> = {
+  none: 'No GPU',
+  integrated: 'Integrated GPU',
+  nvidia: 'NVIDIA GPU',
+  amd: 'AMD GPU',
+  apple_silicon: 'Apple Silicon GPU',
+}
+
+const CPU_LABEL: Record<CPUClass, string> = {
+  low: 'Low-end CPU',
+  mid: 'Mid-range CPU',
+  high: 'High-end CPU',
+}
+
+function panelStyle(): React.CSSProperties {
+  return {
+    padding: '14px 16px',
+    borderTop: '1px solid var(--line-hair, #2a2a2f)',
+    background: 'var(--bg-0, #101013)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 10,
+    color: 'var(--fg-1, #f0f0f0)',
+  }
+}
+
+function chipStyle(): React.CSSProperties {
+  return {
+    display: 'inline-block',
+    fontFamily: 'var(--font-mono, monospace)',
+    fontSize: 10.5,
+    background: 'var(--bg-inset, #1a1a1f)',
+    border: '1px solid var(--line-1, #2a2a2f)',
+    borderRadius: 999,
+    padding: '2px 8px',
+    color: 'var(--fg-2, #d0d0d6)',
+  }
+}
+
+function refreshButtonStyle(): React.CSSProperties {
+  return {
+    fontFamily: 'inherit',
+    fontSize: 11,
+    fontWeight: 500,
+    padding: '4px 10px',
+    borderRadius: 4,
+    border: '1px solid var(--line-1, #2a2a2f)',
+    background: 'transparent',
+    color: 'var(--fg-2, #d0d0d6)',
+    cursor: 'pointer',
+  }
+}
+
+function summaryLine(profile: HardwareProfile): string {
+  const parts: string[] = []
+  parts.push(TIER_LABEL[profile.tier] ?? 'Device')
+  if (profile.ram_gb > 0) {
+    parts.push(`${profile.ram_gb} GB RAM`)
+  }
+  if (profile.gpu !== 'none') {
+    const gpuLabel = GPU_LABEL[profile.gpu] ?? 'GPU'
+    if (profile.gpu_vram_gb && profile.gpu_vram_gb > 0) {
+      parts.push(`${gpuLabel} (${profile.gpu_vram_gb} GB VRAM)`)
+    } else {
+      parts.push(gpuLabel)
+    }
+  }
+  parts.push(CPU_LABEL[profile.cpu_class] ?? 'CPU')
+  if (profile.is_battery) {
+    parts.push('on battery')
+  }
+  if (profile.thermal_constrained) {
+    parts.push('thermal-constrained')
+  }
+  return parts.join(' · ')
+}
+
+export function HardwareProfilePanel({
+  profile,
+  onRefresh,
+  refreshing,
+}: HardwareProfilePanelProps) {
+  const [showModels, setShowModels] = useState(false)
+
+  if (profile === null) {
+    return (
+      <section
+        aria-labelledby="hardware-profile-heading"
+        role="region"
+        style={panelStyle()}
+        data-testid="hardware-profile-panel-unavailable"
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h3
+            id="hardware-profile-heading"
+            style={{ margin: 0, fontSize: 11, letterSpacing: 1.2, color: 'var(--fg-4, #6f6f78)' }}
+          >
+            DEVICE
+          </h3>
+          {onRefresh ? (
+            <button
+              type="button"
+              style={refreshButtonStyle()}
+              onClick={() => void onRefresh()}
+              disabled={refreshing === true}
+              aria-label="Re-run hardware probe"
+            >
+              {refreshing ? 'Refreshing…' : 'Refresh'}
+            </button>
+          ) : null}
+        </div>
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--fg-2, #d0d0d6)' }}>
+          Hardware probe unavailable on this daemon.
+        </p>
+      </section>
+    )
+  }
+
+  const runtimes: Runtime[] = profile.detected_runtimes ?? []
+  const models: DetectedModel[] = profile.detected_models ?? []
+
+  return (
+    <section
+      aria-labelledby="hardware-profile-heading"
+      role="region"
+      style={panelStyle()}
+      data-testid="hardware-profile-panel"
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h3
+          id="hardware-profile-heading"
+          style={{ margin: 0, fontSize: 11, letterSpacing: 1.2, color: 'var(--fg-4, #6f6f78)' }}
+        >
+          DEVICE
+        </h3>
+        {onRefresh ? (
+          <button
+            type="button"
+            style={refreshButtonStyle()}
+            onClick={() => void onRefresh()}
+            disabled={refreshing === true}
+            aria-label="Re-run hardware probe"
+          >
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+        ) : null}
+      </div>
+
+      <p style={{ margin: 0, fontSize: 12.5, color: 'var(--fg-1, #f0f0f0)' }}>
+        {summaryLine(profile)}
+      </p>
+
+      <div>
+        <div
+          style={{ fontSize: 10.5, color: 'var(--fg-4, #6f6f78)', letterSpacing: 0.6, marginBottom: 4 }}
+        >
+          DETECTED RUNTIMES
+        </div>
+        {runtimes.length === 0 ? (
+          <span style={{ fontSize: 11.5, color: 'var(--fg-3, #9a9aa2)' }}>None detected.</span>
+        ) : (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }} aria-label="Detected runtimes">
+            {runtimes.map((runtime) => (
+              <span key={runtime} style={chipStyle()}>
+                {runtime}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <details
+        open={showModels}
+        onToggle={(event) => setShowModels((event.currentTarget as HTMLDetailsElement).open)}
+      >
+        <summary
+          style={{
+            cursor: 'pointer',
+            fontSize: 11.5,
+            color: showModels ? 'var(--accent, #5eb2ff)' : 'var(--fg-2, #d0d0d6)',
+            listStyle: 'none',
+          }}
+        >
+          Detected models ({models.length})
+        </summary>
+        {models.length === 0 ? (
+          <p style={{ margin: '6px 0 0', fontSize: 11.5, color: 'var(--fg-3, #9a9aa2)' }}>
+            No local models detected. Install Ollama / LM Studio to populate this list.
+          </p>
+        ) : (
+          <ul
+            style={{
+              margin: '6px 0 0',
+              paddingLeft: 18,
+              fontSize: 11.5,
+              color: 'var(--fg-2, #d0d0d6)',
+            }}
+            aria-label="Detected models"
+          >
+            {models.map(([runtime, name, sizeLabel], idx) => (
+              <li key={`${runtime}:${name}:${idx}`}>
+                <span style={{ color: 'var(--fg-1, #f0f0f0)' }}>{name}</span>{' '}
+                <span style={chipStyle()}>{runtime}</span>{' '}
+                <span style={chipStyle()}>{sizeLabel}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </details>
+    </section>
+  )
+}

--- a/ui/cockpit/src/components/SystemVitals.tsx
+++ b/ui/cockpit/src/components/SystemVitals.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react'
 
 import type { CycleState, ModelState } from '../api/usePipelineEvents'
 import type { BucketBudgets } from '../types'
+import type { HardwareProfile } from '../types/setup'
+import { HardwareProfilePanel } from './HardwareProfilePanel'
 
 export interface SystemVitalsProps {
   live: boolean
@@ -27,6 +29,14 @@ export interface SystemVitalsProps {
     count: number
     accuracy: number
   }> | null
+  // 0.8.6 WS10 — optional Device readout. The HardwareProfilePanel is
+  // rendered as a new section under the existing vitals so the user can
+  // see *why* a particular bundle was auto-selected. Until WS8 wires the
+  // /hardware/profile endpoint, the parent passes hardwareProfile=null
+  // and the panel renders its "probe unavailable" fallback.
+  hardwareProfile?: HardwareProfile | null
+  onRefreshHardware?: () => Promise<void> | void
+  refreshingHardware?: boolean
 }
 
 function formatDuration(ms: number | null | undefined): string {
@@ -69,6 +79,9 @@ export function SystemVitals({
   pendingLlm,
   predictionMetrics,
   predictionCalibration,
+  hardwareProfile,
+  onRefreshHardware,
+  refreshingHardware,
 }: SystemVitalsProps) {
   const calibrationEce =
     predictionCalibration && predictionCalibration.length
@@ -238,6 +251,17 @@ export function SystemVitals({
         <VitalRow
           label="llm errors"
           value={<span style={{ color: 'var(--err)' }}>{model.totalErrors}</span>}
+        />
+      ) : null}
+      {/* 0.8.6 WS10 — Device / hardware readout. Rendered when the parent
+          provides at least one hardware-related prop; null profile renders
+          the "probe unavailable" fallback so users on a daemon that has
+          not yet wired WS8 still see a clear message. */}
+      {hardwareProfile !== undefined || onRefreshHardware ? (
+        <HardwareProfilePanel
+          profile={hardwareProfile ?? null}
+          onRefresh={onRefreshHardware}
+          refreshing={refreshingHardware}
         />
       ) : null}
     </div>

--- a/ui/cockpit/src/components/chrome.tsx
+++ b/ui/cockpit/src/components/chrome.tsx
@@ -14,6 +14,8 @@ import type {
   UIPinnedFact,
   UISkill,
 } from '../types'
+import type { AppliedPolicy, VanerPolicyBundle } from '../types/setup'
+import { BundleSummaryCard } from './BundleSummaryCard'
 
 export interface CommandItem {
   id: string
@@ -86,7 +88,7 @@ export function TopBar({ running, onToggleRun, packageState, onOpenSettings, onO
             {running ? 'LIVE' : 'RETRYING'}
           </span>
         </div>
-        <button onClick={onToggleRun} style={headerBtn}>
+        <button type="button" onClick={onToggleRun} style={headerBtn} aria-label="Refresh cockpit data">
           ↻ refresh
         </button>
         {packageState ? (
@@ -105,10 +107,22 @@ export function TopBar({ running, onToggleRun, packageState, onOpenSettings, onO
             </div>
           </>
         ) : null}
-        <button onClick={onOpenPalette} style={headerBtn} title="Command palette (Ctrl/Cmd+K)">
+        <button
+          type="button"
+          onClick={onOpenPalette}
+          style={headerBtn}
+          title="Command palette (Ctrl/Cmd+K)"
+          aria-label="Open command palette"
+        >
           ⌘K
         </button>
-        <button onClick={onOpenSettings} style={headerBtn} title="Settings">
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          style={headerBtn}
+          title="Settings"
+          aria-label="Open settings"
+        >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3">
             <circle cx="6" cy="6" r="1.5" />
             <path d="M6 1v1.5M6 9.5V11M11 6H9.5M2.5 6H1M9.5 2.5 8.5 3.5M3.5 8.5 2.5 9.5M9.5 9.5 8.5 8.5M3.5 3.5 2.5 2.5" />
@@ -580,6 +594,13 @@ interface SettingsDrawerProps {
   onSaveContext: (maxContextTokens: number) => Promise<void>
   onPatchCockpit: (patch: Partial<CockpitSettings>) => void
   onToggleGateway?: (enabled: boolean) => Promise<void>
+  // 0.8.6 WS10 — optional bundle-summary inputs. Until WS8's
+  // /policy/current endpoint ships, the parent App passes
+  // appliedPolicy={null} and the BundleSummaryCard renders its
+  // wizard-prompt fallback.
+  appliedPolicy?: AppliedPolicy | null
+  selectionReasons?: string[]
+  runnerUps?: VanerPolicyBundle[]
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -758,6 +779,11 @@ export function SettingsDrawer(props: SettingsDrawerProps) {
     onSaveContext,
     onPatchCockpit,
     onToggleGateway,
+    // 0.8.6 WS10 — bundle summary props are optional; App.tsx passes
+    // null until WS8 wires the daemon /policy/current endpoint.
+    appliedPolicy = null,
+    selectionReasons = [],
+    runnerUps = [],
   } = props
 
   if (!open) {
@@ -795,11 +821,26 @@ export function SettingsDrawer(props: SettingsDrawerProps) {
               {mode} · saves to .vaner/config.toml
             </div>
           </div>
-          <button onClick={onClose} style={{ background: 'transparent', border: 'none', color: 'var(--fg-3)', fontSize: 20, cursor: 'pointer' }}>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close settings"
+            style={{ background: 'transparent', border: 'none', color: 'var(--fg-3)', fontSize: 20, cursor: 'pointer' }}
+          >
             ×
           </button>
         </div>
         <div className="scroll" style={{ flex: 1, overflow: 'auto' }}>
+          {/* 0.8.6 WS10 — Bundle summary card. Always rendered; the card
+              itself decides whether to show the applied bundle, the
+              wizard-prompt fallback, or the cloud-widening warning. */}
+          <Section title="POLICY BUNDLE">
+            <BundleSummaryCard
+              applied_policy={appliedPolicy}
+              selection_reasons={selectionReasons}
+              runner_ups={runnerUps}
+            />
+          </Section>
           <Section title="BACKEND">
             <Field label="Preset">
               <SelectInput

--- a/ui/cockpit/src/test/setup.ts
+++ b/ui/cockpit/src/test/setup.ts
@@ -1,4 +1,15 @@
 import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+// 0.8.6 WS10 — explicit cleanup hook. With `globals: false` in vitest 4,
+// the auto-cleanup that @testing-library/react traditionally registers
+// against the global `afterEach` is not wired up; we register it here so
+// each test gets a fresh DOM and getByRole() does not collide across
+// renders that accumulate inside the same test file.
+afterEach(() => {
+  cleanup()
+})
 
 class MockResizeObserver {
   observe(): void {

--- a/ui/cockpit/src/types/setup.ts
+++ b/ui/cockpit/src/types/setup.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// 0.8.6 WS10 — TypeScript mirrors of the WS1/WS2/WS3/WS5 setup primitives.
+//
+// TODO: replace with ts-rs generated types when vaner-contract ships them.
+//
+// Hand-written mirrors of:
+//   - SetupAnswers          (src/vaner/setup/answers.py)
+//   - VanerPolicyBundle     (src/vaner/setup/policy.py)
+//   - SelectionResult       (src/vaner/setup/select.py)
+//   - AppliedPolicy         (src/vaner/setup/apply.py)
+//   - HardwareProfile       (src/vaner/setup/hardware.py)
+//
+// Field names and Literal vocabularies are byte-aligned with the Python
+// dataclasses; downstream WS8 daemon endpoints serialise these in the
+// exact shape declared here. WS11 may add ts-rs codegen; until then, treat
+// this file as the authoritative cockpit-side schema.
+
+// ---------------------------------------------------------------------------
+// Setup answers (WS1)
+// ---------------------------------------------------------------------------
+
+export type WorkStyle =
+  | 'writing'
+  | 'research'
+  | 'planning'
+  | 'support'
+  | 'learning'
+  | 'coding'
+  | 'general'
+  | 'mixed'
+  | 'unsure'
+
+export type Priority =
+  | 'balanced'
+  | 'speed'
+  | 'quality'
+  | 'privacy'
+  | 'cost'
+  | 'low_resource'
+
+export type ComputePosture = 'light' | 'balanced' | 'available_power'
+
+export type CloudPosture =
+  | 'local_only'
+  | 'ask_first'
+  | 'hybrid_when_worth_it'
+  | 'best_available'
+
+export type BackgroundPosture =
+  | 'minimal'
+  | 'normal'
+  | 'idle_more'
+  | 'deep_run_aggressive'
+
+export type HardwareTier = 'light' | 'capable' | 'high_performance' | 'unknown'
+
+export interface SetupAnswers {
+  work_styles: WorkStyle[]
+  priority: Priority
+  compute_posture: ComputePosture
+  cloud_posture: CloudPosture
+  background_posture: BackgroundPosture
+}
+
+// ---------------------------------------------------------------------------
+// Policy bundles (WS1)
+// ---------------------------------------------------------------------------
+
+export type LocalCloudPosture =
+  | 'local_only'
+  | 'local_preferred'
+  | 'hybrid'
+  | 'cloud_preferred'
+
+export type RuntimeProfile = 'small' | 'medium' | 'large' | 'auto'
+export type SpendProfile = 'zero' | 'low' | 'medium' | 'high'
+export type LatencyProfile = 'snappy' | 'balanced' | 'quality'
+export type PrivacyProfile = 'strict' | 'standard' | 'relaxed'
+
+export type PredictionHorizonKey =
+  | 'likely_next'
+  | 'long_horizon'
+  | 'finish_partials'
+  | 'balanced'
+
+export type ContextInjectionMode =
+  | 'none'
+  | 'digest_only'
+  | 'adopted_package_only'
+  | 'top_match_auto_include'
+  | 'policy_hybrid'
+  | 'client_controlled'
+
+// Mirrors vaner.intent.deep_run.DeepRunPreset.
+export type DeepRunPresetMirror = 'conservative' | 'balanced' | 'aggressive'
+
+export interface VanerPolicyBundle {
+  id: string
+  label: string
+  description: string
+  local_cloud_posture: LocalCloudPosture
+  runtime_profile: RuntimeProfile
+  spend_profile: SpendProfile
+  latency_profile: LatencyProfile
+  privacy_profile: PrivacyProfile
+  prediction_horizon_bias: Record<PredictionHorizonKey, number>
+  drafting_aggressiveness: number
+  exploration_ratio: number
+  persistence_strength: number
+  goal_weighting: number
+  context_injection_default: ContextInjectionMode
+  deep_run_profile: DeepRunPresetMirror
+}
+
+// ---------------------------------------------------------------------------
+// Selection result (WS3)
+// ---------------------------------------------------------------------------
+
+export interface SelectionResult {
+  bundle: VanerPolicyBundle
+  score: number
+  reasons: string[]
+  runner_ups: VanerPolicyBundle[]
+  forced_fallback: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Applied policy (WS5)
+// ---------------------------------------------------------------------------
+
+// Sentinel prefix used by WS5's apply_policy_bundle when a bundle change
+// strictly widens the cloud posture (e.g. local_only -> hybrid). Callers
+// detect this via String.prototype.startsWith. Mirrors the Python
+// constant in src/vaner/setup/apply.py.
+export const WIDENS_CLOUD_POSTURE_SENTINEL = 'WIDENS_CLOUD_POSTURE'
+
+export interface AppliedPolicy {
+  // The full VanerConfig is omitted from this mirror — the cockpit only
+  // needs the bundle id and the human-readable override audit list. WS8
+  // will choose whether to ship the full materialised VanerConfig in the
+  // /policy/current response; for now this slim shape covers the
+  // BundleSummaryCard's read-only needs.
+  bundle_id: string
+  overrides_applied: string[]
+  // Optional fields populated when the daemon also returns the bundle
+  // descriptor + the selection-time runner-ups. These let the cockpit
+  // render the "Why this bundle?" disclosure without a second fetch.
+  bundle?: VanerPolicyBundle
+  selection_reasons?: string[]
+  runner_ups?: VanerPolicyBundle[]
+}
+
+// ---------------------------------------------------------------------------
+// Hardware profile (WS2)
+// ---------------------------------------------------------------------------
+
+export type OSKind = 'linux' | 'darwin' | 'windows'
+export type CPUClass = 'low' | 'mid' | 'high'
+export type GPUKind = 'none' | 'integrated' | 'nvidia' | 'amd' | 'apple_silicon'
+export type Runtime = 'ollama' | 'llama.cpp' | 'lmstudio' | 'vllm' | 'mlx'
+
+// Each detected model is serialised as a 3-tuple [runtime, name, size_label].
+// Python emits a tuple-of-tuples; FastAPI/MCP serialise tuples as JSON arrays.
+export type DetectedModel = [Runtime | string, string, string]
+
+export interface HardwareProfile {
+  os: OSKind
+  cpu_class: CPUClass
+  ram_gb: number
+  gpu: GPUKind
+  gpu_vram_gb: number | null
+  is_battery: boolean
+  thermal_constrained: boolean
+  detected_runtimes: Runtime[]
+  detected_models: DetectedModel[]
+  tier: HardwareTier
+}
+
+// ---------------------------------------------------------------------------
+// Setup status (WS6/WS8 — composite "where is the user in the wizard?")
+// ---------------------------------------------------------------------------
+
+export interface SetupStatus {
+  // True when the user has completed the wizard at least once and the
+  // daemon has a persisted SetupAnswers + selected bundle.
+  completed: boolean
+  // Optional — present only when `completed` is true.
+  answers?: SetupAnswers
+  selected_bundle_id?: string
+}
+
+export type {}

--- a/ui/cockpit/tests/a11y-audit-baseline.json
+++ b/ui/cockpit/tests/a11y-audit-baseline.json
@@ -1,0 +1,30 @@
+{
+  "_comment": "0.8.6 WS10 — axe-core baseline for the cockpit dev server + the MCP Apps UI bundle. CI fails if any new HIGH/SERIOUS violations appear that are not listed here. Re-generate with `npm run a11y:scan` and `npm run a11y:scan:mcp` after fixing real violations.",
+  "_generated_by": "cockpit-a11y.yml",
+  "schema_version": 1,
+  "targets": [
+    {
+      "name": "cockpit-dev-server",
+      "url": "http://127.0.0.1:5173/",
+      "axe_options": {
+        "runOnly": {
+          "type": "tag",
+          "values": ["wcag2a", "wcag2aa", "best-practice"]
+        }
+      },
+      "known_violations": []
+    },
+    {
+      "name": "mcp-apps-active-predictions",
+      "source": "src/vaner/mcp/apps/active_predictions.html",
+      "axe_options": {
+        "runOnly": {
+          "type": "tag",
+          "values": ["wcag2a", "wcag2aa", "best-practice"]
+        }
+      },
+      "known_violations": []
+    }
+  ],
+  "fail_on_severities": ["serious", "critical"]
+}

--- a/ui/cockpit/tests/a11y.spec.tsx
+++ b/ui/cockpit/tests/a11y.spec.tsx
@@ -1,0 +1,110 @@
+// 0.8.6 WS10 — jest-axe unit-level a11y harness for the new cockpit
+// components. The full axe-core scan against the running cockpit and the
+// MCP Apps UI bundle is performed by .github/workflows/cockpit-a11y.yml;
+// this file catches regressions earlier in the dev loop.
+//
+// We only assert the absence of *serious* / *critical* violations — the
+// same threshold the CI workflow uses. Best-practice and minor warnings
+// are surfaced as console output but do not fail the suite.
+
+import { render } from '@testing-library/react'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import { describe, expect, it } from 'vitest'
+
+import { BundleSummaryCard } from '../src/components/BundleSummaryCard'
+import { HardwareProfilePanel } from '../src/components/HardwareProfilePanel'
+import type { AppliedPolicy, HardwareProfile } from '../src/types/setup'
+
+expect.extend(toHaveNoViolations)
+
+const SAMPLE_APPLIED: AppliedPolicy = {
+  bundle_id: 'hybrid_balanced',
+  overrides_applied: [],
+  bundle: {
+    id: 'hybrid_balanced',
+    label: 'Hybrid Balanced',
+    description: 'Mid-spend, mid-latency. The canonical default.',
+    local_cloud_posture: 'hybrid',
+    runtime_profile: 'medium',
+    spend_profile: 'low',
+    latency_profile: 'balanced',
+    privacy_profile: 'standard',
+    prediction_horizon_bias: {
+      likely_next: 1,
+      long_horizon: 1,
+      finish_partials: 1,
+      balanced: 1,
+    },
+    drafting_aggressiveness: 1,
+    exploration_ratio: 0.2,
+    persistence_strength: 1,
+    goal_weighting: 1,
+    context_injection_default: 'policy_hybrid',
+    deep_run_profile: 'balanced',
+  },
+}
+
+const SAMPLE_PROFILE: HardwareProfile = {
+  os: 'darwin',
+  cpu_class: 'high',
+  ram_gb: 32,
+  gpu: 'apple_silicon',
+  gpu_vram_gb: null,
+  is_battery: false,
+  thermal_constrained: false,
+  detected_runtimes: ['ollama'],
+  detected_models: [['ollama', 'qwen2.5-coder:7b', '4.4GB']],
+  tier: 'capable',
+}
+
+describe('a11y — BundleSummaryCard', () => {
+  it('has no serious axe violations when applied_policy is null', async () => {
+    const { container } = render(
+      <BundleSummaryCard applied_policy={null} selection_reasons={[]} runner_ups={[]} />,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no serious axe violations with an applied policy', async () => {
+    const { container } = render(
+      <BundleSummaryCard
+        applied_policy={SAMPLE_APPLIED}
+        selection_reasons={['Speed-first → hybrid_balanced is balanced']}
+        runner_ups={[]}
+      />,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no serious axe violations when the WIDENS sentinel is present', async () => {
+    const widening: AppliedPolicy = {
+      ...SAMPLE_APPLIED,
+      overrides_applied: ['WIDENS_CLOUD_POSTURE: local_only->hybrid'],
+    }
+    const { container } = render(
+      <BundleSummaryCard
+        applied_policy={widening}
+        selection_reasons={[]}
+        runner_ups={[]}
+      />,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+describe('a11y — HardwareProfilePanel', () => {
+  it('has no serious axe violations when profile is null', async () => {
+    const { container } = render(<HardwareProfilePanel profile={null} />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no serious axe violations with a populated profile', async () => {
+    const { container } = render(<HardwareProfilePanel profile={SAMPLE_PROFILE} />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/ui/cockpit/tsconfig.json
+++ b/ui/cockpit/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/ui/cockpit/vite.config.ts
+++ b/ui/cockpit/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// 0.8.6 WS10 — Minimal vite + vitest config so the cockpit can be built
+// in CI for the axe-core scan and so unit tests can run via `npm run
+// test`. Earlier WSes (notably WS5 / WS6) may extend this with proxy
+// config, alias paths, or coverage thresholds.
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+    target: 'es2022',
+  },
+  test: {
+    globals: false,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}', 'tests/**/*.spec.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary
Stacked on WS7. Adds seven daemon HTTP endpoints mirroring the WS7 MCP tools: `GET /setup/questions`, `POST /setup/recommend`, `POST /setup/apply`, `GET /setup/status`, `GET /policy/current`, `GET /hardware/profile`, `POST /policy/refresh` (hot-reload trigger for `vaner setup apply`). Endpoint count 23 → 30.

Reuses WS6's serialisation helpers. WIDENS_CLOUD_POSTURE behaviour matches WS7: block by default unless `confirm_cloud_widening`. `GET /hardware/profile` caches `detect()` for daemon process lifetime (one cold-start probe; warm reads are free). `POST /policy/refresh` triggers `engine._refresh_policy_bundle_state()`.

## Test plan
- [x] `tests/test_daemon/test_setup_endpoints.py` — 16 tests
- [x] All endpoints loopback-only; matches existing `/deep-run/*` auth pattern
- [x] Engine-unavailable + engine-error code paths return 503 with clear messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)