### PR TITLE
ci: move to larger GitHub-hosted runners + quality/compatibility split

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,13 @@
+# Tell actionlint about the org's GitHub-hosted larger runners.
+# These are NOT self-hosted — they are managed GitHub-hosted runners
+# in the "Default Larger Runners" group. Actionlint doesn't know
+# their labels by default, so listing them here suppresses
+# `runner-label` warnings without needing to introduce a self-hosted
+# fallback path.
+#
+# Source: org-level Actions runner-group config (Borgels/Default Larger Runners).
+
+self-hosted-runner:
+  labels:
+    - ubuntu-latest-m
+    - windows-latest-l

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,34 +9,38 @@ on:
 permissions:
   contents: read
 
+# Cancel in-progress CI for the same ref when a newer commit arrives.
+# The longest jobs (release-smoke, full pytest matrix) are expensive on
+# the new larger runners — wasting minutes on superseded commits is
+# worth avoiding.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  verify:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
-    timeout-minutes: 30
+  # -------------------------------------------------------------------------
+  # quality — the required PR gate. Single Linux 3.12 job that runs every
+  # static / type / coverage / security / installer check. Lives on the
+  # large GitHub-hosted Linux runner so it finishes fast.
+  # -------------------------------------------------------------------------
+  quality:
+    runs-on: ubuntu-latest-m
+    timeout-minutes: 25
     env:
       PYTHONPATH: src
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.11", "3.12", "3.13"]
-        include:
-          - os: windows-latest
-            python-version: "3.12"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           cache: pip
+          cache-dependency-path: requirements/ci.txt
       - name: Install
-        run: |
-          python -m pip install --require-hashes -r requirements/ci.txt
+        run: python -m pip install --require-hashes -r requirements/ci.txt
       - name: Lint
         run: |
           ruff check .
@@ -85,26 +89,16 @@ jobs:
             src/vaner/learning/counterfactual.py \
             src/vaner/defaults/loader.py
       - name: AGENTS.md primer in sync with canonical guidance
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: python scripts/sync_agents_primer.py --check
       - name: Replay regression
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: pytest tests/test_replay_regression.py -v
-      - name: Tests (non-windows)
-        if: matrix.os != 'windows-latest'
+      - name: Tests + coverage
         run: pytest tests -m "not slow and not integration" --cov=src/vaner --cov-fail-under=70
-      - name: Tests (windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          # Keep a lightweight Windows signal until asyncio/CLI teardown flakes are stabilized.
-          pytest tests/test_api.py tests/test_broker tests/test_policy tests/test_store -p no:randomly
       - name: Upload coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           fail_ci_if_error: false
       - name: Security audit
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         # CVE-2026-3219 applies to pip itself. pip 26.0.1 is both the
         # latest release and the vulnerable version — no upstream fix
         # is available yet. Dismissed in Dependabot as ``tolerable_risk``
@@ -112,15 +106,70 @@ jobs:
         # the ignore flag once a patched pip release ships.
         run: pip-audit --ignore-vuln CVE-2026-3219
       - name: Installer lint and dry-run smoke
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq shellcheck
           shellcheck scripts/install.sh
           bash scripts/install.sh --dry-run --yes --backend uv
 
+  # -------------------------------------------------------------------------
+  # compatibility — broader Python/OS coverage. Skips ruff/pre-commit/mypy
+  # (already done in quality) and runs only the test suite. Smaller matrix
+  # than the old `verify` job (4 entries vs 7) to keep wall-clock low while
+  # still covering every supported Python on Linux + a macOS + Windows
+  # signal. Schedule/main can later expand this if needed.
+  # -------------------------------------------------------------------------
+  compatibility:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.test-kind == 'windows' }}
+    timeout-minutes: 25
+    env:
+      PYTHONPATH: src
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest-m
+            python-version: "3.11"
+            test-kind: non-windows
+          - os: ubuntu-latest-m
+            python-version: "3.13"
+            test-kind: non-windows
+          - os: macos-latest
+            python-version: "3.12"
+            test-kind: non-windows
+          - os: windows-latest-l
+            python-version: "3.12"
+            test-kind: windows
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements/ci.txt
+      - name: Install
+        run: python -m pip install --require-hashes -r requirements/ci.txt
+      - name: Tests (non-windows)
+        if: matrix.test-kind == 'non-windows'
+        run: pytest tests -m "not slow and not integration"
+      - name: Tests (windows)
+        if: matrix.test-kind == 'windows'
+        # Keep a lightweight Windows signal until asyncio/CLI teardown flakes are stabilized.
+        run: |
+          pytest tests/test_api.py tests/test_broker tests/test_policy tests/test_store -p no:randomly
+
+  # -------------------------------------------------------------------------
+  # examples-smoke — quick check that the shipped multi-backend example
+  # remains coherent with the engine surface. Cheap; runs on the larger
+  # Linux runner.
+  # -------------------------------------------------------------------------
   examples-smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 10
     env:
       PYTHONPATH: src
@@ -134,6 +183,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+          cache-dependency-path: requirements/ci.txt
       - name: Install Vaner
         run: |
           python -m pip install --require-hashes -r requirements/ci.txt
@@ -147,8 +197,16 @@ jobs:
           test -f examples/multi-backend/README.md
           grep -En "backends.openai|vaner proxy|X-Vaner-Backend" examples/multi-backend/README.md
 
+  # -------------------------------------------------------------------------
+  # release-smoke — full build + install via pipx end-to-end. Runs on the
+  # larger Linux runner. (Path-based gating to packaging-only PRs was
+  # considered, but `github.event.pull_request.changed_files_paths` is
+  # not actually available in the workflow context — would need a
+  # separate dorny/paths-filter action. Deferred; keep it running on
+  # every PR for now.)
+  # -------------------------------------------------------------------------
   release-smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     timeout-minutes: 25
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Restructures `.github/workflows/ci.yml` per the org's new larger-runner rollout. Two goals:
1. **Move Linux + Windows jobs to the new GitHub-hosted larger runners** (`ubuntu-latest-m`, `windows-latest-l`) — leaves `macos-latest` unchanged (no larger macOS runner available yet).
2. **Eliminate duplicated work** — the old 7-cell matrix repeated ruff + pre-commit + mypy + coverage in every cell.

## Job moves

| Job | Before | After |
|---|---|---|
| `verify` (single 7-cell matrix) | gone | replaced by `quality` + `compatibility` |
| `quality` (new) | — | `ubuntu-latest-m` × py3.12, owns lint/type/coverage/audit/installer |
| `compatibility` (new) | — | 4-cell matrix: `ubuntu-latest-m` × {3.11, 3.13}, `macos-latest` × 3.12, `windows-latest-l` × 3.12 — tests only |
| `examples-smoke` | `ubuntu-latest` | `ubuntu-latest-m` |
| `release-smoke` | `ubuntu-latest` | `ubuntu-latest-m` |

No `self-hosted` runners introduced (public repo). All Linux jobs use `ubuntu-latest-m`, the Windows job uses `windows-latest-l`, macOS stays on `macos-latest`.

## Duplication removed

- ruff + ruff format → 1× (was 7×)
- pre-commit → 1× (was 7×)
- mypy (3 invocations) → 1× (was 7×)
- codecov upload → 1× (was 1× via `if:` gate, behaviour preserved)
- pip-audit → 1× (was 1×)
- installer lint + dry-run smoke → 1× (was 1×)
- replay regression → 1× (was 1×)
- pytest with `--cov-fail-under=70` → 1× in `quality`; tests-only run 4× across `compatibility` cells

## Other changes

- **Workflow-level concurrency**: `cancel-in-progress: true` keyed on `${{ github.workflow }}-${{ github.ref }}` — kills superseded in-flight runs on the same branch. Material savings on the larger runners.
- **`setup-python` cache-dependency-path**: every invocation now pins `requirements/ci.txt` so pip cache keys are deterministic across PRs.
- **`release-smoke` path filtering**: attempted via `github.event.pull_request.changed_files_paths` but that context field isn't available — deferred to a follow-up paths-filter action. Job runs on every PR for now (just on the larger runner).

## Branch protection follow-up

This PR removes the `verify (ubuntu-latest, 3.12)` job that's currently listed as a required status check on `main`. Branch protection must be updated to require `quality` (and optionally specific `compatibility` matrix entries) before this PR can merge. Will do that as a settings change right before merging this PR.

## Expected speedup

Current `verify` matrix runs the same expensive Linux work 3× (3.11/3.12/3.13) plus 3× macOS plus once on Windows = 7 cells × ~5-15 min = 35-105 minutes total compute. The new shape:
- `quality`: 1 job × ~5-8 min on `ubuntu-latest-m` (faster than baseline `ubuntu-latest`)
- `compatibility`: 4 cells × ~3-5 min each
- `examples-smoke`: ~1-2 min
- `release-smoke`: ~5-8 min

Wall-clock should drop ~40-60% on a typical PR with concurrency cancellation factored in.

## Test plan
- [x] yaml-shape: actionlint passes on this branch (CI will confirm)
- [x] no `self-hosted` references (verified by grep)
- [ ] First run of the new shape on this PR's CI confirms the runner labels resolve correctly
- [ ] Branch protection updated to require `quality` before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)