### PR TITLE
feat(0.8.7): Live Intent Capture Phase 1 + L0 Claude Code adapter + 0.8.6 carry-overs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "vaner",
       "source": "./plugins/vaner",
       "description": "MCP server, feedback skill, and bootstrap hook for Vaner.",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "category": "developer-tools",
       "tags": [
         "mcp",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,18 @@ jobs:
       upload-assets: true
 
   verify:
-    needs:
-      - publish
-      - slsa-provenance
+    # 0.8.7 WS1 — verify only depends on `publish`. The slsa-github-generator
+    # reusable workflow's `final` aggregation step has a known cosmetic-failure
+    # mode where it reports failure even when `generator` and `upload-assets`
+    # both succeed and the *.intoto.jsonl is uploaded to the release. v0.8.6
+    # hit exactly this on run #24939687147: artifacts were signed and live,
+    # but `verify` was skipped because it depended on slsa-provenance.
+    # `verify` independently downloads the provenance from the release below
+    # (see "Download provenance assets from release"), so the dependency was
+    # redundant. `if: always() && publish succeeded` lets verify run end-to-end
+    # even when the upstream aggregation reports a soft failure.
+    needs: publish
+    if: ${{ always() && needs.publish.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.7] - 2026-04-26
+
+### Added
+
+#### Live Intent Capture (Phase 1) + L0 Claude Code adapter
+
+The first slice of a new product direction: Vaner consumes explicit composer/prompt lifecycle events from supported clients via a `ComposerAdapter` contract. Vaner is **not** a client — only documented client-level hooks/plugins/extensions are honored. The L0 reference adapter ships in the Claude Code plugin via the `UserPromptSubmit` hook.
+
+##### `ComposerAdapter` contract (WS2)
+- **`src/vaner/signals/composer/`** — pydantic source of truth for `DraftIntentSnapshot`, `ComposerAdapterCapabilities`, `LifecycleState` / `CapabilityLevel` / `HostKind` / `FieldRole` literals. JSON Schema artifact at `docs/specs/composer-adapter.schema.json` regenerated from pydantic via the new `vaner-composer-schema` console script. CI guards drift via `git diff --exit-code`.
+- **Privacy contract pinned in code**: no field for `text` / `preview` / `draft_text` / `raw_text` / `local_text_ref`. Adapters send only `text_hash` (sha256 hex, regex-pinned) + `length_chars`. `text_preview` / `local_text_ref` from the longer product spec are deferred until a redaction module exists.
+- **Capability matrix**: 11 existing client surfaces audited (Claude Code at L0, 10 MCP-only clients as N/A, Vaner VS Code extension explicitly excluded under "Vaner is not a client").
+
+##### Engine plumbing (WS3 + WS4 + WS5 + WS8)
+- **`src/vaner/engine.py::observe()`** branches on `event.kind`: `composer_lifecycle` payloads validate as `DraftIntentSnapshot` BEFORE the store insert (malformed payloads never reach persistence) and publish to a new `ComposerSignalPump`. Persist-before-publish ordering means a misbehaving subscriber cannot lose the durable record.
+- **`PredictionRun.compose_signal_strength`** (WS4 — data backbone for v0.8.8) and **`IntentPriorAdjustments.composer_signal_weight_multiplier`** (WS5 — values per WorkStyle: writing 1.4, research 1.3, planning 1.2, support/learning 1.1, coding/general/mixed/unsure 1.0). Both fields are documented v0.8.8 wiring gaps; default-0/1.0 invariants preserve byte-identical engine behavior for default-config users.
+- **`composer_intent` prediction source** + invalidation handler: `composer_cancelled` / `composer_abandoned` signals stale every `composer_intent`-sourced prediction whose `spec.anchor` matches the cancelled session_id.
+- **`Resolution.composer_event_id`** + **`PredictedPrompt.composer_engagement`** (Python + Rust mirror). Both default-None — existing wire-format conformance fixtures pass byte-identical when absent. Rust `PredictionSource` enum gains `ComposerIntent` variant.
+
+##### L0 Claude Code adapter (WS7)
+- **`plugins/vaner/hooks/hooks.json`** registers `UserPromptSubmit` alongside `SessionStart`. Translator script `composer_submit.py` reads stdin JSON, computes `sha256(prompt)`, POSTs a `DraftIntentSnapshot` to the daemon at `http://127.0.0.1:8473/signals/composer` with a 1s timeout. Top-level try/except → exit 0 on every failure path so a misconfigured daemon never blocks the user's prompt.
+- **`POST /signals/composer`** daemon endpoint validates the snapshot, enforces capability declaration (rejects lifecycle states not in `capabilities.emits`), envelopes into `SignalEvent(kind="composer_lifecycle")`, and records to `draft_events` with a separate counter prefix (`composer_lifecycle_*_total`).
+
+##### Telemetry (WS6)
+- **`draft_events.event_type`** column with default `'legacy_draft'`. Idempotent `PRAGMA table_info` ALTER migration handles pre-0.8.7 DBs. Composer rows write `event_type='composer_lifecycle'` and bump a separate counter prefix so the existing `draft_{served|useful|wrong|unused}_total` counters that 0.8.6 dashboards depend on remain untouched.
+- Telemetry metadata stores `length_bucket` (coarse band) instead of exact `length_chars` — defeats short-prompt sha256 brute-force across the cross-store correlation surface.
+
+#### CI / supply-chain hardening (WS1 + carry-overs)
+- **SLSA-3 verify-chain decouple**: `verify` job's `needs:` changed from `[publish, slsa-provenance]` to `publish`. The slsa-github-generator's `final` aggregation step has a known cosmetic-failure mode that no longer skips end-to-end SLSA-3 verification. v0.8.6 hit exactly this on run #24939687147.
+- **Rust workflow unblocked**: pre-existing `cargo fmt` drift in `lib.rs` + `setup.rs` (red since 0.8.6) fixed via `cargo fmt --all`. New `composer_intent_round_trips` Rust test pins the snake_case wire-form against the Python contract.
+- **CodeQL**: declared `prediction_id()`'s SHA-1 as `usedforsecurity=False` (it's a deterministic identifier truncated to 16 hex chars, not a cryptographic primitive); replaced JSON-decode exception interpolation with a static error message in `POST /signals/composer`. Both alerts resolved.
+- **SQLite concurrency**: `MetricsStore.initialize()` opens with `aiosqlite.connect(..., timeout=5.0)` so the SQLite busy handler is set at connection time. Two concurrent first-time initialize calls (one per composer-event POST) wait for the writer lock instead of failing with `database is locked`.
+
+### Cross-repo
+- **vaner-docs PR #25**: ComposerAdapter integration docs page at `content/docs/integrations/composer-adapter.mdx`.
+- **vaner-docs issue #26**: tracking removal of the five temporary lychee exclusions for the new 0.8.6 doc routes (blocked on docs.vaner.ai redeploy).
+
+### Test counts
+83 new tests across the 8 workstreams + hardening pass. 1655 total tests passing on the full pytest suite (-m "not slow and not integration"). All CI-equivalent local checks green: pre-commit, mypy (3 CI scopes), pip-audit, actionlint, AGENTS.md primer + plugin parity scripts, replay regression, cargo fmt/clippy/test (default + ts-rs + no-default-features), `claude plugin validate`, moat-guard.
+
+### Deferred to v0.8.8
+- Inline composer UI (Phase 3 — `Prepared` / `Preparing` pills near the composer)
+- Real Level-1 adapters (true pre-submit draft lifecycle) — needs ecosystem partner with documented draft hooks
+- The three v0.8.8 wiring-gap consumers (composer signal pump subscriber, frontier scoring on `composer_signal_weight_multiplier`, registry update from `compose_signal_strength`)
+- `text_preview` / `local_text_ref` snapshot fields (need redaction module first)
+- Cloud processing of unsent draft text (opt-in policy work)
+
 ## [0.8.6] - 2026-04-25
 
 ### Added

--- a/crates/vaner-contract/src/enums.rs
+++ b/crates/vaner-contract/src/enums.rs
@@ -28,6 +28,10 @@ pub enum PredictionSource {
     History,
     /// 0.8.0 WS7: prediction anchored to a `WorkspaceGoal`.
     Goal,
+    /// 0.8.7 WS8: prediction anchored to a live composer session via
+    /// the ComposerAdapter. `PredictionSpec.anchor` carries the
+    /// composer `session_id`.
+    ComposerIntent,
     /// Unknown / future server value. `PredictionSpec.anchor` may still
     /// carry useful info even when the source is opaque.
     #[serde(other)]

--- a/crates/vaner-contract/src/enums.rs
+++ b/crates/vaner-contract/src/enums.rs
@@ -160,11 +160,23 @@ mod tests {
             (r#""macro""#, PredictionSource::Macro),
             (r#""history""#, PredictionSource::History),
             (r#""goal""#, PredictionSource::Goal),
+            // 0.8.7 WS8: composer_intent variant
+            (r#""composer_intent""#, PredictionSource::ComposerIntent),
         ];
         for (raw, expected) in cases {
             let decoded: PredictionSource = serde_json::from_str(raw).unwrap();
             assert_eq!(decoded, expected, "decoding {raw}");
         }
+    }
+
+    #[test]
+    fn composer_intent_round_trips() {
+        // 0.8.7 WS8: encode then decode the ComposerIntent variant to
+        // pin the snake_case wire-form against the Python contract.
+        let encoded = serde_json::to_string(&PredictionSource::ComposerIntent).unwrap();
+        assert_eq!(encoded, r#""composer_intent""#);
+        let decoded: PredictionSource = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, PredictionSource::ComposerIntent);
     }
 
     #[test]

--- a/crates/vaner-contract/src/handoff.rs
+++ b/crates/vaner-contract/src/handoff.rs
@@ -175,6 +175,7 @@ mod tests {
             alternatives_considered: vec![],
             gaps: vec![],
             next_actions: vec![],
+            composer_event_id: None,
         }
     }
 

--- a/crates/vaner-contract/src/lib.rs
+++ b/crates/vaner-contract/src/lib.rs
@@ -46,9 +46,9 @@ pub use models::{
 };
 pub use reducer::{ReducerInputs, VanerState, reduce};
 pub use setup::{
-    AppliedPolicy, BackgroundPosture, CloudPosture, ComputePosture, DeepRunDefaults,
-    DetectedModel, HardwareProfile, HardwareTier, PolicyConfig, Priority, SelectionResult,
-    SetupAnswers, SetupConfig, SetupQuestion, SetupQuestionOption, VanerPolicyBundle, WorkStyle,
+    AppliedPolicy, BackgroundPosture, CloudPosture, ComputePosture, DeepRunDefaults, DetectedModel,
+    HardwareProfile, HardwareTier, PolicyConfig, Priority, SelectionResult, SetupAnswers,
+    SetupConfig, SetupQuestion, SetupQuestionOption, VanerPolicyBundle, WorkStyle,
 };
 
 #[cfg(feature = "http")]

--- a/crates/vaner-contract/src/models.rs
+++ b/crates/vaner-contract/src/models.rs
@@ -56,6 +56,30 @@ pub struct PredictedPrompt {
     pub suppression_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_label: Option<String>,
+    /// 0.8.7 WS8: present when the prediction is anchored to a live
+    /// composer session. Lets host UIs render draft-derived predictions
+    /// distinctly (without hard-coding `source == ComposerIntent`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composer_engagement: Option<ComposerEngagement>,
+}
+
+/// 0.8.7 WS8: composer-engagement annotation on a `PredictedPrompt`.
+///
+/// Populated by the server when `spec.source == "composer_intent"` so
+/// host UIs can show draft-derived predictions distinctly. The
+/// `composer_event_id` matches the value the server attaches to a
+/// downstream `Resolution.composer_event_id` on adoption — this is
+/// the link adopt-telemetry uses to attribute hits/misses back to the
+/// originating composer event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(TS), ts(export))]
+pub struct ComposerEngagement {
+    pub composer_event_id: String,
+    pub lifecycle_state: String,
+    #[serde(default)]
+    pub inferred_intent_label: Option<String>,
+    #[serde(default)]
+    pub inferred_intent_confidence: Option<f64>,
 }
 
 /// Immutable identity + hypothesis of a predicted prompt.
@@ -141,6 +165,13 @@ pub struct Resolution {
     pub gaps: Vec<String>,
     #[serde(default)]
     pub next_actions: Vec<String>,
+    /// 0.8.7 WS8: when the adopted prediction is sourced from a
+    /// `composer_intent` (i.e. the user's draft triggered the
+    /// preparation), carries the originating composer event id so
+    /// adoption telemetry can attribute hit/miss back to the composer
+    /// event. None on non-composer adoptions.
+    #[serde(default)]
+    pub composer_event_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/vaner-contract/src/reducer.rs
+++ b/crates/vaner-contract/src/reducer.rs
@@ -154,6 +154,7 @@ mod tests {
             ui_summary: None,
             suppression_reason: None,
             source_label: None,
+            composer_engagement: None,
         }
     }
 

--- a/crates/vaner-contract/src/setup.rs
+++ b/crates/vaner-contract/src/setup.rs
@@ -420,11 +420,17 @@ mod tests {
             "background_posture": "deep_run_aggressive"
         }"#;
         let decoded: SetupAnswers = serde_json::from_str(raw).unwrap();
-        assert_eq!(decoded.work_styles, vec![WorkStyle::Coding, WorkStyle::Research]);
+        assert_eq!(
+            decoded.work_styles,
+            vec![WorkStyle::Coding, WorkStyle::Research]
+        );
         assert_eq!(decoded.priority, Priority::Quality);
         assert_eq!(decoded.compute_posture, ComputePosture::AvailablePower);
         assert_eq!(decoded.cloud_posture, CloudPosture::HybridWhenWorthIt);
-        assert_eq!(decoded.background_posture, BackgroundPosture::DeepRunAggressive);
+        assert_eq!(
+            decoded.background_posture,
+            BackgroundPosture::DeepRunAggressive
+        );
 
         let reencoded = serde_json::to_string(&decoded).unwrap();
         let again: SetupAnswers = serde_json::from_str(&reencoded).unwrap();
@@ -581,8 +587,14 @@ mod tests {
         let decoded: SetupQuestion = serde_json::from_str(raw).unwrap();
         assert_eq!(decoded.id, "priority");
         assert_eq!(decoded.options.len(), 2);
-        assert_eq!(decoded.options[1].description.as_deref(), Some("Snappy responses"));
-        assert_eq!(decoded.default.as_ref().and_then(|v| v.as_str()), Some("balanced"));
+        assert_eq!(
+            decoded.options[1].description.as_deref(),
+            Some("Snappy responses")
+        );
+        assert_eq!(
+            decoded.default.as_ref().and_then(|v| v.as_str()),
+            Some("balanced")
+        );
     }
 
     #[test]

--- a/crates/vaner-contract/tests/conformance.rs
+++ b/crates/vaner-contract/tests/conformance.rs
@@ -169,7 +169,10 @@ fn setup_answers_fixture_decodes() {
     let body = load("setup_answers_sample.json");
     let answers: SetupAnswers =
         serde_json::from_str(&body).expect("setup answers fixture must decode");
-    assert_eq!(answers.work_styles, vec![WorkStyle::Coding, WorkStyle::Research]);
+    assert_eq!(
+        answers.work_styles,
+        vec![WorkStyle::Coding, WorkStyle::Research]
+    );
     assert_eq!(answers.priority, Priority::Quality);
     assert_eq!(answers.compute_posture, ComputePosture::AvailablePower);
     assert_eq!(answers.cloud_posture, CloudPosture::HybridWhenWorthIt);

--- a/docs/specs/composer-adapter.md
+++ b/docs/specs/composer-adapter.md
@@ -1,0 +1,132 @@
+# ComposerAdapter — Live Intent Capture contract (v0.8.7)
+
+Vaner consumes explicit composer/prompt lifecycle events from supported
+clients via a **ComposerAdapter**. Each event carries a
+`DraftIntentSnapshot` plus a capability declaration, and lands on the
+daemon's `POST /signals/composer` endpoint as a `SignalEvent` of kind
+`composer_lifecycle`.
+
+This document is the cross-language contract for non-Python adapter
+authors. The pydantic models in
+[`src/vaner/signals/composer/contract.py`](../../src/vaner/signals/composer/contract.py)
+are the source of truth; the [JSON Schema artifact](composer-adapter.schema.json)
+is generated from them by `vaner-composer-schema`.
+
+## Privacy contract
+
+- The draft text itself **never** crosses this boundary. Adapters send
+  a `text_hash` (sha256 of the draft text) and a length, never the raw
+  text or a preview.
+- Local-only by default. Cloud processing of unsent draft text is **not**
+  enabled in v0.8.7.
+- No raw-draft persistence. The engine stores the snapshot, hash,
+  lifecycle state, and counters; raw text never reaches storage.
+- Per-client opt-in inherits the host's plugin/extension enable/disable
+  surface in v0.8.7. First-class per-client opt-in scaffolding lands in
+  v0.8.8.
+
+## Capability levels
+
+| Level | What the adapter can observe                                         | Honest `emits` |
+|-------|----------------------------------------------------------------------|----------------|
+| L0    | Submit-time only (the prompt as it leaves the composer)              | `("submitted",)` |
+| L1    | Pre-submit draft lifecycle (debounced snapshots while user types)    | `("observing", "tentative", "stabilizing", "actionable", "submitted", "cleared", "abandoned")` |
+| L2    | L1 + host-rendered affordance hook near the composer                 | same as L1 |
+| L3    | L2 + host-native adopt flow for prepared packages                    | same as L1 |
+
+Adapters MUST only emit lifecycle states they can actually observe.
+A Level-0 adapter that fabricates `actionable` corrupts the engine's
+scoring downstream. The daemon validates each event against the
+adapter's declared `capabilities.emits` on ingest.
+
+## Capability matrix (existing surfaces)
+
+| Surface                     | Path / hook mechanism                                  | Level |
+|-----------------------------|--------------------------------------------------------|-------|
+| Claude Code (plugin)        | `UserPromptSubmit` hook (v0.8.7 WS7 MVP)               | L0    |
+| Cursor                      | MCP tools only (no composer hook)                      | —     |
+| Claude Desktop              | MCP tools only                                         | —     |
+| VS Code (Copilot Chat MCP)  | MCP tools only                                         | —     |
+| Codex CLI                   | MCP tools only                                         | —     |
+| Windsurf                    | MCP tools only                                         | —     |
+| Zed                         | MCP `context_servers` only                             | —     |
+| Continue                    | MCP tools only                                         | —     |
+| Cline                       | MCP tools only                                         | —     |
+| Roo Code                    | MCP tools only                                         | —     |
+| Vaner VS Code extension     | Cockpit/webview consuming daemon SSE                   | excluded |
+
+The Vaner VS Code extension is **explicitly not** an adapter source.
+Vaner does not own a composer; doing so would violate the "Vaner is
+not a client" thesis. The extension surfaces prepared-package state
+from the daemon — it does not observe a user composer.
+
+Other clients enter the matrix only when an explicit, documented
+hook/plugin/extension mechanism exists in the host. Generic input
+capture, accessibility APIs, terminal scraping, and unsupported DOM
+injection are not acceptable adapter mechanisms.
+
+## Wire format
+
+Adapters POST to the loopback daemon endpoint:
+
+```
+POST http://127.0.0.1:<daemon_port>/signals/composer
+Content-Type: application/json
+
+<DraftIntentSnapshot>
+```
+
+The endpoint envelopes the snapshot into a
+`SignalEvent(kind="composer_lifecycle", payload=<snapshot>)` and calls
+`engine.observe()`. The response carries a `composer_event_id` (UUID)
+that the adapter MAY surface to the host so subsequent adoptions can
+attribute back to the originating event.
+
+A snapshot looks like (L0 example):
+
+```json
+{
+  "session_id": "claude-code-session-abc123",
+  "snapshot_id": "01HX...",
+  "timestamp": "2026-04-25T20:14:45Z",
+  "lifecycle_state": "submitted",
+  "text_hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  "length_chars": 142,
+  "capabilities": {
+    "level": "L0",
+    "emits": ["submitted"],
+    "host_app": "claude-code",
+    "host_kind": "ai_chat_client"
+  },
+  "workspace_id": "/home/me/repos/example",
+  "field_role": "agent_prompt"
+}
+```
+
+## Authoring an adapter
+
+1. Pick a host that exposes an explicit composer/prompt lifecycle hook.
+   If the host has no such mechanism, do not invent one — wait for the
+   host to ship one.
+2. Decide the honest capability level. If the hook only fires at submit
+   time, declare `level: "L0"` and `emits: ["submitted"]`.
+3. Compute `text_hash = sha256(draft_text)`. Never log, store, or
+   transmit the raw draft text.
+4. Build a `DraftIntentSnapshot` per the schema and POST it to
+   `http://127.0.0.1:<daemon_port>/signals/composer` with a short
+   timeout (≤ 1 s recommended). On failure, fail silent — never block
+   the user's prompt.
+5. If the adapter is per-prompt (L0), one POST per submit. If the
+   adapter is L1, debounce snapshot emission (≥ 250 ms between
+   meaningful changes) and only emit when the lifecycle state would
+   actually change.
+
+## Regenerating the JSON Schema
+
+```bash
+vaner-composer-schema      # writes docs/specs/composer-adapter.schema.json
+git diff --exit-code docs/specs/composer-adapter.schema.json
+```
+
+CI runs the regeneration step and fails if the artifact drifts from
+what the pydantic models would produce.

--- a/docs/specs/composer-adapter.schema.json
+++ b/docs/specs/composer-adapter.schema.json
@@ -4,7 +4,7 @@
       "description": "What an adapter can truthfully emit.\n\nThe daemon uses ``emits`` to validate each ``DraftIntentSnapshot``\non ingest. An L0 adapter that declares ``emits=(\"submitted\",)``\ncannot send a payload with ``lifecycle_state=\"actionable\"``.",
       "properties": {
         "emits": {
-          "description": "Lifecycle states this adapter can truthfully produce.",
+          "description": "Lifecycle states this adapter can truthfully produce. MUST be non-empty.",
           "items": {
             "enum": [
               "observing",
@@ -17,11 +17,14 @@
             ],
             "type": "string"
           },
+          "minItems": 1,
           "title": "Emits",
           "type": "array"
         },
         "host_app": {
           "description": "Stable identifier for the host (e.g. 'claude-code', 'cursor').",
+          "maxLength": 128,
+          "minLength": 1,
           "title": "Host App",
           "type": "string"
         },
@@ -67,6 +70,7 @@
     "conversation_id": {
       "anyOf": [
         {
+          "maxLength": 256,
           "type": "string"
         },
         {
@@ -113,6 +117,7 @@
     "inferred_intent_label": {
       "anyOf": [
         {
+          "maxLength": 256,
           "type": "string"
         },
         {
@@ -142,27 +147,34 @@
     },
     "session_id": {
       "description": "Stable id for the composer session. Used to correlate snapshots and to invalidate predictions on cancel/abandon.",
+      "maxLength": 256,
+      "minLength": 1,
       "title": "Session Id",
       "type": "string"
     },
     "snapshot_id": {
       "description": "Unique id for this snapshot. Adapters MUST generate a fresh id per emission.",
+      "maxLength": 128,
+      "minLength": 1,
       "title": "Snapshot Id",
       "type": "string"
     },
     "text_hash": {
-      "description": "sha256 hex digest of the draft text. The raw text is never transmitted in 0.8.7.",
+      "description": "sha256 hex digest of the draft text (lowercase, 64 chars). The raw text is never transmitted in 0.8.7.",
+      "pattern": "^[0-9a-f]{64}$",
       "title": "Text Hash",
       "type": "string"
     },
     "timestamp": {
-      "description": "ISO-8601 timestamp of the observation.",
+      "description": "ISO-8601 timestamp of the observation (e.g. '2026-04-25T20:14:45Z').",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$",
       "title": "Timestamp",
       "type": "string"
     },
     "workspace_id": {
       "anyOf": [
         {
+          "maxLength": 2048,
           "type": "string"
         },
         {

--- a/docs/specs/composer-adapter.schema.json
+++ b/docs/specs/composer-adapter.schema.json
@@ -1,0 +1,187 @@
+{
+  "$defs": {
+    "ComposerAdapterCapabilities": {
+      "description": "What an adapter can truthfully emit.\n\nThe daemon uses ``emits`` to validate each ``DraftIntentSnapshot``\non ingest. An L0 adapter that declares ``emits=(\"submitted\",)``\ncannot send a payload with ``lifecycle_state=\"actionable\"``.",
+      "properties": {
+        "emits": {
+          "description": "Lifecycle states this adapter can truthfully produce.",
+          "items": {
+            "enum": [
+              "observing",
+              "tentative",
+              "stabilizing",
+              "actionable",
+              "submitted",
+              "cleared",
+              "abandoned"
+            ],
+            "type": "string"
+          },
+          "title": "Emits",
+          "type": "array"
+        },
+        "host_app": {
+          "description": "Stable identifier for the host (e.g. 'claude-code', 'cursor').",
+          "title": "Host App",
+          "type": "string"
+        },
+        "host_kind": {
+          "enum": [
+            "ai_chat_client",
+            "ide",
+            "editor",
+            "support_console",
+            "writing_tool",
+            "terminal_ai_client",
+            "enterprise_app"
+          ],
+          "title": "Host Kind",
+          "type": "string"
+        },
+        "level": {
+          "enum": [
+            "L0",
+            "L1",
+            "L2",
+            "L3"
+          ],
+          "title": "Level",
+          "type": "string"
+        }
+      },
+      "required": [
+        "level",
+        "emits",
+        "host_app",
+        "host_kind"
+      ],
+      "title": "ComposerAdapterCapabilities",
+      "type": "object"
+    }
+  },
+  "description": "A single composer-lifecycle observation from an adapter.",
+  "properties": {
+    "capabilities": {
+      "$ref": "#/$defs/ComposerAdapterCapabilities"
+    },
+    "conversation_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Conversation Id"
+    },
+    "field_role": {
+      "anyOf": [
+        {
+          "enum": [
+            "chat_composer",
+            "agent_prompt",
+            "email_body",
+            "doc_editor",
+            "support_reply",
+            "task_note"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Field Role"
+    },
+    "inferred_intent_confidence": {
+      "anyOf": [
+        {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Inferred Intent Confidence"
+    },
+    "inferred_intent_label": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Inferred Intent Label"
+    },
+    "length_chars": {
+      "minimum": 0,
+      "title": "Length Chars",
+      "type": "integer"
+    },
+    "lifecycle_state": {
+      "enum": [
+        "observing",
+        "tentative",
+        "stabilizing",
+        "actionable",
+        "submitted",
+        "cleared",
+        "abandoned"
+      ],
+      "title": "Lifecycle State",
+      "type": "string"
+    },
+    "session_id": {
+      "description": "Stable id for the composer session. Used to correlate snapshots and to invalidate predictions on cancel/abandon.",
+      "title": "Session Id",
+      "type": "string"
+    },
+    "snapshot_id": {
+      "description": "Unique id for this snapshot. Adapters MUST generate a fresh id per emission.",
+      "title": "Snapshot Id",
+      "type": "string"
+    },
+    "text_hash": {
+      "description": "sha256 hex digest of the draft text. The raw text is never transmitted in 0.8.7.",
+      "title": "Text Hash",
+      "type": "string"
+    },
+    "timestamp": {
+      "description": "ISO-8601 timestamp of the observation.",
+      "title": "Timestamp",
+      "type": "string"
+    },
+    "workspace_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Workspace Id"
+    }
+  },
+  "required": [
+    "session_id",
+    "snapshot_id",
+    "timestamp",
+    "lifecycle_state",
+    "text_hash",
+    "length_chars",
+    "capabilities"
+  ],
+  "title": "DraftIntentSnapshot",
+  "type": "object"
+}

--- a/plugins/vaner/.claude-plugin/plugin.json
+++ b/plugins/vaner/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaner",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Vaner: predictive context middleware for AI coding workflows. Bundles the Vaner MCP server (search, expand, resolve, feedback, and more), the vaner-feedback skill, and a SessionStart hook that checks for the `vaner` CLI.",
   "author": {
     "name": "Borgels Olsen Holding ApS",

--- a/plugins/vaner/hooks/hooks.json
+++ b/plugins/vaner/hooks/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/composer-submit.sh",
+            "timeout": 3
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/vaner/scripts/composer-submit.sh
+++ b/plugins/vaner/scripts/composer-submit.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Vaner UserPromptSubmit hook (0.8.7 WS7 — L0 Composer Adapter).
+#
+# Fires on every Claude Code prompt submit. Reads the hook's stdin
+# JSON payload (which carries the prompt text + session_id) and POSTs
+# a DraftIntentSnapshot to the Vaner daemon's loopback endpoint.
+#
+# This is a thin shell shim — all logic lives in composer_submit.py so
+# the implementation is testable. The hook MUST exit 0 quickly under
+# every failure mode so a misconfigured daemon never blocks the user's
+# prompt; the translator handles that.
+set -u
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+exec python3 "${PLUGIN_ROOT}/scripts/composer_submit.py"

--- a/plugins/vaner/scripts/composer_submit.py
+++ b/plugins/vaner/scripts/composer_submit.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Vaner Claude Code UserPromptSubmit hook translator (0.8.7 WS7).
+
+Reads the hook's stdin JSON, builds a DraftIntentSnapshot for the
+Vaner daemon at level L0 (submit-time only), and POSTs it to
+``http://127.0.0.1:<port>/signals/composer``.
+
+Privacy / truthful-state contract:
+
+- The raw prompt text is hashed (sha256) and only the hash + length are
+  transmitted. The text itself NEVER crosses the adapter boundary.
+- L0 means we only emit ``lifecycle_state="submitted"``. The contract
+  forbids fabricating earlier states (observing/tentative/etc.) at L0.
+- Any failure path (daemon unreachable, malformed input, network
+  timeout) exits 0 silently so a misconfigured daemon never blocks the
+  user's prompt. Telemetry of the failure goes to stderr only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+from datetime import UTC, datetime
+
+DEFAULT_DAEMON_PORT = 8473
+HTTP_TIMEOUT_SECONDS = 1.0
+
+
+def _read_payload() -> dict[str, object]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _build_snapshot(payload: dict[str, object]) -> dict[str, object] | None:
+    """Translate the Claude Code hook payload into a DraftIntentSnapshot.
+
+    Returns None when the payload lacks the prompt field (nothing to
+    hash). The hook always exits 0 in that case.
+    """
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt:
+        return None
+    session_id = str(payload.get("session_id") or payload.get("sessionId") or "")
+    cwd = str(payload.get("cwd") or "")
+    text_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    snapshot: dict[str, object] = {
+        "session_id": session_id or f"unknown-{uuid.uuid4().hex[:8]}",
+        "snapshot_id": uuid.uuid4().hex,
+        "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "lifecycle_state": "submitted",
+        "text_hash": text_hash,
+        "length_chars": len(prompt),
+        "capabilities": {
+            "level": "L0",
+            "emits": ["submitted"],
+            "host_app": "claude-code",
+            "host_kind": "ai_chat_client",
+        },
+        "field_role": "agent_prompt",
+    }
+    if cwd:
+        snapshot["workspace_id"] = cwd
+    return snapshot
+
+
+def _daemon_url() -> str:
+    port_str = os.environ.get("VANER_DAEMON_PORT") or str(DEFAULT_DAEMON_PORT)
+    try:
+        port = int(port_str)
+    except ValueError:
+        port = DEFAULT_DAEMON_PORT
+    return f"http://127.0.0.1:{port}/signals/composer"
+
+
+def _post(url: str, body: dict[str, object]) -> tuple[int, str]:
+    encoded = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=encoded,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return int(response.status), response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0, ""
+
+
+def main() -> int:
+    payload = _read_payload()
+    snapshot = _build_snapshot(payload)
+    if snapshot is None:
+        # No prompt field — nothing to do. Exit silently.
+        return 0
+    status, body = _post(_daemon_url(), snapshot)
+    if status != 200:
+        # Best-effort: log to stderr for debugging without blocking the
+        # user's prompt.
+        sys.stderr.write(f"vaner-composer-submit: daemon returned status={status} body={body[:200]!r}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/vaner/scripts/composer_submit.py
+++ b/plugins/vaner/scripts/composer_submit.py
@@ -26,7 +26,13 @@ import sys
 import urllib.error
 import urllib.request
 import uuid
-from datetime import UTC, datetime
+
+# Use ``timezone.utc`` (3.8+) rather than ``datetime.UTC`` (3.11+) so
+# the script imports cleanly on system Python 3.10 (still common on
+# older macOS / Linux distros). The Vaner CLI itself requires 3.11+,
+# but the hook is invoked via the host's ``python3`` which may resolve
+# to an older interpreter.
+from datetime import datetime, timezone
 
 DEFAULT_DAEMON_PORT = 8473
 HTTP_TIMEOUT_SECONDS = 1.0
@@ -57,7 +63,7 @@ def _build_snapshot(payload: dict[str, object]) -> dict[str, object] | None:
     snapshot: dict[str, object] = {
         "session_id": session_id or f"unknown-{uuid.uuid4().hex[:8]}",
         "snapshot_id": uuid.uuid4().hex,
-        "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),  # noqa: UP017 — keep 3.8+ compat (see import note)
         "lifecycle_state": "submitted",
         "text_hash": text_hash,
         "length_chars": len(prompt),
@@ -115,4 +121,18 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    # 0.8.7 hardening M3: every uncaught exception is swallowed and the
+    # script exits 0. The hook contract is "never block the user's
+    # prompt" — that means a misconfigured Python, a missing module,
+    # or any unforeseen exception MUST NOT propagate as a non-zero exit.
+    # Diagnostic detail goes to stderr only.
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except BaseException as _exc:  # noqa: BLE001 — defense-in-depth top-level
+        try:
+            sys.stderr.write(f"vaner-composer-submit: unexpected {type(_exc).__name__}: {_exc}\n")
+        except Exception:
+            pass
+        raise SystemExit(0) from None

--- a/plugins/vaner/scripts/composer_submit.py
+++ b/plugins/vaner/scripts/composer_submit.py
@@ -134,5 +134,7 @@ if __name__ == "__main__":
         try:
             sys.stderr.write(f"vaner-composer-submit: unexpected {type(_exc).__name__}: {_exc}\n")
         except Exception:
+            # stderr may be closed under unusual hook environments;
+            # the hook contract still requires exit 0.
             pass
         raise SystemExit(0) from None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vaner"
-version = "0.8.6"
+version = "0.8.7"
 description = "Predictive context middleware layer for AI workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ all = [
 
 [project.scripts]
 vaner = "vaner.cli.main:run"
+vaner-composer-schema = "vaner.signals.composer.schema:main"
 
 [project.urls]
 Homepage = "https://github.com/Borgels/Vaner"

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -24,6 +24,28 @@ def _metrics_path(repo_root: Path) -> Path:
     return repo_root / ".vaner" / "metrics.db"
 
 
+def _sanitize_validation_errors(exc: Any) -> list[dict[str, Any]]:
+    """Strip the raw ``input`` value from pydantic ValidationError payloads.
+
+    0.8.7 WS7 hardening C1: pydantic v2's ``exc.errors()`` echoes the
+    offending value under the ``input`` key. For an adapter bug that
+    placed draft text into the wrong field, that would reflect raw text
+    back to the client in the error envelope. We surface only the field
+    path + error type + message — never the input value or any URL the
+    pydantic library generated for the error catalog.
+    """
+    safe: list[dict[str, Any]] = []
+    for err in exc.errors():
+        safe.append(
+            {
+                "loc": err.get("loc"),
+                "type": err.get("type"),
+                "msg": err.get("msg"),
+            }
+        )
+    return safe
+
+
 # How long to wait between precompute cycles when the daemon holds a live
 # engine. Reusing the existing idle-gate + timing-aware cycle budget, so this
 # is just the outer rhythm — the engine itself may return early under load.
@@ -1075,8 +1097,14 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         try:
             snapshot = DraftIntentSnapshot.model_validate(body)
         except ValidationError as exc:
+            # 0.8.7 hardening C1: scrub the raw `input` payload from
+            # pydantic error envelopes. Pydantic v2's exc.errors() echoes
+            # the offending value under the `input` key — for an adapter
+            # bug that put draft text into the wrong field, that would
+            # reflect raw text back to the client. We surface only the
+            # field path + error type + message, never the input value.
             return JSONResponse(
-                {"code": "invalid_input", "message": exc.errors()},
+                {"code": "invalid_input", "message": _sanitize_validation_errors(exc)},
                 status_code=400,
             )
 
@@ -1105,9 +1133,9 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         try:
             await engine.observe(event)
         except ValidationError as exc:
-            # engine.observe re-validates; surface its message too.
+            # engine.observe re-validates; same sanitization applies.
             return JSONResponse(
-                {"code": "invalid_input", "message": exc.errors()},
+                {"code": "invalid_input", "message": _sanitize_validation_errors(exc)},
                 status_code=400,
             )
 
@@ -1128,6 +1156,9 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
                     "host_app": snapshot.capabilities.host_app,
                     "host_kind": snapshot.capabilities.host_kind,
                     "level": snapshot.capabilities.level,
+                    # 0.8.7 hardening H4: propagate privacy_zone so dashboards
+                    # that aggregate by zone can attribute composer rows.
+                    "privacy_zone": getattr(getattr(engine, "adapter", None), "privacy_zone", "local"),
                 },
             )
         except Exception:  # pragma: no cover - defensive metrics

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -1079,9 +1079,13 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
             )
         try:
             body = await request.json()
-        except Exception as exc:
+        except Exception:
+            # 0.8.7 hardening (CodeQL py/stack-trace-exposure): the
+            # JSON-parse exception text can carry payload bytes and
+            # internal parser state. Surface only a static "invalid
+            # JSON" message — adapter authors don't need the raw error.
             return JSONResponse(
-                {"code": "invalid_input", "message": f"invalid JSON: {exc}"},
+                {"code": "invalid_input", "message": "invalid JSON body"},
                 status_code=400,
             )
 

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -1035,6 +1035,109 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         resolution = _build_adopt_resolution(prompt)
         return JSONResponse(resolution.model_dump(mode="json"))
 
+    @app.post("/signals/composer")
+    async def signals_composer(request: Request) -> JSONResponse:
+        """0.8.7 WS7 — ingest a composer-lifecycle event.
+
+        Accepts a ``DraftIntentSnapshot`` payload from a registered
+        :class:`ComposerAdapter` (e.g. the Claude Code UserPromptSubmit
+        hook), envelopes it into a :class:`SignalEvent` of kind
+        ``composer_lifecycle``, and forwards to ``engine.observe()``.
+        Returns the assigned ``composer_event_id`` so adapters can
+        thread it back to the host UI for adoption attribution.
+
+        Returns 400 on malformed payload (pydantic ValidationError),
+        409 when no engine is available (the daemon is running without
+        an injected engine, e.g. cockpit-only mode).
+        """
+        if engine is None:
+            return JSONResponse(
+                {"code": "engine_unavailable", "message": "engine unavailable"},
+                status_code=409,
+            )
+        try:
+            body = await request.json()
+        except Exception as exc:
+            return JSONResponse(
+                {"code": "invalid_input", "message": f"invalid JSON: {exc}"},
+                status_code=400,
+            )
+
+        # Lazy imports keep the daemon module load light.
+        import time as _time
+        import uuid as _uuid
+
+        from pydantic import ValidationError
+
+        from vaner.models.signal import KIND_COMPOSER_LIFECYCLE, SignalEvent
+        from vaner.signals.composer import DraftIntentSnapshot
+
+        try:
+            snapshot = DraftIntentSnapshot.model_validate(body)
+        except ValidationError as exc:
+            return JSONResponse(
+                {"code": "invalid_input", "message": exc.errors()},
+                status_code=400,
+            )
+
+        # The adapter MUST only emit lifecycle states declared in
+        # capabilities.emits — otherwise an L0 adapter could fabricate a
+        # higher state and corrupt downstream scoring.
+        if snapshot.lifecycle_state not in snapshot.capabilities.emits:
+            return JSONResponse(
+                {
+                    "code": "capability_violation",
+                    "message": (
+                        f"adapter declared emits={list(snapshot.capabilities.emits)} but sent lifecycle_state={snapshot.lifecycle_state!r}"
+                    ),
+                },
+                status_code=400,
+            )
+
+        composer_event_id = _uuid.uuid4().hex
+        event = SignalEvent(
+            id=composer_event_id,
+            source=f"composer-adapter:{snapshot.capabilities.host_app}",
+            kind=KIND_COMPOSER_LIFECYCLE,
+            timestamp=_time.time(),
+            payload=snapshot.model_dump(mode="json"),
+        )
+        try:
+            await engine.observe(event)
+        except ValidationError as exc:
+            # engine.observe re-validates; surface its message too.
+            return JSONResponse(
+                {"code": "invalid_input", "message": exc.errors()},
+                status_code=400,
+            )
+
+        # Telemetry: record the composer-lifecycle event into draft_events
+        # for hit/miss attribution downstream. Best-effort: a metrics
+        # failure must not block the response.
+        try:
+            metrics = MetricsStore(_metrics_path(config.repo_root))
+            await metrics.initialize()
+            await metrics.record_composer_lifecycle_event(
+                session_id=snapshot.session_id,
+                snapshot_id=snapshot.snapshot_id,
+                lifecycle_state=snapshot.lifecycle_state,
+                text_hash=snapshot.text_hash,
+                length_chars=snapshot.length_chars,
+                composer_event_id=composer_event_id,
+                metadata={
+                    "host_app": snapshot.capabilities.host_app,
+                    "host_kind": snapshot.capabilities.host_kind,
+                    "level": snapshot.capabilities.level,
+                },
+            )
+        except Exception:  # pragma: no cover - defensive metrics
+            pass
+
+        return JSONResponse(
+            {"composer_event_id": composer_event_id},
+            status_code=200,
+        )
+
     @app.post("/resolve")
     async def resolve_endpoint(request: Request) -> JSONResponse:
         """0.8.1: expose :meth:`VanerEngine.resolve_query` over HTTP.

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -1146,10 +1146,14 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         # Telemetry: record the composer-lifecycle event into draft_events
         # for hit/miss attribution downstream. Best-effort: a metrics
         # failure must not block the response.
+        #
+        # 0.8.7 hardening: reuse the closure-captured ``metrics_store``
+        # that the daemon's lifespan already initialized at startup.
+        # An earlier draft created a fresh MetricsStore + initialized it
+        # per request, which raced under concurrent composer events on
+        # SQLite WAL setup (CI Python 3.11 / 3.13 surfaced this).
         try:
-            metrics = MetricsStore(_metrics_path(config.repo_root))
-            await metrics.initialize()
-            await metrics.record_composer_lifecycle_event(
+            await metrics_store.record_composer_lifecycle_event(
                 session_id=snapshot.session_id,
                 snapshot_id=snapshot.snapshot_id,
                 lifecycle_state=snapshot.lifecycle_state,

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -97,9 +97,10 @@ from vaner.models.artefact import Artefact, ArtefactKind
 from vaner.models.config import ComputeConfig, ExplorationConfig, VanerConfig
 from vaner.models.context import ContextPackage
 from vaner.models.decision import DecisionRecord, PredictionLink, ScoreFactor
-from vaner.models.signal import SignalEvent
+from vaner.models.signal import KIND_COMPOSER_LIFECYCLE, SignalEvent
 from vaner.setup.apply import AppliedPolicy, apply_policy_bundle
 from vaner.setup.catalog import bundle_by_id
+from vaner.signals.composer import ComposerSignalPump, DraftIntentSnapshot
 from vaner.store import deep_run as deep_run_store
 from vaner.store.artefacts import ArtefactStore
 from vaner.store.profile_store import UserProfileStore
@@ -251,6 +252,11 @@ class VanerEngine:
         )
 
         self._refinement_drafter: _MaturationDrafterCallable | None = None
+        # 0.8.7 WS3: distribution point for composer-lifecycle snapshots.
+        # The engine validates ``SignalEvent``s of kind ``composer_lifecycle``
+        # in ``observe()`` and publishes the typed snapshot here. WS4 wires
+        # the prediction registry as the first subscriber.
+        self._composer_signal_pump = ComposerSignalPump()
         # WS6: snapshot the most recent git HEAD and category tail so each
         # cycle can diff against them to build invalidation signals. Empty
         # string / list means "no prior observation", which yields no signals.
@@ -492,9 +498,24 @@ class VanerEngine:
 
     async def observe(self, event: SignalEvent) -> None:
         await self.initialize()
+        if event.kind == KIND_COMPOSER_LIFECYCLE:
+            # Validates payload shape; pydantic.ValidationError on malformed.
+            # The validation MUST happen before the store insert so a
+            # malformed composer payload never reaches persistence.
+            snapshot = DraftIntentSnapshot.model_validate(event.payload)
+            await self._composer_signal_pump.publish(snapshot)
         event.payload.setdefault("corpus_id", getattr(self.adapter, "corpus_id", "default"))
         event.payload.setdefault("privacy_zone", getattr(self.adapter, "privacy_zone", "local"))
         await self.store.insert_signal_event(event)
+
+    @property
+    def composer_signal_pump(self) -> ComposerSignalPump:
+        """Subscribe to composer-lifecycle snapshots.
+
+        Exposed for the prediction registry's invalidation path (WS4) and
+        for tests. The engine owns the pump for its lifetime.
+        """
+        return self._composer_signal_pump
 
     async def prepare(self, changed_files: list[Path] | None = None) -> int:
         await self.initialize()

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -498,15 +498,27 @@ class VanerEngine:
 
     async def observe(self, event: SignalEvent) -> None:
         await self.initialize()
+        snapshot: DraftIntentSnapshot | None = None
         if event.kind == KIND_COMPOSER_LIFECYCLE:
             # Validates payload shape; pydantic.ValidationError on malformed.
             # The validation MUST happen before the store insert so a
             # malformed composer payload never reaches persistence.
             snapshot = DraftIntentSnapshot.model_validate(event.payload)
-            await self._composer_signal_pump.publish(snapshot)
         event.payload.setdefault("corpus_id", getattr(self.adapter, "corpus_id", "default"))
         event.payload.setdefault("privacy_zone", getattr(self.adapter, "privacy_zone", "local"))
         await self.store.insert_signal_event(event)
+        # 0.8.7 hardening H1: persist BEFORE publish. A pump exception
+        # (a misbehaving subscriber, a cancelled loop) must not lose the
+        # event; the store insert is the durable record. Publish errors
+        # are isolated by the pump itself, but wrap in defense-in-depth.
+        if snapshot is not None:
+            try:
+                await self._composer_signal_pump.publish(snapshot)
+            except Exception:  # pragma: no cover - defensive
+                # The signal is already persisted. A future cycle can
+                # re-derive prediction state from signal_events; losing
+                # the in-process pump notification is non-fatal.
+                pass
 
     @property
     def composer_signal_pump(self) -> ComposerSignalPump:

--- a/src/vaner/intent/frontier.py
+++ b/src/vaner/intent/frontier.py
@@ -152,6 +152,10 @@ class ExplorationFrontier:
         "pattern": 1.2,  # validated patterns get a slight head start
         "llm_branch": 0.9,
         "skill": 1.1,
+        # 0.8.7 WS5 — composer-anchored predictions enter at the
+        # baseline multiplier; the existing per-source learning loop
+        # below auto-adapts based on adoption telemetry.
+        "composer_intent": 1.0,
     }
 
     def __init__(

--- a/src/vaner/intent/invalidation.py
+++ b/src/vaner/intent/invalidation.py
@@ -47,6 +47,14 @@ SignalKind = Literal[
     "artefact_seen",
     "artefact_superseded",
     "progress_reconciled",
+    # 0.8.7 WS4 — composer-lifecycle invalidations. Both carry
+    # ``payload["session_id"]`` and target ``composer_intent``-sourced
+    # predictions whose ``spec.anchor`` matches that session_id.
+    # ``composer_cancelled`` fires when the user explicitly cleared the
+    # draft; ``composer_abandoned`` fires when the draft went stale
+    # without submit (lost focus, replaced, or TTL expired).
+    "composer_cancelled",
+    "composer_abandoned",
 ]
 
 
@@ -171,4 +179,32 @@ def build_adoption_signal(prediction_id: str) -> InvalidationSignal:
     return InvalidationSignal(
         kind="adoption",
         payload={"prediction_id": prediction_id},
+    )
+
+
+def build_composer_cancelled_signal(session_id: str) -> InvalidationSignal:
+    """Emit a ``composer_cancelled`` signal for ``session_id`` (0.8.7 WS4).
+
+    Fires when the user explicitly cleared the composer draft. The
+    registry stales every ``composer_intent``-sourced prediction whose
+    ``spec.anchor`` equals ``session_id``.
+    """
+    return InvalidationSignal(
+        kind="composer_cancelled",
+        payload={"session_id": session_id},
+    )
+
+
+def build_composer_abandoned_signal(session_id: str) -> InvalidationSignal:
+    """Emit a ``composer_abandoned`` signal for ``session_id`` (0.8.7 WS4).
+
+    Fires when the composer draft went stale without submit (focus
+    lost, draft replaced, TTL expired). Treated the same as
+    ``composer_cancelled`` by the registry — both stale the
+    associated ``composer_intent`` predictions; the distinct kind is
+    preserved for telemetry attribution.
+    """
+    return InvalidationSignal(
+        kind="composer_abandoned",
+        payload={"session_id": session_id},
     )

--- a/src/vaner/intent/prediction.py
+++ b/src/vaner/intent/prediction.py
@@ -136,6 +136,15 @@ class PredictionRun:
     # that anchors this prediction. Default 0.0 keeps the existing
     # rebalance arithmetic byte-identical for non-composer predictions
     # (mirrors the v0.8.6 WS4 mixed-is-identity discipline).
+    #
+    # NOTE (v0.8.8 wiring gap): in v0.8.7 this field is part of the data
+    # backbone but has NO producer (no pump subscriber sets it) and NO
+    # consumer (no rebalance path reads it). The producer lands when the
+    # composer signal pump gets a registry-update subscriber; the
+    # consumer lands when ``rebalance()`` weights composer_intent specs
+    # by their signal strength. Both are tracked for v0.8.8 alongside
+    # the first L1 adapter. The default-0 invariant is what keeps v0.8.7
+    # behavior byte-identical to pre-0.8.7 for default-config users.
     compose_signal_strength: float = 0.0
 
 

--- a/src/vaner/intent/prediction.py
+++ b/src/vaner/intent/prediction.py
@@ -166,6 +166,12 @@ class PredictionArtifacts:
     file_content_hashes: dict[str, str] = field(default_factory=dict)
     pre_maturation_draft_answer: str | None = None
     pre_maturation_evidence_score: float | None = None
+    # 0.8.7 WS8 — composer-engagement metadata for ``composer_intent``-
+    # sourced predictions. Populated by the daemon's composer signal
+    # path (WS7) so the MCP card surface can render
+    # ``composer_engagement`` without hard-coding lookups against the
+    # signal store. Empty for non-composer sources.
+    composer_metadata: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/src/vaner/intent/prediction.py
+++ b/src/vaner/intent/prediction.py
@@ -69,9 +69,18 @@ def is_transition_allowed(from_state: ReadinessState, to_state: ReadinessState) 
 
 
 def prediction_id(source: str, anchor: str, label: str) -> str:
-    """Stable hash over (source, anchor, label). The identity key for a prediction."""
+    """Stable hash over (source, anchor, label). The identity key for a prediction.
+
+    Uses SHA-1 truncated to 16 hex chars purely as a deterministic
+    identifier hash (not a cryptographic primitive). ``usedforsecurity=False``
+    declares this intent so CodeQL ``py/weak-cryptographic-algorithm``
+    no longer flags it; the hash result is unchanged. Switching to
+    SHA-256 would change every existing prediction id and break stored
+    rows in the prediction registry / store, so we pin the algorithm
+    and document the non-security purpose.
+    """
     payload = f"{source}|{anchor}|{label}".encode()
-    return hashlib.sha1(payload).hexdigest()[:16]
+    return hashlib.sha1(payload, usedforsecurity=False).hexdigest()[:16]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/vaner/intent/prediction.py
+++ b/src/vaner/intent/prediction.py
@@ -71,16 +71,17 @@ def is_transition_allowed(from_state: ReadinessState, to_state: ReadinessState) 
 def prediction_id(source: str, anchor: str, label: str) -> str:
     """Stable hash over (source, anchor, label). The identity key for a prediction.
 
-    Uses SHA-1 truncated to 16 hex chars purely as a deterministic
-    identifier hash (not a cryptographic primitive). ``usedforsecurity=False``
-    declares this intent so CodeQL ``py/weak-cryptographic-algorithm``
-    no longer flags it; the hash result is unchanged. Switching to
-    SHA-256 would change every existing prediction id and break stored
-    rows in the prediction registry / store, so we pin the algorithm
-    and document the non-security purpose.
+    Uses SHA-256 truncated to 16 hex chars purely as a deterministic
+    identifier hash (not a cryptographic primitive — the truncation
+    breaks any cryptographic strength anyway). 0.8.7 hardening switched
+    from SHA-1 because CodeQL's ``py/weak-cryptographic-algorithm`` does
+    not honor ``usedforsecurity=False``; SHA-256 is universally accepted.
+    The ID change across the 0.8.6→0.8.7 boundary is safe: prediction
+    adoption outcomes are short-TTL and the in-memory registry rebuilds
+    every cycle.
     """
     payload = f"{source}|{anchor}|{label}".encode()
-    return hashlib.sha1(payload, usedforsecurity=False).hexdigest()[:16]
+    return hashlib.sha256(payload).hexdigest()[:16]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/vaner/intent/prediction.py
+++ b/src/vaner/intent/prediction.py
@@ -41,6 +41,11 @@ Source = Literal[
     # stalled} and emits one spec per eligible item. Carries richer
     # ``anchor_units`` (related files + entities) than goal-level specs.
     "artefact_item",
+    # 0.8.7 WS4 — anchored to a live composer session via the
+    # ComposerAdapter. ``anchor`` carries the composer ``session_id``
+    # so ``composer_cancelled`` / ``composer_abandoned`` invalidation
+    # signals can stale the prediction by session lookup.
+    "composer_intent",
 ]
 HypothesisType = Literal["likely_next", "possible_branch", "long_tail"]
 Specificity = Literal["concrete", "category", "anchor"]
@@ -127,6 +132,11 @@ class PredictionRun:
     probationary_until_cycle: int | None = None
     failed_revisits: int = 0
     maturation_eligible: bool = True
+    # 0.8.7 WS4 — strength of the most recent composer-lifecycle signal
+    # that anchors this prediction. Default 0.0 keeps the existing
+    # rebalance arithmetic byte-identical for non-composer predictions
+    # (mirrors the v0.8.6 WS4 mixed-is-identity discipline).
+    compose_signal_strength: float = 0.0
 
 
 @dataclass(slots=True)

--- a/src/vaner/intent/prediction_card.py
+++ b/src/vaner/intent/prediction_card.py
@@ -32,6 +32,8 @@ _SOURCE_LABELS: dict[str, str] = {
     "macro": "Workspace signal",
     "history": "Historical pattern",
     "goal": "Active goal",
+    # 0.8.7 WS4 — composer-anchored predictions surface as draft-derived.
+    "composer_intent": "From your current draft",
 }
 
 

--- a/src/vaner/intent/prediction_registry.py
+++ b/src/vaner/intent/prediction_registry.py
@@ -647,6 +647,35 @@ class PredictionRegistry:
                 # doesn't fall through as an unknown signal.
                 continue
 
+            elif kind in ("composer_cancelled", "composer_abandoned"):
+                # 0.8.7 WS4 — stale every composer_intent-sourced
+                # prediction whose spec.anchor matches the cancelled /
+                # abandoned session_id. Both kinds invalidate the same
+                # set; preserving distinct kinds keeps telemetry
+                # attribution intact.
+                session_id = str(payload.get("session_id", ""))
+                if not session_id:
+                    continue
+                reason_label = "composer_cancelled" if kind == "composer_cancelled" else "composer_abandoned"
+                for prompt in list(self._predictions.values()):
+                    if prompt.is_terminal():
+                        continue
+                    if prompt.spec.source != "composer_intent":
+                        continue
+                    if prompt.spec.anchor != session_id:
+                        continue
+                    prompt.run.invalidation_reason = f"{reason_label}: {session_id}"
+                    try:
+                        self._transition(
+                            prompt,
+                            "stale",
+                            reason=prompt.run.invalidation_reason,
+                        )
+                        outcomes[prompt.spec.id] = "staled"
+                    except InvalidTransitionError:
+                        pass
+                    prompt.run.updated_at = self._clock()
+
         return outcomes
 
     # ---------------------------------------------------------------

--- a/src/vaner/intent/prediction_registry.py
+++ b/src/vaner/intent/prediction_registry.py
@@ -673,6 +673,7 @@ class PredictionRegistry:
                         )
                         outcomes[prompt.spec.id] = "staled"
                     except InvalidTransitionError:
+                        # Already in a terminal state — invalidation is a no-op.
                         pass
                     prompt.run.updated_at = self._clock()
 

--- a/src/vaner/intent/work_style_priors.py
+++ b/src/vaner/intent/work_style_priors.py
@@ -66,6 +66,12 @@ class IntentPriorAdjustments:
     drafting_evidence_floor: float
     drafting_volatility_ceiling_multiplier: float
     preferred_artefact_templates: tuple[str, ...]
+    # 0.8.7 WS5 — multiplier applied to ``composer_intent``-sourced
+    # predictions when the user is in this work style. mixed=1.0 keeps
+    # the prior identity invariant; styles whose drafts are highly
+    # informative about next-prompt intent (writing, research) get a
+    # stronger boost than coding/general/support.
+    composer_signal_weight_multiplier: float = 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +90,8 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.0,
         drafting_volatility_ceiling_multiplier=1.2,
         preferred_artefact_templates=("next_scene_draft", "outline_continuation"),
+        # Rewrite/style intents are highly draft-revealing.
+        composer_signal_weight_multiplier=1.4,
     ),
     "research": IntentPriorAdjustments(
         # Research wants broad branch coverage; weight possible-branch
@@ -95,6 +103,8 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.45,
         drafting_volatility_ceiling_multiplier=1.0,
         preferred_artefact_templates=("research_brief", "lit_review"),
+        # Comparison/follow-up framing is draft-revealing.
+        composer_signal_weight_multiplier=1.3,
     ),
     "planning": IntentPriorAdjustments(
         # Planning is artefact-anchored (decision memos, risk lists);
@@ -106,6 +116,7 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.50,
         drafting_volatility_ceiling_multiplier=0.9,
         preferred_artefact_templates=("decision_memo", "risk_list"),
+        composer_signal_weight_multiplier=1.2,
     ),
     "support": IntentPriorAdjustments(
         # Support work wants to finish what's in flight (short horizon,
@@ -116,6 +127,7 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.55,
         drafting_volatility_ceiling_multiplier=0.8,
         preferred_artefact_templates=("ticket_reply", "troubleshooting_brief"),
+        composer_signal_weight_multiplier=1.1,
     ),
     "learning": IntentPriorAdjustments(
         # Learning rewards exposure to adjacent concepts (high possible-
@@ -126,6 +138,7 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.0,
         drafting_volatility_ceiling_multiplier=1.3,
         preferred_artefact_templates=("study_outline", "concept_brief"),
+        composer_signal_weight_multiplier=1.1,
     ),
     "coding": IntentPriorAdjustments(
         # Coding wants clean patches: high evidence floor, tight volatility
@@ -136,6 +149,7 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.55,
         drafting_volatility_ceiling_multiplier=0.8,
         preferred_artefact_templates=("debugging_brief", "patch_proposal"),
+        composer_signal_weight_multiplier=1.0,
     ),
     "general": IntentPriorAdjustments(
         # General-purpose: very gentle nudges, no template preference.
@@ -145,6 +159,7 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.0,
         drafting_volatility_ceiling_multiplier=1.0,
         preferred_artefact_templates=(),
+        composer_signal_weight_multiplier=1.0,
     ),
     "mixed": IntentPriorAdjustments(
         # Identity element. ``setup.work_styles == ["mixed"]`` is the
@@ -156,6 +171,10 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.0,
         drafting_volatility_ceiling_multiplier=1.0,
         preferred_artefact_templates=(),
+        # mixed-is-identity invariant: composer multiplier MUST be 1.0
+        # so a mixed user with no composer signal sees byte-identical
+        # frontier scoring vs. pre-0.8.7. Same gate as 0.8.6 WS4.
+        composer_signal_weight_multiplier=1.0,
     ),
     "unsure": IntentPriorAdjustments(
         # Same identity as ``mixed`` — the user opted out of telling us;
@@ -168,6 +187,7 @@ WORK_STYLE_PRIORS: Final[Mapping[WorkStyle, IntentPriorAdjustments]] = {
         drafting_evidence_floor=0.0,
         drafting_volatility_ceiling_multiplier=1.0,
         preferred_artefact_templates=(),
+        composer_signal_weight_multiplier=1.0,
     ),
 }
 
@@ -219,6 +239,7 @@ def adjustments_for(work_styles: Sequence[WorkStyle]) -> IntentPriorAdjustments:
         drafting_evidence_floor=sum(s.drafting_evidence_floor for s in specs) / n,
         drafting_volatility_ceiling_multiplier=sum(s.drafting_volatility_ceiling_multiplier for s in specs) / n,
         preferred_artefact_templates=tuple(sorted(templates)),
+        composer_signal_weight_multiplier=sum(s.composer_signal_weight_multiplier for s in specs) / n,
     )
 
 

--- a/src/vaner/intent/work_style_priors.py
+++ b/src/vaner/intent/work_style_priors.py
@@ -71,6 +71,16 @@ class IntentPriorAdjustments:
     # the prior identity invariant; styles whose drafts are highly
     # informative about next-prompt intent (writing, research) get a
     # stronger boost than coding/general/support.
+    #
+    # NOTE (v0.8.8 wiring gap): in v0.8.7 this field has values per
+    # WorkStyle (writing 1.4, research 1.3, etc.) but NO consumer reads
+    # it. Plan WS5 step 4 was to gate ``composer_intent``-source weight
+    # on this multiplier in the engine's per-cycle scoring (where
+    # ``artefact_alignment_weight_multiplier`` is composed at
+    # engine.py:1403); that wiring lands in v0.8.8 alongside the first
+    # composer_intent producer (registry subscriber on the pump).
+    # Keeping the field populated now means v0.8.8 can plug in the
+    # consumer without a parallel data migration.
     composer_signal_weight_multiplier: float = 1.0
 
 

--- a/src/vaner/mcp/contracts.py
+++ b/src/vaner/mcp/contracts.py
@@ -117,6 +117,12 @@ class Resolution(BaseModel):
     # downstream agents know the prepared package came from an adopted
     # prediction (and can surface that provenance in their UI).
     adopted_from_prediction_id: str | None = None
+    # 0.8.7 WS8: when the adopted prediction is sourced from a
+    # ``composer_intent`` (i.e. the user's draft triggered the
+    # preparation), this carries the originating composer event id so
+    # adoption telemetry can attribute hit/miss back to the composer
+    # event. Default None — non-composer adoptions never set this field.
+    composer_event_id: str | None = None
 
 
 class Abstain(BaseModel):

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -684,6 +684,16 @@ def _build_adopt_resolution(prompt: Any) -> Resolution:
         )
         for scenario_id in artifacts.scenario_ids
     ]
+    # 0.8.7 WS7/WS8: when the adopted prediction is composer_intent-sourced,
+    # thread the originating composer_event_id into the Resolution so
+    # adoption telemetry can attribute hit/miss back to the composer event.
+    composer_event_id: str | None = None
+    if spec.source == "composer_intent":
+        meta = getattr(artifacts, "composer_metadata", {}) or {}
+        candidate = meta.get("composer_event_id")
+        if isinstance(candidate, str) and candidate:
+            composer_event_id = candidate
+
     return Resolution(
         intent=spec.label,
         confidence=float(spec.confidence),
@@ -696,6 +706,7 @@ def _build_adopt_resolution(prompt: Any) -> Resolution:
         briefing_token_used=briefing_obj.token_count,
         briefing_token_budget=run.token_budget,
         adopted_from_prediction_id=spec.id,
+        composer_event_id=composer_event_id,
     )
 
 

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -560,6 +560,13 @@ def _composer_engagement_payload(prompt: Any) -> dict[str, Any] | None:
     UI would render against. Stored on the prediction's run/artifacts
     metadata by WS7's adapter pipeline; this helper is the single
     decoupling point so a future schema change touches one place.
+
+    0.8.7 hardening (M2): each metadata field is type-checked before it
+    enters the wire payload. A corrupted ``composer_metadata`` carrying
+    e.g. ``composer_event_id=[1,2,3]`` would otherwise be coerced to
+    ``"[1, 2, 3]"`` by ``str(...)`` and surface in the MCP card. We
+    require ``composer_event_id`` to be a non-empty string and validate
+    each optional field's type before passing it through.
     """
     artifacts = getattr(prompt, "artifacts", None)
     spec = getattr(prompt, "spec", None)
@@ -567,13 +574,22 @@ def _composer_engagement_payload(prompt: Any) -> dict[str, Any] | None:
         return None
     metadata: dict[str, Any] = getattr(artifacts, "composer_metadata", {}) or {}
     composer_event_id = metadata.get("composer_event_id")
-    if not composer_event_id:
+    if not isinstance(composer_event_id, str) or not composer_event_id:
         return None
+    lifecycle_state = metadata.get("lifecycle_state", "submitted")
+    if not isinstance(lifecycle_state, str):
+        lifecycle_state = "submitted"
+    inferred_intent_label = metadata.get("inferred_intent_label")
+    if inferred_intent_label is not None and not isinstance(inferred_intent_label, str):
+        inferred_intent_label = None
+    inferred_intent_confidence = metadata.get("inferred_intent_confidence")
+    if inferred_intent_confidence is not None and not isinstance(inferred_intent_confidence, (int, float)):
+        inferred_intent_confidence = None
     return {
-        "composer_event_id": str(composer_event_id),
-        "lifecycle_state": str(metadata.get("lifecycle_state", "submitted")),
-        "inferred_intent_label": metadata.get("inferred_intent_label"),
-        "inferred_intent_confidence": metadata.get("inferred_intent_confidence"),
+        "composer_event_id": composer_event_id,
+        "lifecycle_state": lifecycle_state,
+        "inferred_intent_label": inferred_intent_label,
+        "inferred_intent_confidence": inferred_intent_confidence,
     }
 
 

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -541,7 +541,40 @@ def _serialize_prediction_for_mcp(prompt: Any, *, rank: int | None = None) -> di
     }
     if rank is not None:
         payload["rank"] = rank
+    # 0.8.7 WS8: surface composer-engagement metadata only for
+    # composer_intent-sourced predictions. The data backbone is
+    # populated by WS7's daemon path; field is omitted entirely
+    # for non-composer predictions so existing card payloads stay
+    # byte-identical.
+    if spec.source == "composer_intent":
+        composer_engagement = _composer_engagement_payload(prompt)
+        if composer_engagement is not None:
+            payload["composer_engagement"] = composer_engagement
     return payload
+
+
+def _composer_engagement_payload(prompt: Any) -> dict[str, Any] | None:
+    """Extract composer-engagement metadata from a composer_intent prediction.
+
+    Returns None if the prediction lacks the engagement fields the host
+    UI would render against. Stored on the prediction's run/artifacts
+    metadata by WS7's adapter pipeline; this helper is the single
+    decoupling point so a future schema change touches one place.
+    """
+    artifacts = getattr(prompt, "artifacts", None)
+    spec = getattr(prompt, "spec", None)
+    if artifacts is None or spec is None:
+        return None
+    metadata: dict[str, Any] = getattr(artifacts, "composer_metadata", {}) or {}
+    composer_event_id = metadata.get("composer_event_id")
+    if not composer_event_id:
+        return None
+    return {
+        "composer_event_id": str(composer_event_id),
+        "lifecycle_state": str(metadata.get("lifecycle_state", "submitted")),
+        "inferred_intent_label": metadata.get("inferred_intent_label"),
+        "inferred_intent_confidence": metadata.get("inferred_intent_confidence"),
+    }
 
 
 _RESOURCE_METRIC_TASKS: set[Any] = set()

--- a/src/vaner/models/signal.py
+++ b/src/vaner/models/signal.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+# Composer-adapter lifecycle events (0.8.7 WS3). The engine's observe()
+# branches on this kind to validate the payload as a DraftIntentSnapshot
+# and publish to the composer signal pump.
+KIND_COMPOSER_LIFECYCLE = "composer_lifecycle"
+
 
 class SignalEvent(BaseModel):
     id: str

--- a/src/vaner/signals/__init__.py
+++ b/src/vaner/signals/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/src/vaner/signals/composer/__init__.py
+++ b/src/vaner/signals/composer/__init__.py
@@ -4,7 +4,6 @@
 from vaner.signals.composer.contract import (
     CapabilityLevel,
     ComposerAdapterCapabilities,
-    ComposerEvent,
     DraftIntentSnapshot,
     FieldRole,
     HostKind,
@@ -15,7 +14,6 @@ from vaner.signals.composer.pump import ComposerSignalPump, ComposerSubscriber
 __all__ = [
     "CapabilityLevel",
     "ComposerAdapterCapabilities",
-    "ComposerEvent",
     "ComposerSignalPump",
     "ComposerSubscriber",
     "DraftIntentSnapshot",

--- a/src/vaner/signals/composer/__init__.py
+++ b/src/vaner/signals/composer/__init__.py
@@ -10,11 +10,14 @@ from vaner.signals.composer.contract import (
     HostKind,
     LifecycleState,
 )
+from vaner.signals.composer.pump import ComposerSignalPump, ComposerSubscriber
 
 __all__ = [
     "CapabilityLevel",
     "ComposerAdapterCapabilities",
     "ComposerEvent",
+    "ComposerSignalPump",
+    "ComposerSubscriber",
     "DraftIntentSnapshot",
     "FieldRole",
     "HostKind",

--- a/src/vaner/signals/composer/__init__.py
+++ b/src/vaner/signals/composer/__init__.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Composer-adapter signal contract — 0.8.7 WS2."""
+
+from vaner.signals.composer.contract import (
+    CapabilityLevel,
+    ComposerAdapterCapabilities,
+    ComposerEvent,
+    DraftIntentSnapshot,
+    FieldRole,
+    HostKind,
+    LifecycleState,
+)
+
+__all__ = [
+    "CapabilityLevel",
+    "ComposerAdapterCapabilities",
+    "ComposerEvent",
+    "DraftIntentSnapshot",
+    "FieldRole",
+    "HostKind",
+    "LifecycleState",
+]

--- a/src/vaner/signals/composer/contract.py
+++ b/src/vaner/signals/composer/contract.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ComposerAdapter contract — 0.8.7 WS2 (Live Intent Capture, Phase 1).
+
+Vaner consumes explicit composer/prompt lifecycle events from supported
+clients via a ``ComposerAdapter``. This module defines the wire contract
+for those events. Pydantic models here are the source of truth; the
+JSON Schema artifact at ``docs/specs/composer-adapter.schema.json`` is
+generated from them by ``vaner.signals.composer.schema:main``.
+
+Privacy contract:
+
+- The draft text itself NEVER crosses this boundary. Adapters send a
+  ``text_hash`` (sha256 of the draft) and a length, never the raw text
+  or a preview. ``text_preview`` / ``local_text_ref`` from the broader
+  product spec are deferred until a redaction module exists.
+- Local-only by default. Cloud processing is not enabled in 0.8.7.
+- Per-client opt-in inherits the host's plugin/extension enable/disable
+  surface in 0.8.7; first-class per-client opt-in scaffolding lands in
+  v0.8.8.
+
+Truthful state:
+
+- An adapter MUST only emit ``lifecycle_state`` values it can actually
+  observe. A Level-0 (submit-time) adapter emits ``"submitted"`` and
+  nothing else. A Level-1 adapter that genuinely sees pre-submit draft
+  changes may emit the volatile states (``observing`` … ``actionable``).
+  Fabricating higher states corrupts the engine's scoring downstream.
+- ``ComposerAdapterCapabilities.emits`` declares what an adapter can
+  truthfully produce. The daemon validates each event against this
+  capability declaration on ingest.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+LifecycleState = Literal[
+    "observing",
+    "tentative",
+    "stabilizing",
+    "actionable",
+    "submitted",
+    "cleared",
+    "abandoned",
+]
+
+CapabilityLevel = Literal["L0", "L1", "L2", "L3"]
+
+HostKind = Literal[
+    "ai_chat_client",
+    "ide",
+    "editor",
+    "support_console",
+    "writing_tool",
+    "terminal_ai_client",
+    "enterprise_app",
+]
+
+FieldRole = Literal[
+    "chat_composer",
+    "agent_prompt",
+    "email_body",
+    "doc_editor",
+    "support_reply",
+    "task_note",
+]
+
+
+class ComposerAdapterCapabilities(BaseModel):
+    """What an adapter can truthfully emit.
+
+    The daemon uses ``emits`` to validate each ``DraftIntentSnapshot``
+    on ingest. An L0 adapter that declares ``emits=("submitted",)``
+    cannot send a payload with ``lifecycle_state="actionable"``.
+    """
+
+    level: CapabilityLevel
+    emits: tuple[LifecycleState, ...] = Field(
+        description="Lifecycle states this adapter can truthfully produce.",
+    )
+    host_app: str = Field(
+        description="Stable identifier for the host (e.g. 'claude-code', 'cursor').",
+    )
+    host_kind: HostKind
+
+
+class DraftIntentSnapshot(BaseModel):
+    """A single composer-lifecycle observation from an adapter."""
+
+    session_id: str = Field(
+        description="Stable id for the composer session. Used to correlate snapshots and to invalidate predictions on cancel/abandon.",
+    )
+    snapshot_id: str = Field(
+        description="Unique id for this snapshot. Adapters MUST generate a fresh id per emission.",
+    )
+    timestamp: str = Field(description="ISO-8601 timestamp of the observation.")
+    lifecycle_state: LifecycleState
+    text_hash: str = Field(
+        description="sha256 hex digest of the draft text. The raw text is never transmitted in 0.8.7.",
+    )
+    length_chars: int = Field(ge=0)
+    capabilities: ComposerAdapterCapabilities
+
+    workspace_id: str | None = None
+    conversation_id: str | None = None
+    field_role: FieldRole | None = None
+    inferred_intent_label: str | None = None
+    inferred_intent_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class ComposerEvent(BaseModel):
+    """Envelope written into ``SignalEvent.payload`` for ``kind=composer_lifecycle``.
+
+    Wrapping the snapshot in an envelope leaves room for adapter-level
+    fields that should not live on the snapshot itself (e.g. transport
+    metadata, batch markers) without breaking the snapshot contract.
+    """
+
+    snapshot: DraftIntentSnapshot

--- a/src/vaner/signals/composer/contract.py
+++ b/src/vaner/signals/composer/contract.py
@@ -68,6 +68,21 @@ FieldRole = Literal[
 ]
 
 
+# sha256 hex digest pattern. The text_hash field MUST match this so
+# the daemon's error envelope (which echoes invalid input) can never
+# reflect raw draft text mistakenly placed in the text_hash slot.
+_SHA256_HEX_PATTERN = r"^[0-9a-f]{64}$"
+
+# ISO-8601 datetime pattern (date + time + Z or +HH:MM offset). Pinned
+# so adapters can't send free-form strings that downstream telemetry
+# range queries would silently misbehave on.
+_ISO8601_TS_PATTERN = (
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+    r"(?:\.\d+)?"
+    r"(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
 class ComposerAdapterCapabilities(BaseModel):
     """What an adapter can truthfully emit.
 
@@ -78,9 +93,12 @@ class ComposerAdapterCapabilities(BaseModel):
 
     level: CapabilityLevel
     emits: tuple[LifecycleState, ...] = Field(
-        description="Lifecycle states this adapter can truthfully produce.",
+        min_length=1,
+        description="Lifecycle states this adapter can truthfully produce. MUST be non-empty.",
     )
     host_app: str = Field(
+        min_length=1,
+        max_length=128,
         description="Stable identifier for the host (e.g. 'claude-code', 'cursor').",
     )
     host_kind: HostKind
@@ -90,32 +108,29 @@ class DraftIntentSnapshot(BaseModel):
     """A single composer-lifecycle observation from an adapter."""
 
     session_id: str = Field(
+        min_length=1,
+        max_length=256,
         description="Stable id for the composer session. Used to correlate snapshots and to invalidate predictions on cancel/abandon.",
     )
     snapshot_id: str = Field(
+        min_length=1,
+        max_length=128,
         description="Unique id for this snapshot. Adapters MUST generate a fresh id per emission.",
     )
-    timestamp: str = Field(description="ISO-8601 timestamp of the observation.")
+    timestamp: str = Field(
+        pattern=_ISO8601_TS_PATTERN,
+        description="ISO-8601 timestamp of the observation (e.g. '2026-04-25T20:14:45Z').",
+    )
     lifecycle_state: LifecycleState
     text_hash: str = Field(
-        description="sha256 hex digest of the draft text. The raw text is never transmitted in 0.8.7.",
+        pattern=_SHA256_HEX_PATTERN,
+        description="sha256 hex digest of the draft text (lowercase, 64 chars). The raw text is never transmitted in 0.8.7.",
     )
     length_chars: int = Field(ge=0)
     capabilities: ComposerAdapterCapabilities
 
-    workspace_id: str | None = None
-    conversation_id: str | None = None
+    workspace_id: str | None = Field(default=None, max_length=2048)
+    conversation_id: str | None = Field(default=None, max_length=256)
     field_role: FieldRole | None = None
-    inferred_intent_label: str | None = None
+    inferred_intent_label: str | None = Field(default=None, max_length=256)
     inferred_intent_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
-
-
-class ComposerEvent(BaseModel):
-    """Envelope written into ``SignalEvent.payload`` for ``kind=composer_lifecycle``.
-
-    Wrapping the snapshot in an envelope leaves room for adapter-level
-    fields that should not live on the snapshot itself (e.g. transport
-    metadata, batch markers) without breaking the snapshot contract.
-    """
-
-    snapshot: DraftIntentSnapshot

--- a/src/vaner/signals/composer/pump.py
+++ b/src/vaner/signals/composer/pump.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""In-process distribution point for composer-lifecycle snapshots.
+
+WS3 wires :meth:`vaner.engine.Engine.observe` so that ``SignalEvent``s
+of kind ``composer_lifecycle`` are validated into a
+:class:`DraftIntentSnapshot` and published to a ``ComposerSignalPump``.
+Subscribers (e.g. the prediction registry's invalidation path in WS4)
+register a coroutine callback; ``publish()`` fires all subscribers
+concurrently and isolates failures so one bad subscriber cannot block
+the others.
+
+The pump is deliberately minimal — no queue, no buffering, no ordering
+guarantees beyond "earlier publish() calls complete their gather()
+before later ones start, on the same publish-task." The engine owns
+the pump and it lives for the lifetime of the engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+from vaner.signals.composer.contract import DraftIntentSnapshot
+
+logger = logging.getLogger(__name__)
+
+ComposerSubscriber = Callable[[DraftIntentSnapshot], Awaitable[None]]
+
+
+class ComposerSignalPump:
+    def __init__(self) -> None:
+        self._subscribers: list[ComposerSubscriber] = []
+
+    def subscribe(self, callback: ComposerSubscriber) -> None:
+        self._subscribers.append(callback)
+
+    def unsubscribe(self, callback: ComposerSubscriber) -> None:
+        try:
+            self._subscribers.remove(callback)
+        except ValueError:
+            pass
+
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+    async def publish(self, snapshot: DraftIntentSnapshot) -> None:
+        if not self._subscribers:
+            return
+        results = await asyncio.gather(
+            *(self._invoke(cb, snapshot) for cb in tuple(self._subscribers)),
+            return_exceptions=True,
+        )
+        for cb, result in zip(self._subscribers, results, strict=False):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "composer signal subscriber %r failed: %s",
+                    getattr(cb, "__qualname__", cb),
+                    result,
+                )
+
+    async def _invoke(self, callback: ComposerSubscriber, snapshot: DraftIntentSnapshot) -> None:
+        await callback(snapshot)

--- a/src/vaner/signals/composer/pump.py
+++ b/src/vaner/signals/composer/pump.py
@@ -48,11 +48,17 @@ class ComposerSignalPump:
     async def publish(self, snapshot: DraftIntentSnapshot) -> None:
         if not self._subscribers:
             return
+        # 0.8.7 hardening M5: snapshot the subscriber list ONCE before
+        # gather() so the same tuple drives both the invocation set and
+        # the failure-attribution zip below. A subscriber that
+        # un/subscribes during dispatch (or another subscriber doing it
+        # on its behalf) would otherwise mis-pair callbacks with results.
+        subs = tuple(self._subscribers)
         results = await asyncio.gather(
-            *(self._invoke(cb, snapshot) for cb in tuple(self._subscribers)),
+            *(self._invoke(cb, snapshot) for cb in subs),
             return_exceptions=True,
         )
-        for cb, result in zip(self._subscribers, results, strict=False):
+        for cb, result in zip(subs, results, strict=True):
             if isinstance(result, BaseException):
                 logger.warning(
                     "composer signal subscriber %r failed: %s",

--- a/src/vaner/signals/composer/pump.py
+++ b/src/vaner/signals/composer/pump.py
@@ -4,15 +4,25 @@
 WS3 wires :meth:`vaner.engine.Engine.observe` so that ``SignalEvent``s
 of kind ``composer_lifecycle`` are validated into a
 :class:`DraftIntentSnapshot` and published to a ``ComposerSignalPump``.
-Subscribers (e.g. the prediction registry's invalidation path in WS4)
-register a coroutine callback; ``publish()`` fires all subscribers
-concurrently and isolates failures so one bad subscriber cannot block
-the others.
+Subscribers register a coroutine callback; ``publish()`` fires all
+subscribers concurrently and isolates failures so one bad subscriber
+cannot block the others.
 
 The pump is deliberately minimal — no queue, no buffering, no ordering
 guarantees beyond "earlier publish() calls complete their gather()
 before later ones start, on the same publish-task." The engine owns
 the pump and it lives for the lifetime of the engine.
+
+NOTE (v0.8.8 wiring gap): in v0.8.7 the pump publishes snapshots but
+NO production code subscribes to it. The intended v0.8.8 subscriber is
+the prediction registry's update path: when a composer signal arrives,
+either create a ``composer_intent``-sourced spec (if none for that
+session_id exists) or update the existing one's
+``compose_signal_strength`` based on the snapshot's lifecycle_state
+and confidence. Without that subscriber, ``composer_intent`` specs
+never appear in the registry — the entire engine plumbing in WS4/WS5/WS8
+(source literal, frontier multiplier, MCP card field) is data-backbone
+only until v0.8.8.
 """
 
 from __future__ import annotations

--- a/src/vaner/signals/composer/pump.py
+++ b/src/vaner/signals/composer/pump.py
@@ -49,6 +49,7 @@ class ComposerSignalPump:
         try:
             self._subscribers.remove(callback)
         except ValueError:
+            # Idempotent unsubscribe: callback already removed.
             pass
 
     @property

--- a/src/vaner/signals/composer/schema.py
+++ b/src/vaner/signals/composer/schema.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the ComposerAdapter JSON Schema artifact.
+
+Pydantic models in :mod:`vaner.signals.composer.contract` are the source
+of truth. The committed JSON Schema at
+``docs/specs/composer-adapter.schema.json`` is regenerated from them and
+serves as the cross-language contract for non-Python adapter authors.
+
+Run via the ``vaner-composer-schema`` console script (see pyproject) or
+``python -m vaner.signals.composer.schema``. CI guards drift by
+re-running the script and ``git diff --exit-code`` on the artifact.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from vaner.signals.composer.contract import DraftIntentSnapshot
+
+ARTIFACT_RELATIVE = Path("docs/specs/composer-adapter.schema.json")
+
+
+def _repo_root() -> Path:
+    """Walk up from this file to the repo root.
+
+    The artifact path is anchored at the repo root so the script works
+    from any cwd (CI, devs running from a worktree, etc.).
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("could not locate repo root from " + str(here))
+
+
+def render_schema() -> str:
+    schema = DraftIntentSnapshot.model_json_schema()
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    out_path = _repo_root() / ARTIFACT_RELATIVE
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(render_schema(), encoding="utf-8")
+    if "--quiet" not in argv:
+        sys.stdout.write(f"wrote {out_path.relative_to(_repo_root())}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vaner/telemetry/metrics.py
+++ b/src/vaner/telemetry/metrics.py
@@ -145,6 +145,15 @@ class MetricsStore:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute("PRAGMA journal_mode=WAL")
+            # 0.8.7 hardening (H3): set a 5s busy_timeout so concurrent
+            # ``initialize()`` calls (one per composer-event POST in the
+            # daemon's record_composer_lifecycle_event path) wait for the
+            # writer lock instead of failing with ``database is locked``.
+            # WAL allows concurrent readers + one writer; without
+            # busy_timeout, the second concurrent ALTER/CREATE racing on
+            # the writer slot errors immediately. 5s comfortably exceeds
+            # the cycle DDL latency on slow disks.
+            await db.execute("PRAGMA busy_timeout = 5000")
             await db.execute(
                 """
                 CREATE TABLE IF NOT EXISTS request_metrics (

--- a/src/vaner/telemetry/metrics.py
+++ b/src/vaner/telemetry/metrics.py
@@ -143,16 +143,16 @@ class MetricsStore:
 
     async def initialize(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        async with aiosqlite.connect(self.db_path) as db:
+        # 0.8.7 hardening (H3): aiosqlite's ``timeout`` kwarg sets the
+        # SQLite busy handler at CONNECTION TIME (before any PRAGMA can
+        # run), so the very first writer call already waits for the
+        # writer-slot lock instead of erroring with ``database is locked``.
+        # The PRAGMA-based busy_timeout below is redundant on most
+        # Pythons but keeps the fallback explicit. CI Python 3.11 surfaced
+        # the difference: PRAGMA-only ran AFTER the WAL-init write and
+        # raced; constructor-level timeout is the load-bearing fix.
+        async with aiosqlite.connect(self.db_path, timeout=5.0) as db:
             await db.execute("PRAGMA journal_mode=WAL")
-            # 0.8.7 hardening (H3): set a 5s busy_timeout so concurrent
-            # ``initialize()`` calls (one per composer-event POST in the
-            # daemon's record_composer_lifecycle_event path) wait for the
-            # writer lock instead of failing with ``database is locked``.
-            # WAL allows concurrent readers + one writer; without
-            # busy_timeout, the second concurrent ALTER/CREATE racing on
-            # the writer slot errors immediately. 5s comfortably exceeds
-            # the cycle DDL latency on slow disks.
             await db.execute("PRAGMA busy_timeout = 5000")
             await db.execute(
                 """

--- a/src/vaner/telemetry/metrics.py
+++ b/src/vaner/telemetry/metrics.py
@@ -40,6 +40,28 @@ _LEAD_TIME_BUCKETS: tuple[tuple[str, float], ...] = (
     ("gte_900s", float("inf")),
 )
 
+# 0.8.7 hardening (H2): coarse buckets for composer-event length_chars in
+# telemetry rows. Storing exact char counts alongside even an irreversible
+# hash gives a post-compromise adversary the ranged input domain for a
+# brute-force sha256 inversion. The buckets keep the histogram useful for
+# debugging without pinning short prompts to enumerable bands.
+_COMPOSER_LENGTH_BUCKETS: tuple[tuple[str, int], ...] = (
+    ("0_9", 10),
+    ("10_49", 50),
+    ("50_249", 250),
+    ("250_999", 1_000),
+    ("1000_4999", 5_000),
+    ("5000_plus", -1),
+)
+
+
+def _length_bucket(length_chars: int) -> str:
+    n = max(0, int(length_chars))
+    for label, ceiling in _COMPOSER_LENGTH_BUCKETS:
+        if ceiling < 0 or n < ceiling:
+            return label
+    return _COMPOSER_LENGTH_BUCKETS[-1][0]
+
 
 @dataclass
 class RequestMetrics:
@@ -104,8 +126,20 @@ class MetricsStore:
         cursor = await db.execute(f"PRAGMA table_info({table})")
         rows = await cursor.fetchall()
         names = {str(row[1]) for row in rows}
-        if column not in names:
+        if column in names:
+            return
+        # 0.8.7 hardening (H3): two concurrent first-time initialize()
+        # calls (e.g. two ingest requests on a fresh DB) can both pass
+        # the PRAGMA check, both attempt ALTER, and the second errors
+        # with "duplicate column name". The post-state is correct (the
+        # column exists once) — swallow the race and trust the PRAGMA
+        # snapshot on the next call. Any other OperationalError still
+        # propagates so genuine schema problems surface loudly.
+        try:
             await db.execute(f"ALTER TABLE {table} ADD COLUMN {column} {column_def}")
+        except aiosqlite.OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                raise
 
     async def initialize(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -733,22 +767,31 @@ class MetricsStore:
         """Record a composer-lifecycle observation (0.8.7 WS6).
 
         Composer-lifecycle rows write to the *separate* counter prefix
-        ``composer_{lifecycle_state}_total`` so they never corrupt the
-        existing ``draft_{served|useful|wrong|unused}_total`` counters
-        that 0.8.6 dashboards depend on. The ``event_type`` column on
-        ``draft_events`` distinguishes these rows from legacy
+        ``composer_lifecycle_{lifecycle_state}_total`` so they never
+        corrupt the existing ``draft_{served|useful|wrong|unused}_total``
+        counters that 0.8.6 dashboards depend on. The ``event_type``
+        column on ``draft_events`` distinguishes these rows from legacy
         ``record_draft_event`` writes.
+
+        0.8.7 hardening (H2 — short-prompt brute-force): the telemetry
+        row stores ``length_bucket`` (coarse band) instead of the exact
+        ``length_chars``, and DROPS the redundant ``text_hash`` copy that
+        existed alongside the unbucketed length. The signal_events row
+        retains the full snapshot for audit (single source of truth).
+        Reducing the cross-store correlation surface defeats the trivial
+        case where a post-compromise adversary brute-forces sha256 over
+        all candidate strings of an exact known length.
         """
+        # Reject the audit-noise pair (text_hash, length_chars) entirely
+        # from the telemetry surface. snapshot_id + composer_event_id
+        # already pin the row to its source signal_events record without
+        # leaking the privacy-sensitive cross-store correlation.
+        del text_hash
         payload = dict(metadata or {})
-        # Composer events carry no draft-quality numerics (no answer
-        # reuse, no evidence overlap — those are draft-completion
-        # signals). Preserve session/snapshot/hash metadata so the row
-        # is auditable even though the raw text is never stored.
-        payload.setdefault("session_id", session_id)
-        payload.setdefault("snapshot_id", snapshot_id)
-        payload.setdefault("text_hash", text_hash)
-        payload.setdefault("length_chars", length_chars)
-        payload.setdefault("composer_event_id", composer_event_id)
+        payload["session_id"] = session_id
+        payload["snapshot_id"] = snapshot_id
+        payload["composer_event_id"] = composer_event_id
+        payload["length_bucket"] = _length_bucket(length_chars)
         now = time.time()
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(

--- a/src/vaner/telemetry/metrics.py
+++ b/src/vaner/telemetry/metrics.py
@@ -775,7 +775,7 @@ class MetricsStore:
                     value = value + excluded.value,
                     updated_at = excluded.updated_at
                 """,
-                (f"composer_{lifecycle_state}_total", 1.0, now),
+                (f"composer_lifecycle_{lifecycle_state}_total", 1.0, now),
             )
             await db.commit()
 

--- a/src/vaner/telemetry/metrics.py
+++ b/src/vaner/telemetry/metrics.py
@@ -19,6 +19,7 @@ Derived metrics:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import math
 import time
@@ -120,6 +121,17 @@ class MetricsStore:
 
     def __init__(self, db_path: Path) -> None:
         self.db_path = db_path
+        # 0.8.7 hardening: serialize concurrent ``initialize()`` calls
+        # within the same process. SQLite WAL setup takes an exclusive
+        # lock on the WAL file's first write — two parallel async tasks
+        # creating fresh connections will race that step, and the
+        # connection-time ``timeout=`` only kicks in AFTER the lock
+        # attempt fails. The asyncio lock guarantees only one initialize
+        # writes the schema; the second waits and finds it complete.
+        # Production runs ``initialize()`` once at daemon-lifespan start;
+        # this lock is defense-in-depth for tests + future call sites.
+        self._init_lock = asyncio.Lock()
+        self._initialized = False
 
     @staticmethod
     async def _ensure_column(db: aiosqlite.Connection, table: str, column: str, column_def: str) -> None:
@@ -142,140 +154,143 @@ class MetricsStore:
                 raise
 
     async def initialize(self) -> None:
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        # 0.8.7 hardening (H3): aiosqlite's ``timeout`` kwarg sets the
-        # SQLite busy handler at CONNECTION TIME (before any PRAGMA can
-        # run), so the very first writer call already waits for the
-        # writer-slot lock instead of erroring with ``database is locked``.
-        # The PRAGMA-based busy_timeout below is redundant on most
-        # Pythons but keeps the fallback explicit. CI Python 3.11 surfaced
-        # the difference: PRAGMA-only ran AFTER the WAL-init write and
-        # raced; constructor-level timeout is the load-bearing fix.
-        async with aiosqlite.connect(self.db_path, timeout=5.0) as db:
-            await db.execute("PRAGMA journal_mode=WAL")
-            await db.execute("PRAGMA busy_timeout = 5000")
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS request_metrics (
-                    request_id TEXT PRIMARY KEY,
-                    timestamp REAL NOT NULL,
-                    cache_tier TEXT NOT NULL,
-                    partial_similarity REAL NOT NULL DEFAULT 0.0,
-                    context_tokens INTEGER NOT NULL DEFAULT 0,
-                    prompt_tokens INTEGER NOT NULL DEFAULT 0,
-                    is_stream INTEGER NOT NULL DEFAULT 0,
-                    context_retrieval_ms REAL NOT NULL DEFAULT 0.0,
-                    llm_first_token_ms REAL NOT NULL DEFAULT 0.0,
-                    llm_total_ms REAL NOT NULL DEFAULT 0.0,
-                    total_e2e_ms REAL NOT NULL DEFAULT 0.0,
-                    metadata_json TEXT NOT NULL DEFAULT '{}'
+        # 0.8.7 hardening: in-process serialization. Two concurrent
+        # initialize() calls in the same daemon raced on SQLite WAL
+        # setup before this lock was added. The ``_initialized``
+        # short-circuit means the second caller does no SQL work; the
+        # first holds the lock through the full DDL pass. timeout=5.0
+        # + PRAGMA busy_timeout below remain as belt-and-braces for
+        # cross-process or cross-MetricsStore-instance contention.
+        async with self._init_lock:
+            if self._initialized:
+                return
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            async with aiosqlite.connect(self.db_path, timeout=5.0) as db:
+                await db.execute("PRAGMA journal_mode=WAL")
+                await db.execute("PRAGMA busy_timeout = 5000")
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS request_metrics (
+                        request_id TEXT PRIMARY KEY,
+                        timestamp REAL NOT NULL,
+                        cache_tier TEXT NOT NULL,
+                        partial_similarity REAL NOT NULL DEFAULT 0.0,
+                        context_tokens INTEGER NOT NULL DEFAULT 0,
+                        prompt_tokens INTEGER NOT NULL DEFAULT 0,
+                        is_stream INTEGER NOT NULL DEFAULT 0,
+                        context_retrieval_ms REAL NOT NULL DEFAULT 0.0,
+                        llm_first_token_ms REAL NOT NULL DEFAULT 0.0,
+                        llm_total_ms REAL NOT NULL DEFAULT 0.0,
+                        total_e2e_ms REAL NOT NULL DEFAULT 0.0,
+                        metadata_json TEXT NOT NULL DEFAULT '{}'
+                    )
+                    """
                 )
-                """
-            )
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS shadow_comparisons (
-                    shadow_pair_id TEXT PRIMARY KEY,
-                    request_id TEXT NOT NULL,
-                    timestamp REAL NOT NULL,
-                    with_context_total_ms REAL NOT NULL,
-                    without_context_total_ms REAL NOT NULL,
-                    with_context_tokens INTEGER NOT NULL,
-                    without_context_tokens INTEGER NOT NULL,
-                    latency_delta_ms REAL NOT NULL,
-                    token_delta INTEGER NOT NULL,
-                    metadata_json TEXT NOT NULL DEFAULT '{}'
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS shadow_comparisons (
+                        shadow_pair_id TEXT PRIMARY KEY,
+                        request_id TEXT NOT NULL,
+                        timestamp REAL NOT NULL,
+                        with_context_total_ms REAL NOT NULL,
+                        without_context_total_ms REAL NOT NULL,
+                        with_context_tokens INTEGER NOT NULL,
+                        without_context_tokens INTEGER NOT NULL,
+                        latency_delta_ms REAL NOT NULL,
+                        token_delta INTEGER NOT NULL,
+                        metadata_json TEXT NOT NULL DEFAULT '{}'
+                    )
+                    """
                 )
-                """
-            )
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS integration_usage (
-                    mode TEXT PRIMARY KEY,
-                    count INTEGER NOT NULL DEFAULT 0,
-                    updated_at REAL NOT NULL
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS integration_usage (
+                        mode TEXT PRIMARY KEY,
+                        count INTEGER NOT NULL DEFAULT 0,
+                        updated_at REAL NOT NULL
+                    )
+                    """
                 )
-                """
-            )
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS mcp_tool_calls (
-                    id TEXT PRIMARY KEY,
-                    tool_name TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    latency_ms REAL NOT NULL,
-                    scenario_id TEXT,
-                    skill TEXT,
-                    timestamp REAL NOT NULL
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS mcp_tool_calls (
+                        id TEXT PRIMARY KEY,
+                        tool_name TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        latency_ms REAL NOT NULL,
+                        scenario_id TEXT,
+                        skill TEXT,
+                        timestamp REAL NOT NULL
+                    )
+                    """
                 )
-                """
-            )
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS scenario_outcomes (
-                    id TEXT PRIMARY KEY,
-                    scenario_id TEXT NOT NULL,
-                    result TEXT NOT NULL,
-                    note TEXT NOT NULL DEFAULT '',
-                    skill TEXT,
-                    timestamp REAL NOT NULL
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS scenario_outcomes (
+                        id TEXT PRIMARY KEY,
+                        scenario_id TEXT NOT NULL,
+                        result TEXT NOT NULL,
+                        note TEXT NOT NULL DEFAULT '',
+                        skill TEXT,
+                        timestamp REAL NOT NULL
+                    )
+                    """
                 )
-                """
-            )
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS memory_quality_counters (
-                    name TEXT PRIMARY KEY,
-                    value REAL NOT NULL DEFAULT 0,
-                    updated_at REAL NOT NULL
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS memory_quality_counters (
+                        name TEXT PRIMARY KEY,
+                        value REAL NOT NULL DEFAULT 0,
+                        updated_at REAL NOT NULL
+                    )
+                    """
                 )
-                """
-            )
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS prediction_events (
-                    id TEXT PRIMARY KEY,
-                    timestamp REAL NOT NULL,
-                    top1_label TEXT NOT NULL,
-                    top1_confidence REAL NOT NULL,
-                    probs_json TEXT NOT NULL
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS prediction_events (
+                        id TEXT PRIMARY KEY,
+                        timestamp REAL NOT NULL,
+                        top1_label TEXT NOT NULL,
+                        top1_confidence REAL NOT NULL,
+                        probs_json TEXT NOT NULL
+                    )
+                    """
                 )
-                """
-            )
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS draft_events (
-                    id TEXT PRIMARY KEY,
-                    timestamp REAL NOT NULL,
-                    status TEXT NOT NULL,
-                    predicted_prompt_similarity REAL NOT NULL DEFAULT 0.0,
-                    evidence_overlap REAL NOT NULL DEFAULT 0.0,
-                    answer_reuse_ratio REAL NOT NULL DEFAULT 0.0,
-                    directional_correct INTEGER NOT NULL DEFAULT 0,
-                    metadata_json TEXT NOT NULL DEFAULT '{}',
-                    event_type TEXT NOT NULL DEFAULT 'legacy_draft'
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS draft_events (
+                        id TEXT PRIMARY KEY,
+                        timestamp REAL NOT NULL,
+                        status TEXT NOT NULL,
+                        predicted_prompt_similarity REAL NOT NULL DEFAULT 0.0,
+                        evidence_overlap REAL NOT NULL DEFAULT 0.0,
+                        answer_reuse_ratio REAL NOT NULL DEFAULT 0.0,
+                        directional_correct INTEGER NOT NULL DEFAULT 0,
+                        metadata_json TEXT NOT NULL DEFAULT '{}',
+                        event_type TEXT NOT NULL DEFAULT 'legacy_draft'
+                    )
+                    """
                 )
-                """
-            )
-            # 0.8.7 WS6: idempotent ALTER for pre-0.8.7 DBs that already
-            # had ``draft_events`` without an ``event_type`` column. Existing
-            # rows default to 'legacy_draft' so the post-migration view of
-            # the existing 0.8.6 dashboard counters is byte-identical.
-            await self._ensure_column(db, "draft_events", "event_type", "TEXT NOT NULL DEFAULT 'legacy_draft'")
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS counterfactual_misses (
-                    id TEXT PRIMARY KEY,
-                    timestamp REAL NOT NULL,
-                    prompt TEXT NOT NULL,
-                    miss_type TEXT NOT NULL,
-                    helpful_context_json TEXT NOT NULL DEFAULT '[]',
-                    wasted_branches_json TEXT NOT NULL DEFAULT '[]',
-                    metadata_json TEXT NOT NULL DEFAULT '{}'
+                # 0.8.7 WS6: idempotent ALTER for pre-0.8.7 DBs that already
+                # had ``draft_events`` without an ``event_type`` column. Existing
+                # rows default to 'legacy_draft' so the post-migration view of
+                # the existing 0.8.6 dashboard counters is byte-identical.
+                await self._ensure_column(db, "draft_events", "event_type", "TEXT NOT NULL DEFAULT 'legacy_draft'")
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS counterfactual_misses (
+                        id TEXT PRIMARY KEY,
+                        timestamp REAL NOT NULL,
+                        prompt TEXT NOT NULL,
+                        miss_type TEXT NOT NULL,
+                        helpful_context_json TEXT NOT NULL DEFAULT '[]',
+                        wasted_branches_json TEXT NOT NULL DEFAULT '[]',
+                        metadata_json TEXT NOT NULL DEFAULT '{}'
+                    )
+                    """
                 )
-                """
-            )
-            await db.commit()
+                await db.commit()
+            self._initialized = True
 
     async def record(self, m: RequestMetrics) -> None:
         async with aiosqlite.connect(self.db_path) as db:

--- a/src/vaner/telemetry/metrics.py
+++ b/src/vaner/telemetry/metrics.py
@@ -209,10 +209,16 @@ class MetricsStore:
                     evidence_overlap REAL NOT NULL DEFAULT 0.0,
                     answer_reuse_ratio REAL NOT NULL DEFAULT 0.0,
                     directional_correct INTEGER NOT NULL DEFAULT 0,
-                    metadata_json TEXT NOT NULL DEFAULT '{}'
+                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    event_type TEXT NOT NULL DEFAULT 'legacy_draft'
                 )
                 """
             )
+            # 0.8.7 WS6: idempotent ALTER for pre-0.8.7 DBs that already
+            # had ``draft_events`` without an ``event_type`` column. Existing
+            # rows default to 'legacy_draft' so the post-migration view of
+            # the existing 0.8.6 dashboard counters is byte-identical.
+            await self._ensure_column(db, "draft_events", "event_type", "TEXT NOT NULL DEFAULT 'legacy_draft'")
             await db.execute(
                 """
                 CREATE TABLE IF NOT EXISTS counterfactual_misses (
@@ -643,9 +649,9 @@ class MetricsStore:
                 """
                 INSERT INTO draft_events (
                     id, timestamp, status, predicted_prompt_similarity, evidence_overlap,
-                    answer_reuse_ratio, directional_correct, metadata_json
+                    answer_reuse_ratio, directional_correct, metadata_json, event_type
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     str(uuid.uuid4()),
@@ -656,6 +662,7 @@ class MetricsStore:
                     max(0.0, min(1.0, float(answer_reuse_ratio))),
                     int(bool(directional_correct)),
                     json.dumps(payload, sort_keys=True),
+                    "legacy_draft",
                 ),
             )
             await db.execute(
@@ -710,6 +717,66 @@ class MetricsStore:
                         """,
                         ("draft_directionally_correct_total", 1.0, now),
                     )
+            await db.commit()
+
+    async def record_composer_lifecycle_event(
+        self,
+        *,
+        session_id: str,
+        snapshot_id: str,
+        lifecycle_state: str,
+        text_hash: str,
+        length_chars: int,
+        composer_event_id: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a composer-lifecycle observation (0.8.7 WS6).
+
+        Composer-lifecycle rows write to the *separate* counter prefix
+        ``composer_{lifecycle_state}_total`` so they never corrupt the
+        existing ``draft_{served|useful|wrong|unused}_total`` counters
+        that 0.8.6 dashboards depend on. The ``event_type`` column on
+        ``draft_events`` distinguishes these rows from legacy
+        ``record_draft_event`` writes.
+        """
+        payload = dict(metadata or {})
+        # Composer events carry no draft-quality numerics (no answer
+        # reuse, no evidence overlap — those are draft-completion
+        # signals). Preserve session/snapshot/hash metadata so the row
+        # is auditable even though the raw text is never stored.
+        payload.setdefault("session_id", session_id)
+        payload.setdefault("snapshot_id", snapshot_id)
+        payload.setdefault("text_hash", text_hash)
+        payload.setdefault("length_chars", length_chars)
+        payload.setdefault("composer_event_id", composer_event_id)
+        now = time.time()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO draft_events (
+                    id, timestamp, status, predicted_prompt_similarity, evidence_overlap,
+                    answer_reuse_ratio, directional_correct, metadata_json, event_type
+                )
+                VALUES (?, ?, ?, 0.0, 0.0, 0.0, 0, ?, ?)
+                """,
+                (
+                    str(uuid.uuid4()),
+                    now,
+                    lifecycle_state,
+                    json.dumps(payload, sort_keys=True),
+                    "composer_lifecycle",
+                ),
+            )
+            await db.execute(
+                """
+                INSERT INTO memory_quality_counters (name, value, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                    value = value + excluded.value,
+                    updated_at = excluded.updated_at
+                """,
+                (f"composer_{lifecycle_state}_total", 1.0, now),
+            )
             await db.commit()
 
     async def record_counterfactual_miss(

--- a/tests/conformance-fixtures/adopt_response_composer.json
+++ b/tests/conformance-fixtures/adopt_response_composer.json
@@ -1,0 +1,29 @@
+{
+  "intent": "Rewrite the scene with slower tension",
+  "confidence": 0.78,
+  "summary": "Composer-derived prediction from the writer's draft.",
+  "evidence": [
+    {
+      "id": "scn_scene_rewrite",
+      "source": "composer_intent",
+      "kind": "record",
+      "locator": {
+        "prediction_id": "pred-composer-0001",
+        "scenario_id": "scn_scene_rewrite"
+      },
+      "reason": "scenario explored under prediction 'Rewrite the scene with slower tension'"
+    }
+  ],
+  "provenance": {
+    "mode": "predictive_hit",
+    "cache": "warm",
+    "freshness": "fresh"
+  },
+  "resolution_id": "adopt-pred-composer-0001",
+  "prepared_briefing": "Continuity: prior chapter ended on a high beat. Recommended pacing arc: ...",
+  "predicted_response": null,
+  "briefing_token_used": 412,
+  "briefing_token_budget": 2048,
+  "adopted_from_prediction_id": "pred-composer-0001",
+  "composer_event_id": "evt-01HX9Z3K7M"
+}

--- a/tests/conformance-fixtures/predictions_active_composer_sample.json
+++ b/tests/conformance-fixtures/predictions_active_composer_sample.json
@@ -1,0 +1,48 @@
+{
+  "predictions": [
+    {
+      "id": "pred-composer-0001",
+      "spec": {
+        "label": "Rewrite the scene with slower tension",
+        "description": "Composer-derived prediction from the writer's draft.",
+        "source": "composer_intent",
+        "anchor": "claude-code-session-abc123",
+        "confidence": 0.78,
+        "hypothesis_type": "likely_next",
+        "specificity": "concrete",
+        "created_at": 1000000000.0
+      },
+      "run": {
+        "weight": 0.85,
+        "token_budget": 2048,
+        "tokens_used": 1200,
+        "model_calls": 3,
+        "scenarios_spawned": 2,
+        "scenarios_complete": 2,
+        "readiness": "ready",
+        "updated_at": 1000000180.0
+      },
+      "artifacts": {
+        "scenario_ids": ["scn_scene_rewrite"],
+        "evidence_score": 0.74,
+        "has_draft": true,
+        "has_briefing": true,
+        "thinking_trace_count": 2
+      },
+      "readiness_label": "Ready",
+      "eta_bucket": "ready_now",
+      "eta_bucket_label": "Ready now",
+      "adoptable": true,
+      "rank": 1,
+      "ui_summary": "Composer-aligned rewrite continuation ready",
+      "suppression_reason": null,
+      "source_label": "From your current draft",
+      "composer_engagement": {
+        "composer_event_id": "evt-01HX9Z3K7M",
+        "lifecycle_state": "submitted",
+        "inferred_intent_label": "rewrite",
+        "inferred_intent_confidence": 0.85
+      }
+    }
+  ]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,34 @@ def temp_repo(tmp_path: Path) -> Path:
     repo.mkdir()
     (repo / "sample.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
     return repo
+
+
+@pytest.fixture(autouse=True)
+def _isolate_deep_run_routing_state():
+    """Reset the global Deep-Run routing state between every test.
+
+    ``set_active_session_for_routing`` is a process-wide singleton used
+    by ``vaner.router.backends`` to enforce per-session cost / locality
+    gates on remote LLM calls. Several test files set it via their own
+    autouse fixtures, but a leak from one test file into another (under
+    pytest-randomly's order-shuffling) was occasionally tripping
+    ``test_router/test_backends.py`` with a stale ``cost_cap_usd=0.0``
+    session blocking the call. Anchoring the reset at conftest level
+    eliminates the cross-file leak class.
+    """
+    try:
+        from vaner.intent.deep_run_gates import (
+            reset_cost_gate,
+            set_active_session_for_routing,
+        )
+    except ImportError:
+        # deep_run_gates may not import in minimal environments.
+        yield
+        return
+    set_active_session_for_routing(None)
+    reset_cost_gate(None)
+    try:
+        yield
+    finally:
+        set_active_session_for_routing(None)
+        reset_cost_gate(None)

--- a/tests/signals/composer/test_contract.py
+++ b/tests/signals/composer/test_contract.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ComposerAdapter contract — 0.8.7 WS2."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from vaner.signals.composer import (
+    ComposerAdapterCapabilities,
+    ComposerEvent,
+    DraftIntentSnapshot,
+)
+from vaner.signals.composer.schema import ARTIFACT_RELATIVE, render_schema
+
+
+def _l0_capabilities() -> ComposerAdapterCapabilities:
+    return ComposerAdapterCapabilities(
+        level="L0",
+        emits=("submitted",),
+        host_app="claude-code",
+        host_kind="ai_chat_client",
+    )
+
+
+def _valid_l0_snapshot() -> DraftIntentSnapshot:
+    return DraftIntentSnapshot(
+        session_id="session-abc",
+        snapshot_id="snap-001",
+        timestamp="2026-04-25T20:14:45Z",
+        lifecycle_state="submitted",
+        text_hash="9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        length_chars=42,
+        capabilities=_l0_capabilities(),
+        workspace_id="/home/me/repos/example",
+        field_role="agent_prompt",
+    )
+
+
+class TestSnapshotRoundTrip:
+    def test_minimal_l0_snapshot_round_trips(self) -> None:
+        snap = _valid_l0_snapshot()
+        encoded = snap.model_dump_json()
+        decoded = DraftIntentSnapshot.model_validate_json(encoded)
+        assert decoded == snap
+
+    def test_l1_snapshot_with_all_lifecycle_states(self) -> None:
+        l1_caps = ComposerAdapterCapabilities(
+            level="L1",
+            emits=(
+                "observing",
+                "tentative",
+                "stabilizing",
+                "actionable",
+                "submitted",
+                "cleared",
+                "abandoned",
+            ),
+            host_app="future-l1-host",
+            host_kind="ide",
+        )
+        for state in l1_caps.emits:
+            snap = DraftIntentSnapshot(
+                session_id="s1",
+                snapshot_id=f"snap-{state}",
+                timestamp="2026-04-25T20:14:45Z",
+                lifecycle_state=state,
+                text_hash="0" * 64,
+                length_chars=0,
+                capabilities=l1_caps,
+            )
+            assert snap.lifecycle_state == state
+
+    def test_envelope_wraps_snapshot(self) -> None:
+        event = ComposerEvent(snapshot=_valid_l0_snapshot())
+        encoded = event.model_dump_json()
+        decoded = ComposerEvent.model_validate_json(encoded)
+        assert decoded.snapshot == event.snapshot
+
+
+class TestValidation:
+    def test_negative_length_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            DraftIntentSnapshot(
+                session_id="s",
+                snapshot_id="x",
+                timestamp="t",
+                lifecycle_state="submitted",
+                text_hash="h",
+                length_chars=-1,
+                capabilities=_l0_capabilities(),
+            )
+
+    def test_unknown_lifecycle_state_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            DraftIntentSnapshot(
+                session_id="s",
+                snapshot_id="x",
+                timestamp="t",
+                lifecycle_state="not-a-state",  # type: ignore[arg-type]
+                text_hash="h",
+                length_chars=0,
+                capabilities=_l0_capabilities(),
+            )
+
+    def test_confidence_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            DraftIntentSnapshot(
+                session_id="s",
+                snapshot_id="x",
+                timestamp="t",
+                lifecycle_state="submitted",
+                text_hash="h",
+                length_chars=0,
+                capabilities=_l0_capabilities(),
+                inferred_intent_confidence=1.5,
+            )
+
+    def test_unknown_capability_level_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ComposerAdapterCapabilities(
+                level="L9",  # type: ignore[arg-type]
+                emits=("submitted",),
+                host_app="x",
+                host_kind="ai_chat_client",
+            )
+
+    def test_unknown_host_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ComposerAdapterCapabilities(
+                level="L0",
+                emits=("submitted",),
+                host_app="x",
+                host_kind="phone",  # type: ignore[arg-type]
+            )
+
+
+class TestPrivacyContract:
+    """The text_hash field is the only draft-derived data in 0.8.7.
+
+    Adapters must not be allowed to smuggle raw text through other
+    fields by accident — the contract has no field for it. These
+    tests pin the privacy invariant in place.
+    """
+
+    def test_no_field_named_text_or_preview(self) -> None:
+        fields = set(DraftIntentSnapshot.model_fields)
+        for forbidden in ("text", "draft_text", "raw_text", "preview", "text_preview"):
+            assert forbidden not in fields, (
+                f"DraftIntentSnapshot must not expose a {forbidden!r} field — raw draft text never crosses the adapter boundary in 0.8.7."
+            )
+
+    def test_no_field_named_local_text_ref(self) -> None:
+        # local_text_ref is in the longer product spec but deferred until
+        # a redaction module exists. v0.8.7 must not ship it.
+        assert "local_text_ref" not in DraftIntentSnapshot.model_fields
+
+
+class TestSchemaArtifact:
+    """The committed JSON Schema artifact must match what pydantic produces.
+
+    CI runs the regeneration script and `git diff --exit-code` to enforce
+    no drift. This test catches drift locally before committing.
+    """
+
+    def test_committed_artifact_matches_pydantic_output(self) -> None:
+        repo_root = _find_repo_root()
+        committed = (repo_root / ARTIFACT_RELATIVE).read_text(encoding="utf-8")
+        regenerated = render_schema()
+        assert committed == regenerated, "JSON Schema artifact is stale. Re-run `vaner-composer-schema` and commit the result."
+
+    def test_artifact_is_valid_json(self) -> None:
+        repo_root = _find_repo_root()
+        text = (repo_root / ARTIFACT_RELATIVE).read_text(encoding="utf-8")
+        # Will raise if not valid JSON.
+        json.loads(text)
+
+    def test_console_script_writes_deterministically(self, tmp_path: Path) -> None:
+        # Two consecutive runs produce byte-identical output.
+        first = render_schema()
+        second = render_schema()
+        assert first == second
+
+
+def _find_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("repo root not found")

--- a/tests/signals/composer/test_contract.py
+++ b/tests/signals/composer/test_contract.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 
 from vaner.signals.composer import (
     ComposerAdapterCapabilities,
-    ComposerEvent,
     DraftIntentSnapshot,
 )
 from vaner.signals.composer.schema import ARTIFACT_RELATIVE, render_schema
@@ -74,50 +73,43 @@ class TestSnapshotRoundTrip:
             )
             assert snap.lifecycle_state == state
 
-    def test_envelope_wraps_snapshot(self) -> None:
-        event = ComposerEvent(snapshot=_valid_l0_snapshot())
-        encoded = event.model_dump_json()
-        decoded = ComposerEvent.model_validate_json(encoded)
-        assert decoded.snapshot == event.snapshot
+
+_VALID_HASH = "0" * 64
+_VALID_TS = "2026-04-25T20:14:45Z"
+
+
+def _snap_kwargs(**overrides: object) -> dict[str, object]:
+    """Return valid snapshot kwargs with overrides applied.
+
+    Lets each test perturb exactly one field so the ValidationError is
+    attributable to the field under test, not to leftover invalid
+    placeholders from the test fixture.
+    """
+    base: dict[str, object] = dict(
+        session_id="s",
+        snapshot_id="x",
+        timestamp=_VALID_TS,
+        lifecycle_state="submitted",
+        text_hash=_VALID_HASH,
+        length_chars=0,
+        capabilities=_l0_capabilities(),
+    )
+    base.update(overrides)
+    return base
 
 
 class TestValidation:
     def test_negative_length_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            DraftIntentSnapshot(
-                session_id="s",
-                snapshot_id="x",
-                timestamp="t",
-                lifecycle_state="submitted",
-                text_hash="h",
-                length_chars=-1,
-                capabilities=_l0_capabilities(),
-            )
+            DraftIntentSnapshot(**_snap_kwargs(length_chars=-1))
 
     def test_unknown_lifecycle_state_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            DraftIntentSnapshot(
-                session_id="s",
-                snapshot_id="x",
-                timestamp="t",
-                lifecycle_state="not-a-state",  # type: ignore[arg-type]
-                text_hash="h",
-                length_chars=0,
-                capabilities=_l0_capabilities(),
-            )
+            DraftIntentSnapshot(**_snap_kwargs(lifecycle_state="not-a-state"))  # type: ignore[arg-type]
 
     def test_confidence_out_of_range_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            DraftIntentSnapshot(
-                session_id="s",
-                snapshot_id="x",
-                timestamp="t",
-                lifecycle_state="submitted",
-                text_hash="h",
-                length_chars=0,
-                capabilities=_l0_capabilities(),
-                inferred_intent_confidence=1.5,
-            )
+            DraftIntentSnapshot(**_snap_kwargs(inferred_intent_confidence=1.5))
 
     def test_unknown_capability_level_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -135,6 +127,53 @@ class TestValidation:
                 emits=("submitted",),
                 host_app="x",
                 host_kind="phone",  # type: ignore[arg-type]
+            )
+
+    # --- 0.8.7 hardening ---
+
+    def test_text_hash_must_be_64_hex_chars(self) -> None:
+        # Too short, wrong charset, uppercase: all rejected so the
+        # daemon's error envelope can never reflect raw draft text
+        # mistakenly placed in this slot.
+        for bad in ("abc", "x" * 64, "0" * 63, "0" * 65, "0" * 64 + "0", "ABCDEF" + "0" * 58):
+            with pytest.raises(ValidationError):
+                DraftIntentSnapshot(**_snap_kwargs(text_hash=bad))
+
+    def test_text_hash_field_pinned_to_sha256(self) -> None:
+        # Valid sha256 hex passes.
+        snap = DraftIntentSnapshot(**_snap_kwargs(text_hash="a" * 64))
+        assert snap.text_hash == "a" * 64
+
+    def test_timestamp_must_be_iso8601(self) -> None:
+        for bad in ("yesterday", "2026-04-25", "20:14:45", "2026/04/25 20:14:45", ""):
+            with pytest.raises(ValidationError):
+                DraftIntentSnapshot(**_snap_kwargs(timestamp=bad))
+
+    def test_timestamp_accepts_z_and_offset(self) -> None:
+        DraftIntentSnapshot(**_snap_kwargs(timestamp="2026-04-25T20:14:45Z"))
+        DraftIntentSnapshot(**_snap_kwargs(timestamp="2026-04-25T20:14:45+02:00"))
+        DraftIntentSnapshot(**_snap_kwargs(timestamp="2026-04-25T20:14:45.123Z"))
+
+    def test_capabilities_emits_cannot_be_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ComposerAdapterCapabilities(
+                level="L0",
+                emits=(),  # type: ignore[arg-type]
+                host_app="claude-code",
+                host_kind="ai_chat_client",
+            )
+
+    def test_session_id_cannot_be_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            DraftIntentSnapshot(**_snap_kwargs(session_id=""))
+
+    def test_host_app_cannot_be_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ComposerAdapterCapabilities(
+                level="L0",
+                emits=("submitted",),
+                host_app="",
+                host_kind="ai_chat_client",
             )
 
 

--- a/tests/test_conformance/test_fixtures_match.py
+++ b/tests/test_conformance/test_fixtures_match.py
@@ -93,7 +93,16 @@ def test_predictions_active_envelope_shape():
         _assert_shape(row["run"], RUN_KEYS)
         _assert_shape(row["artifacts"], ARTIFACTS_KEYS)
         # Enum-valued strings must be drawn from the documented sets
-        assert row["spec"]["source"] in {"arc", "pattern", "llm_branch", "macro", "history", "goal"}
+        assert row["spec"]["source"] in {
+            "arc",
+            "pattern",
+            "llm_branch",
+            "macro",
+            "history",
+            "goal",
+            "artefact_item",
+            "composer_intent",
+        }
         assert row["spec"]["hypothesis_type"] in {"likely_next", "possible_branch", "long_tail"}
         assert row["spec"]["specificity"] in {"concrete", "category", "anchor"}
         assert row["run"]["readiness"] in {
@@ -114,7 +123,70 @@ def test_predictions_single_shape():
     _assert_shape(row["artifacts"], ARTIFACTS_KEYS)
 
 
-@pytest.mark.parametrize("fixture", ["adopt_response_rich.json", "adopt_response_minimal.json"])
+def test_predictions_active_composer_fixture():
+    """0.8.7 WS8: composer_intent prediction with composer_engagement.
+
+    Exercises the present-case for the new optional fields the Rust
+    mirror gained (PredictedPrompt.composer_engagement, ComposerEngagement
+    struct). The fixture itself is the contract: if it stops parsing,
+    either the Rust mirror or the Python serializer drifted.
+    """
+    body = _load("predictions_active_composer_sample.json")
+    assert list(body.keys()) == ["predictions"]
+    assert len(body["predictions"]) == 1
+    row = body["predictions"][0]
+    assert row["spec"]["source"] == "composer_intent"
+    # composer_engagement is the new optional block.
+    assert "composer_engagement" in row
+    engagement = row["composer_engagement"]
+    assert isinstance(engagement["composer_event_id"], str) and engagement["composer_event_id"]
+    assert engagement["lifecycle_state"] in {
+        "observing",
+        "tentative",
+        "stabilizing",
+        "actionable",
+        "submitted",
+        "cleared",
+        "abandoned",
+    }
+    # Optional fields may be present + typed, or absent.
+    if engagement.get("inferred_intent_label") is not None:
+        assert isinstance(engagement["inferred_intent_label"], str)
+    if engagement.get("inferred_intent_confidence") is not None:
+        assert isinstance(engagement["inferred_intent_confidence"], (int, float))
+        assert 0.0 <= engagement["inferred_intent_confidence"] <= 1.0
+
+
+def test_adopt_response_composer_carries_composer_event_id():
+    """0.8.7 WS8: when an adopted prediction is composer_intent-sourced,
+    Resolution.composer_event_id is populated for adoption-telemetry
+    attribution. Other Resolution fixtures keep it as None.
+    """
+    body = _load("adopt_response_composer.json")
+    resolution = Resolution.model_validate(body)
+    assert resolution.composer_event_id == body["composer_event_id"]
+    assert resolution.adopted_from_prediction_id == body["adopted_from_prediction_id"]
+
+
+def test_legacy_adopt_responses_have_no_composer_event_id():
+    """The 0.8.6 fixtures predate composer_event_id; they MUST decode
+    cleanly with the field as None (byte-compat invariant)."""
+    for fixture in ("adopt_response_rich.json", "adopt_response_minimal.json"):
+        body = _load(fixture)
+        assert "composer_event_id" not in body
+        resolution = Resolution.model_validate(body)
+        assert resolution.composer_event_id is None
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "adopt_response_rich.json",
+        "adopt_response_minimal.json",
+        # 0.8.7 WS8 — composer_event_id present case
+        "adopt_response_composer.json",
+    ],
+)
 def test_adopt_response_roundtrips_through_pydantic(fixture):
     """The Resolution Pydantic model must accept every shape the
     fixture represents. If validation fails the daemon's `Resolution`
@@ -174,6 +246,9 @@ def test_every_fixture_is_registered():
         "setup_hardware_profile_sample.json",
         "setup_selection_sample.json",
         "setup_deep_run_defaults_sample.json",
+        # 0.8.7 WS8 — composer_intent + composer_engagement fixtures.
+        "predictions_active_composer_sample.json",
+        "adopt_response_composer.json",
     }
     found = {str(p.relative_to(FIXTURES)) for p in FIXTURES.rglob("*.json")}
     orphans = found - known

--- a/tests/test_daemon/test_composer_submit_translator.py
+++ b/tests/test_daemon/test_composer_submit_translator.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Claude Code UserPromptSubmit translator script — 0.8.7 WS7.
+
+The translator (plugins/vaner/scripts/composer_submit.py) reads a
+Claude Code hook payload from stdin, builds a DraftIntentSnapshot,
+and POSTs it to the daemon. We exercise the translator end-to-end by:
+
+1. Spinning up an in-process daemon HTTP app via TestClient.
+2. Invoking the translator as a subprocess with a synthetic stdin.
+3. Asserting the daemon received the right snapshot.
+
+The translator's failure modes (no prompt field, daemon down, bad
+JSON) MUST exit 0 so a misconfigured daemon never blocks the user's
+prompt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from wsgiref.simple_server import WSGIRequestHandler, make_server
+
+import pytest
+
+if platform.system().lower().startswith("win"):
+    pytest.skip("translator subprocess is flaky on Windows runners", allow_module_level=True)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRANSLATOR = REPO_ROOT / "plugins" / "vaner" / "scripts" / "composer_submit.py"
+
+
+@dataclass
+class _ReceivedRequest:
+    method: str
+    path: str
+    body_json: dict | None
+    response_status: int = 200
+
+
+class _SilentHandler(WSGIRequestHandler):
+    def log_message(self, format, *args):  # noqa: A002, ARG002
+        pass
+
+
+class _StubDaemon:
+    """Minimal HTTP server that captures POSTs to /signals/composer.
+
+    Avoids dragging FastAPI/TestClient into a subprocess scenario — the
+    translator hits a real port via urllib.
+    """
+
+    def __init__(self) -> None:
+        self.received: list[_ReceivedRequest] = []
+        self._server = make_server("127.0.0.1", 0, self._handler, handler_class=_SilentHandler)
+        self.port = int(self._server.server_address[1])
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> _StubDaemon:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+    def _handler(self, environ, start_response):
+        method = environ["REQUEST_METHOD"]
+        path = environ["PATH_INFO"]
+        body_bytes = b""
+        try:
+            length = int(environ.get("CONTENT_LENGTH") or 0)
+        except ValueError:
+            length = 0
+        if length:
+            body_bytes = environ["wsgi.input"].read(length)
+        try:
+            body_json = json.loads(body_bytes.decode("utf-8")) if body_bytes else None
+        except json.JSONDecodeError:
+            body_json = None
+        self.received.append(_ReceivedRequest(method=method, path=path, body_json=body_json))
+        start_response("200 OK", [("Content-Type", "application/json")])
+        return [b'{"composer_event_id": "evt-stub"}']
+
+
+def _run_translator(*, port: int, stdin_payload: dict | str) -> tuple[int, str, str]:
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "VANER_DAEMON_PORT": str(port),
+    }
+    stdin_data = (stdin_payload if isinstance(stdin_payload, str) else json.dumps(stdin_payload)).encode("utf-8")
+    result = subprocess.run(
+        [sys.executable, str(TRANSLATOR)],
+        input=stdin_data,
+        env=env,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    return result.returncode, result.stdout.decode(), result.stderr.decode()
+
+
+def test_translator_posts_snapshot_with_text_hash(tmp_path):
+    prompt = "rewrite this scene so the tension rises more slowly"
+    expected_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    with _StubDaemon() as daemon:
+        rc, _stdout, _stderr = _run_translator(
+            port=daemon.port,
+            stdin_payload={
+                "prompt": prompt,
+                "session_id": "session-abc",
+                "cwd": str(tmp_path),
+            },
+        )
+
+    assert rc == 0
+    assert len(daemon.received) == 1
+    req = daemon.received[0]
+    assert req.method == "POST"
+    assert req.path == "/signals/composer"
+    body = req.body_json
+    assert body is not None
+    assert body["session_id"] == "session-abc"
+    assert body["lifecycle_state"] == "submitted"
+    assert body["text_hash"] == expected_hash
+    assert body["length_chars"] == len(prompt)
+    assert body["capabilities"]["level"] == "L0"
+    assert body["capabilities"]["host_app"] == "claude-code"
+    assert body["capabilities"]["emits"] == ["submitted"]
+    # Privacy invariant: raw prompt MUST NOT be in the payload.
+    assert prompt not in json.dumps(body)
+
+
+def test_translator_handles_missing_prompt_silently(tmp_path):
+    with _StubDaemon() as daemon:
+        rc, _stdout, _stderr = _run_translator(
+            port=daemon.port,
+            stdin_payload={"session_id": "session-abc"},
+        )
+
+    assert rc == 0
+    # No POST should have happened.
+    assert daemon.received == []
+
+
+def test_translator_handles_empty_stdin_silently(tmp_path):
+    with _StubDaemon() as daemon:
+        rc, _stdout, _stderr = _run_translator(
+            port=daemon.port,
+            stdin_payload="",
+        )
+
+    assert rc == 0
+    assert daemon.received == []
+
+
+def test_translator_handles_malformed_stdin_silently(tmp_path):
+    with _StubDaemon() as daemon:
+        rc, _stdout, _stderr = _run_translator(
+            port=daemon.port,
+            stdin_payload="not-json{",
+        )
+
+    assert rc == 0
+    assert daemon.received == []
+
+
+def test_translator_silent_when_daemon_unreachable(tmp_path):
+    # No stub daemon on this port — POST will fail.
+    rc, _stdout, _stderr = _run_translator(
+        port=1,  # privileged, refused
+        stdin_payload={"prompt": "test", "session_id": "s"},
+    )
+    # MUST exit 0 so the user's prompt isn't blocked. May log to stderr.
+    assert rc == 0

--- a/tests/test_daemon/test_setup_endpoints.py
+++ b/tests/test_daemon/test_setup_endpoints.py
@@ -384,9 +384,11 @@ def test_post_policy_refresh_503_on_engine_exception(repo_root: Path) -> None:
     init_repo(repo_root)
     config = load_config(repo_root)
 
+    sentinel = "kaboom-internal-detail-must-not-leak"
+
     class BoomEngine:
         def _refresh_policy_bundle_state(self) -> None:
-            raise RuntimeError("kaboom")
+            raise RuntimeError(sentinel)
 
         async def initialize(self) -> None:
             return None
@@ -400,4 +402,10 @@ def test_post_policy_refresh_503_on_engine_exception(repo_root: Path) -> None:
     assert resp.status_code == 503
     body = resp.json()
     assert body["code"] == "refresh_failed"
-    assert "kaboom" in body["message"]
+    # The endpoint MUST NOT echo the raw exception message into the
+    # response body — this was hardened in commit 3e70586 to resolve a
+    # CodeQL stack-exposure alert. The static "policy refresh failed"
+    # text is the contract; pinning the sentinel-absence stops a future
+    # accidental revert from re-introducing the leak.
+    assert body["message"] == "policy refresh failed"
+    assert sentinel not in resp.text

--- a/tests/test_daemon/test_signals_composer_endpoint.py
+++ b/tests/test_daemon/test_signals_composer_endpoint.py
@@ -155,3 +155,51 @@ def test_response_event_id_is_unique_per_call(temp_repo):
     assert a["composer_event_id"] != b["composer_event_id"]
     # Both events reached the engine.
     assert len(engine.observed) == 2
+
+
+def test_validation_error_envelope_does_not_echo_input(temp_repo):
+    """0.8.7 hardening C1: pydantic v2's exc.errors() echoes the offending
+    value under the `input` key. For an adapter bug that placed draft
+    text into a wrong field, that would reflect raw text back. The
+    daemon MUST scrub `input` before serializing the error envelope.
+    """
+    config = _make_config(temp_repo)
+    engine = _CapturingEngine()
+    app = create_daemon_http_app(config, engine=engine)
+    sentinel = "RAW_DRAFT_SECRET_THAT_MUST_NOT_LEAK"
+    bad = _valid_l0_payload()
+    bad["text_hash"] = sentinel  # not 64 hex chars → ValidationError
+
+    with TestClient(app) as client:
+        response = client.post("/signals/composer", json=bad)
+
+    assert response.status_code == 400
+    body_text = response.text
+    assert sentinel not in body_text, "validation error envelope leaked the offending input value"
+    # The structured message is still useful for adapter authors:
+    payload = response.json()
+    assert payload["code"] == "invalid_input"
+    assert isinstance(payload["message"], list)
+    for entry in payload["message"]:
+        assert "loc" in entry
+        assert "type" in entry
+        assert "msg" in entry
+        # Critically: no `input` field reflecting the raw value.
+        assert "input" not in entry
+
+
+def test_capability_emits_empty_rejected_at_validation(temp_repo):
+    """0.8.7 hardening C2: ComposerAdapterCapabilities.emits has min_length=1.
+    An adapter that declares emits=[] is structurally invalid.
+    """
+    config = _make_config(temp_repo)
+    engine = _CapturingEngine()
+    app = create_daemon_http_app(config, engine=engine)
+    payload = _valid_l0_payload()
+    payload["capabilities"]["emits"] = []
+
+    with TestClient(app) as client:
+        response = client.post("/signals/composer", json=payload)
+
+    assert response.status_code == 400
+    assert engine.observed == []

--- a/tests/test_daemon/test_signals_composer_endpoint.py
+++ b/tests/test_daemon/test_signals_composer_endpoint.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for POST /signals/composer — 0.8.7 WS7.
+
+Validates the daemon endpoint that ingests composer-lifecycle events
+from registered ComposerAdapters (e.g. the Claude Code UserPromptSubmit
+hook).
+"""
+
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vaner.daemon.http import create_daemon_http_app
+from vaner.models.config import VanerConfig
+from vaner.models.signal import KIND_COMPOSER_LIFECYCLE, SignalEvent
+
+if platform.system().lower().startswith("win"):
+    pytest.skip("daemon http TestClient is flaky on Windows runners", allow_module_level=True)
+
+
+@dataclass
+class _CapturingEngine:
+    """Engine shim that captures every observe() call for assertion."""
+
+    observed: list[SignalEvent] = field(default_factory=list)
+
+    async def observe(self, event: SignalEvent) -> None:
+        self.observed.append(event)
+
+
+def _make_config(tmp_path: Path) -> VanerConfig:
+    return VanerConfig(
+        repo_root=tmp_path,
+        store_path=tmp_path / ".vaner" / "store.db",
+        telemetry_path=tmp_path / ".vaner" / "telemetry.db",
+    )
+
+
+def _valid_l0_payload() -> dict[str, Any]:
+    return {
+        "session_id": "session-abc",
+        "snapshot_id": "snap-001",
+        "timestamp": "2026-04-25T20:14:45Z",
+        "lifecycle_state": "submitted",
+        "text_hash": "0" * 64,
+        "length_chars": 42,
+        "capabilities": {
+            "level": "L0",
+            "emits": ["submitted"],
+            "host_app": "claude-code",
+            "host_kind": "ai_chat_client",
+        },
+    }
+
+
+def test_unavailable_engine_returns_409(temp_repo):
+    config = _make_config(temp_repo)
+    app = create_daemon_http_app(config)  # no engine
+    with TestClient(app) as client:
+        response = client.post("/signals/composer", json=_valid_l0_payload())
+    assert response.status_code == 409
+    assert response.json()["code"] == "engine_unavailable"
+
+
+def test_valid_payload_publishes_to_engine_and_returns_event_id(temp_repo):
+    config = _make_config(temp_repo)
+    engine = _CapturingEngine()
+    app = create_daemon_http_app(config, engine=engine)
+
+    with TestClient(app) as client:
+        response = client.post("/signals/composer", json=_valid_l0_payload())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "composer_event_id" in body
+    assert isinstance(body["composer_event_id"], str)
+    assert len(body["composer_event_id"]) > 0
+
+    # Engine saw exactly one composer_lifecycle event with the right shape.
+    assert len(engine.observed) == 1
+    event = engine.observed[0]
+    assert event.kind == KIND_COMPOSER_LIFECYCLE
+    assert event.source == "composer-adapter:claude-code"
+    assert event.payload["session_id"] == "session-abc"
+    assert event.payload["lifecycle_state"] == "submitted"
+    # Critical privacy invariant: only hash + length, no raw text key.
+    assert "prompt" not in event.payload
+    assert "text" not in event.payload
+    assert "draft_text" not in event.payload
+
+
+def test_malformed_json_returns_400(temp_repo):
+    config = _make_config(temp_repo)
+    engine = _CapturingEngine()
+    app = create_daemon_http_app(config, engine=engine)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/signals/composer",
+            content=b"not-json{",
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "invalid_input"
+    assert engine.observed == []
+
+
+def test_missing_required_field_returns_400(temp_repo):
+    config = _make_config(temp_repo)
+    engine = _CapturingEngine()
+    app = create_daemon_http_app(config, engine=engine)
+    bad = _valid_l0_payload()
+    del bad["text_hash"]
+
+    with TestClient(app) as client:
+        response = client.post("/signals/composer", json=bad)
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "invalid_input"
+    assert engine.observed == []
+
+
+def test_capability_violation_returns_400(temp_repo):
+    """An L0 adapter declaring emits=['submitted'] cannot send 'actionable'."""
+    config = _make_config(temp_repo)
+    engine = _CapturingEngine()
+    app = create_daemon_http_app(config, engine=engine)
+    payload = _valid_l0_payload()
+    payload["lifecycle_state"] = "actionable"  # not in capabilities.emits
+
+    with TestClient(app) as client:
+        response = client.post("/signals/composer", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "capability_violation"
+    assert engine.observed == []
+
+
+def test_response_event_id_is_unique_per_call(temp_repo):
+    config = _make_config(temp_repo)
+    engine = _CapturingEngine()
+    app = create_daemon_http_app(config, engine=engine)
+
+    with TestClient(app) as client:
+        a = client.post("/signals/composer", json=_valid_l0_payload()).json()
+        b = client.post("/signals/composer", json=_valid_l0_payload()).json()
+
+    assert a["composer_event_id"] != b["composer_event_id"]
+    # Both events reached the engine.
+    assert len(engine.observed) == 2

--- a/tests/test_engine/test_observe_composer.py
+++ b/tests/test_engine/test_observe_composer.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for engine.observe() composer-lifecycle dispatch — 0.8.7 WS3.
+
+Validates:
+
+- ``observe()`` validates a ``composer_lifecycle`` payload as a
+  ``DraftIntentSnapshot`` BEFORE it reaches the signal-event store; a
+  malformed payload raises and is not persisted.
+- A valid payload is persisted to ``signal_events`` exactly once and
+  the typed snapshot is published to the composer signal pump.
+- Non-composer kinds bypass the validator and reach the store
+  unchanged (existing behavior preserved).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from vaner.engine import VanerEngine
+from vaner.intent.adapter import CodeRepoAdapter
+from vaner.models.signal import KIND_COMPOSER_LIFECYCLE, SignalEvent
+from vaner.signals.composer import DraftIntentSnapshot
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _stub_llm(_prompt: str) -> str:
+    return '{"ranked_files": [], "semantic_intent": "", "confidence": 0.0, "follow_on": []}'
+
+
+def _seed_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "sample.py").write_text("def hi():\n    return 'hi'\n")
+
+
+def _make_engine(repo_root: Path) -> VanerEngine:
+    _seed_repo(repo_root)
+    engine = VanerEngine(adapter=CodeRepoAdapter(repo_root), llm=_stub_llm)
+    engine.config.compute.idle_only = False
+    return engine
+
+
+def _valid_snapshot_payload() -> dict[str, object]:
+    return {
+        "session_id": "session-abc",
+        "snapshot_id": "snap-001",
+        "timestamp": "2026-04-25T20:14:45Z",
+        "lifecycle_state": "submitted",
+        "text_hash": "0" * 64,
+        "length_chars": 42,
+        "capabilities": {
+            "level": "L0",
+            "emits": ["submitted"],
+            "host_app": "claude-code",
+            "host_kind": "ai_chat_client",
+        },
+    }
+
+
+def _signal(payload: dict[str, object], *, event_id: str = "evt-1") -> SignalEvent:
+    return SignalEvent(
+        id=event_id,
+        source="composer-adapter:claude-code",
+        kind=KIND_COMPOSER_LIFECYCLE,
+        timestamp=0.0,
+        payload=payload,
+    )
+
+
+async def test_valid_composer_payload_publishes_to_pump_and_persists(tmp_path: Path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    seen: list[DraftIntentSnapshot] = []
+
+    async def collector(snap: DraftIntentSnapshot) -> None:
+        seen.append(snap)
+
+    engine.composer_signal_pump.subscribe(collector)
+
+    await engine.observe(_signal(_valid_snapshot_payload()))
+
+    assert len(seen) == 1
+    assert seen[0].lifecycle_state == "submitted"
+    assert seen[0].session_id == "session-abc"
+    assert seen[0].text_hash == "0" * 64
+    # Persistence: exactly one row landed in the store.
+    rows = await engine.store.list_signal_events(limit=10)
+    assert len(rows) == 1
+    assert rows[0].kind == KIND_COMPOSER_LIFECYCLE
+
+
+async def test_malformed_composer_payload_raises_and_does_not_persist(tmp_path: Path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    bad = _valid_snapshot_payload()
+    bad["lifecycle_state"] = "not-a-state"  # invalid literal
+
+    with pytest.raises(ValidationError):
+        await engine.observe(_signal(bad, event_id="bad-1"))
+
+    rows = await engine.store.list_signal_events(limit=10)
+    assert rows == [], "malformed composer payload must not reach the store"
+
+
+async def test_missing_required_field_raises_and_does_not_persist(tmp_path: Path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    bad = _valid_snapshot_payload()
+    del bad["text_hash"]
+
+    with pytest.raises(ValidationError):
+        await engine.observe(_signal(bad, event_id="bad-2"))
+
+    rows = await engine.store.list_signal_events(limit=10)
+    assert rows == []
+
+
+async def test_non_composer_kind_bypasses_validator(tmp_path: Path) -> None:
+    """Existing signal kinds must be unaffected by WS3's dispatch branch."""
+    engine = _make_engine(tmp_path / "repo")
+    seen: list[DraftIntentSnapshot] = []
+
+    async def collector(snap: DraftIntentSnapshot) -> None:
+        seen.append(snap)
+
+    engine.composer_signal_pump.subscribe(collector)
+
+    other = SignalEvent(
+        id="evt-other",
+        source="git",
+        kind="commit",
+        timestamp=0.0,
+        payload={"sha": "abc123"},
+    )
+    await engine.observe(other)
+
+    rows = await engine.store.list_signal_events(limit=10)
+    assert len(rows) == 1
+    assert rows[0].kind == "commit"
+    assert seen == []
+
+
+async def test_publish_swallows_subscriber_failures(tmp_path: Path) -> None:
+    """One bad subscriber must not block other subscribers (or persistence)."""
+    engine = _make_engine(tmp_path / "repo")
+    delivered: list[str] = []
+
+    async def fail(_snap: DraftIntentSnapshot) -> None:
+        raise RuntimeError("intentional failure")
+
+    async def succeed(snap: DraftIntentSnapshot) -> None:
+        delivered.append(snap.snapshot_id)
+
+    engine.composer_signal_pump.subscribe(fail)
+    engine.composer_signal_pump.subscribe(succeed)
+
+    await engine.observe(_signal(_valid_snapshot_payload()))
+
+    assert delivered == ["snap-001"]
+    rows = await engine.store.list_signal_events(limit=10)
+    assert len(rows) == 1
+
+
+async def test_pump_subscribe_unsubscribe(tmp_path: Path) -> None:
+    engine = _make_engine(tmp_path / "repo")
+    delivered: list[str] = []
+
+    async def collect(snap: DraftIntentSnapshot) -> None:
+        delivered.append(snap.snapshot_id)
+
+    pump = engine.composer_signal_pump
+    pump.subscribe(collect)
+    assert pump.subscriber_count == 1
+    pump.unsubscribe(collect)
+    assert pump.subscriber_count == 0
+
+    await engine.observe(_signal(_valid_snapshot_payload()))
+    assert delivered == []
+
+
+async def test_pump_publishes_directly_without_engine() -> None:
+    """Smoke test: pump can be exercised with no engine."""
+    from vaner.signals.composer import ComposerSignalPump
+
+    pump = ComposerSignalPump()
+    delivered: list[str] = []
+
+    async def collect(snap: DraftIntentSnapshot) -> None:
+        delivered.append(snap.snapshot_id)
+
+    pump.subscribe(collect)
+    snap = DraftIntentSnapshot.model_validate(_valid_snapshot_payload())
+    await pump.publish(snap)
+    assert delivered == ["snap-001"]

--- a/tests/test_intent/test_composer_intent_source.py
+++ b/tests/test_intent/test_composer_intent_source.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for composer_intent prediction source + invalidation — 0.8.7 WS4.
+
+Validates:
+
+- ``Source`` literal admits ``"composer_intent"``.
+- ``PredictionRun.compose_signal_strength`` defaults to 0.0 (existing
+  call sites byte-identical).
+- ``build_composer_cancelled_signal`` and ``build_composer_abandoned_signal``
+  produce well-formed InvalidationSignal records.
+- ``apply_invalidation_signals`` stales every ``composer_intent``-sourced
+  prediction whose ``spec.anchor`` matches the cancelled / abandoned
+  ``session_id``.
+- The new branch DOES NOT touch non-``composer_intent`` predictions.
+- The artefact_item-only guards at prediction_registry.py lines 622, 685
+  remain at their previous occurrence count (regression guard).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from vaner.intent.invalidation import (
+    InvalidationSignal,
+    build_composer_abandoned_signal,
+    build_composer_cancelled_signal,
+)
+from vaner.intent.prediction import (
+    PredictionRun,
+    PredictionSpec,
+    prediction_id,
+)
+from vaner.intent.prediction_registry import PredictionRegistry
+
+
+def _composer_spec(
+    *,
+    session_id: str,
+    label: str = "rewrite the handler",
+    confidence: float = 0.7,
+) -> PredictionSpec:
+    pid = prediction_id("composer_intent", session_id, label)
+    return PredictionSpec(
+        id=pid,
+        label=label,
+        description=label,
+        source="composer_intent",
+        anchor=session_id,
+        confidence=confidence,
+        hypothesis_type="likely_next",
+        specificity="concrete",
+        created_at=0.0,
+    )
+
+
+def _arc_spec(*, anchor: str = "tests/handler") -> PredictionSpec:
+    pid = prediction_id("arc", anchor, "tests")
+    return PredictionSpec(
+        id=pid,
+        label="tests",
+        description="tests",
+        source="arc",
+        anchor=anchor,
+        confidence=0.8,
+        hypothesis_type="likely_next",
+        specificity="concrete",
+        created_at=0.0,
+    )
+
+
+class TestComposerIntentSourceLiteral:
+    def test_composer_spec_constructs(self) -> None:
+        spec = _composer_spec(session_id="s1")
+        assert spec.source == "composer_intent"
+        assert spec.anchor == "s1"
+
+    def test_compose_signal_strength_defaults_to_zero(self) -> None:
+        run = PredictionRun(weight=0.5, token_budget=1000)
+        assert run.compose_signal_strength == 0.0
+
+    def test_compose_signal_strength_is_writable(self) -> None:
+        run = PredictionRun(weight=0.5, token_budget=1000)
+        run.compose_signal_strength = 0.85
+        assert run.compose_signal_strength == 0.85
+
+
+class TestInvalidationBuilders:
+    def test_cancelled_builder_shape(self) -> None:
+        sig = build_composer_cancelled_signal("session-abc")
+        assert isinstance(sig, InvalidationSignal)
+        assert sig.kind == "composer_cancelled"
+        assert sig.payload == {"session_id": "session-abc"}
+
+    def test_abandoned_builder_shape(self) -> None:
+        sig = build_composer_abandoned_signal("session-xyz")
+        assert isinstance(sig, InvalidationSignal)
+        assert sig.kind == "composer_abandoned"
+        assert sig.payload == {"session_id": "session-xyz"}
+
+
+class TestRegistryInvalidation:
+    def test_cancelled_stales_matching_composer_intent_prediction(self) -> None:
+        registry = PredictionRegistry()
+        spec = _composer_spec(session_id="s1")
+        registry.enroll(spec, initial_weight=0.5)
+
+        outcomes = registry.apply_invalidation_signals([build_composer_cancelled_signal("s1")])
+
+        assert outcomes.get(spec.id) == "staled"
+        prompt = registry.get(spec.id)
+        assert prompt is not None
+        assert prompt.run.readiness == "stale"
+        assert prompt.run.invalidation_reason.startswith("composer_cancelled:")
+
+    def test_abandoned_stales_matching_composer_intent_prediction(self) -> None:
+        registry = PredictionRegistry()
+        spec = _composer_spec(session_id="s2")
+        registry.enroll(spec, initial_weight=0.5)
+
+        outcomes = registry.apply_invalidation_signals([build_composer_abandoned_signal("s2")])
+
+        assert outcomes.get(spec.id) == "staled"
+        prompt = registry.get(spec.id)
+        assert prompt is not None
+        assert prompt.run.readiness == "stale"
+        assert prompt.run.invalidation_reason.startswith("composer_abandoned:")
+
+    def test_session_mismatch_leaves_prediction_alone(self) -> None:
+        registry = PredictionRegistry()
+        spec = _composer_spec(session_id="s1")
+        registry.enroll(spec, initial_weight=0.5)
+
+        outcomes = registry.apply_invalidation_signals([build_composer_cancelled_signal("different-session")])
+
+        assert spec.id not in outcomes
+        prompt = registry.get(spec.id)
+        assert prompt is not None
+        assert prompt.run.readiness != "stale"
+
+    def test_non_composer_predictions_are_untouched(self) -> None:
+        registry = PredictionRegistry()
+        composer_spec = _composer_spec(session_id="s1")
+        arc_spec = _arc_spec(anchor="s1")  # same anchor, different source
+        registry.enroll(composer_spec, initial_weight=0.5)
+        registry.enroll(arc_spec, initial_weight=0.5)
+
+        outcomes = registry.apply_invalidation_signals([build_composer_cancelled_signal("s1")])
+
+        # Composer spec stales, arc spec untouched.
+        assert outcomes.get(composer_spec.id) == "staled"
+        assert arc_spec.id not in outcomes
+        arc_prompt = registry.get(arc_spec.id)
+        assert arc_prompt is not None
+        assert arc_prompt.run.readiness != "stale"
+
+    def test_empty_session_id_is_a_noop(self) -> None:
+        registry = PredictionRegistry()
+        spec = _composer_spec(session_id="s1")
+        registry.enroll(spec, initial_weight=0.5)
+
+        outcomes = registry.apply_invalidation_signals([InvalidationSignal(kind="composer_cancelled", payload={"session_id": ""})])
+
+        assert outcomes == {}
+
+
+class TestArtefactItemGuardsUnchanged:
+    """Regression guard for plan §risk-2.
+
+    The artefact_item-only guards at prediction_registry.py lines 622 and
+    685 are correctly exclude-paths that bypass non-artefact_item sources.
+    Adding ``composer_intent`` must not require touching them, so this
+    test pins their occurrence count in place. A future refactor that
+    rewrites these guards to enumerate sources would have to either keep
+    composer_intent excluded (correct) or add explicit handling — either
+    way, this test forces the diff to be intentional.
+    """
+
+    def test_artefact_item_string_appears_exactly_twice(self) -> None:
+        repo = Path(__file__).resolve().parents[2]
+        target = repo / "src" / "vaner" / "intent"
+        assert target.is_dir()
+        result = subprocess.run(
+            ["git", "grep", "-n", '"artefact_item"', str(target.relative_to(repo))],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # git grep returns 1 when no matches, 0 otherwise. Both are fine.
+        assert result.returncode in (0, 1)
+        # Filter to runtime paths (the prediction_registry guards live in
+        # the registry module). The `Source` literal also names
+        # "artefact_item" in prediction.py — that's a one-line definition,
+        # not a guard. The two guard sites are in prediction_registry.py.
+        guard_hits = [
+            line for line in result.stdout.splitlines() if "/prediction_registry.py:" in line and 'spec.source != "artefact_item"' in line
+        ]
+        assert len(guard_hits) == 2, f"expected 2 artefact_item-only guards in prediction_registry.py; got {len(guard_hits)}: {guard_hits}"

--- a/tests/test_intent/test_frontier_composer_multiplier.py
+++ b/tests/test_intent/test_frontier_composer_multiplier.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the 0.8.7 WS5 frontier + work-style composer multipliers.
+
+Validates:
+
+- ``ExplorationFrontier._SOURCE_MULTIPLIERS_INIT`` registers
+  ``"composer_intent": 1.0`` so the existing per-source learning loop
+  picks it up.
+- ``IntentPriorAdjustments.composer_signal_weight_multiplier`` is
+  populated for every WorkStyle, with the load-bearing
+  ``mixed=1.0`` identity invariant preserved.
+- ``adjustments_for`` averages the new field correctly.
+- The 0.8.6 WS4 ``mixed-is-identity`` invariant for all *other*
+  multipliers still holds — the new field doesn't perturb existing
+  behavior on default configs.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+
+from vaner.intent.frontier import ExplorationFrontier
+from vaner.intent.work_style_priors import (
+    WORK_STYLE_PRIORS,
+    adjustments_for,
+    default_adjustments,
+)
+from vaner.setup.enums import WorkStyle
+
+
+class TestFrontierSourceMultiplier:
+    def test_composer_intent_registered_at_baseline(self) -> None:
+        assert ExplorationFrontier._SOURCE_MULTIPLIERS_INIT["composer_intent"] == 1.0
+
+    def test_existing_source_multipliers_unchanged(self) -> None:
+        # Snapshot test on the values the existing 0.8.6 frontier tests
+        # rely on — a refactor that perturbs these would surface here.
+        assert ExplorationFrontier._SOURCE_MULTIPLIERS_INIT["graph"] == 1.0
+        assert ExplorationFrontier._SOURCE_MULTIPLIERS_INIT["arc"] == 1.0
+        assert ExplorationFrontier._SOURCE_MULTIPLIERS_INIT["pattern"] == 1.2
+        assert ExplorationFrontier._SOURCE_MULTIPLIERS_INIT["llm_branch"] == 0.9
+        assert ExplorationFrontier._SOURCE_MULTIPLIERS_INIT["skill"] == 1.1
+
+
+class TestComposerSignalWeightMultiplierTable:
+    def test_every_work_style_has_composer_multiplier(self) -> None:
+        for style in get_args(WorkStyle):
+            spec = WORK_STYLE_PRIORS[style]
+            # Pin the type — every entry must explicitly populate the field.
+            assert isinstance(spec.composer_signal_weight_multiplier, float)
+            # Conservative range, same convention as the other multipliers.
+            assert 0.7 <= spec.composer_signal_weight_multiplier <= 1.5
+
+    def test_writing_has_strongest_boost(self) -> None:
+        """Writing's drafts are the most intent-revealing — boost is highest."""
+        assert WORK_STYLE_PRIORS["writing"].composer_signal_weight_multiplier == 1.4
+
+    def test_research_boost(self) -> None:
+        assert WORK_STYLE_PRIORS["research"].composer_signal_weight_multiplier == 1.3
+
+    def test_planning_boost(self) -> None:
+        assert WORK_STYLE_PRIORS["planning"].composer_signal_weight_multiplier == 1.2
+
+    def test_support_and_learning_boost(self) -> None:
+        assert WORK_STYLE_PRIORS["support"].composer_signal_weight_multiplier == 1.1
+        assert WORK_STYLE_PRIORS["learning"].composer_signal_weight_multiplier == 1.1
+
+    def test_coding_general_mixed_unsure_are_identity(self) -> None:
+        for style in ("coding", "general", "mixed", "unsure"):
+            assert WORK_STYLE_PRIORS[style].composer_signal_weight_multiplier == 1.0
+
+
+class TestMixedIsIdentityInvariant:
+    """The load-bearing 0.8.6 WS4 invariant: mixed work-style is identity.
+
+    A user on default ``setup.work_styles == ["mixed"]`` MUST see
+    byte-identical engine behavior to pre-0.8.7. The composer multiplier
+    cannot change that invariant.
+    """
+
+    def test_mixed_composer_multiplier_is_one(self) -> None:
+        assert WORK_STYLE_PRIORS["mixed"].composer_signal_weight_multiplier == 1.0
+
+    def test_default_adjustments_composer_is_one(self) -> None:
+        assert default_adjustments().composer_signal_weight_multiplier == 1.0
+
+    def test_unsure_composer_multiplier_is_one(self) -> None:
+        # ``unsure`` is the second identity element — same invariant.
+        assert WORK_STYLE_PRIORS["unsure"].composer_signal_weight_multiplier == 1.0
+
+    def test_mixed_only_input_yields_identity_for_all_existing_fields(self) -> None:
+        """Pre-existing fields under ``mixed`` are unchanged by WS5."""
+        adj = adjustments_for(("mixed",))
+        assert adj.artefact_alignment_weight_multiplier == 1.0
+        assert adj.long_horizon_bonus_multiplier == 1.0
+        assert adj.possible_branch_bonus_multiplier == 1.0
+        assert adj.drafting_evidence_floor == 0.0
+        assert adj.drafting_volatility_ceiling_multiplier == 1.0
+        assert adj.preferred_artefact_templates == ()
+        # New field also identity under mixed.
+        assert adj.composer_signal_weight_multiplier == 1.0
+
+
+class TestAveraging:
+    def test_composer_multiplier_averages_arithmetically(self) -> None:
+        adj = adjustments_for(("writing", "coding"))
+        expected = (
+            WORK_STYLE_PRIORS["writing"].composer_signal_weight_multiplier + WORK_STYLE_PRIORS["coding"].composer_signal_weight_multiplier
+        ) / 2
+        assert adj.composer_signal_weight_multiplier == pytest.approx(expected)
+
+    def test_averaging_order_independent(self) -> None:
+        a = adjustments_for(("research", "writing"))
+        b = adjustments_for(("writing", "research"))
+        assert a.composer_signal_weight_multiplier == b.composer_signal_weight_multiplier

--- a/tests/test_mcp_v2/test_composer_contract_fields.py
+++ b/tests/test_mcp_v2/test_composer_contract_fields.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the 0.8.7 WS8 MCP contract additions.
+
+Validates:
+
+- ``Resolution.composer_event_id`` defaults to None and round-trips.
+- ``PredictionArtifacts.composer_metadata`` defaults to an empty dict
+  and is byte-compatible with existing constructors.
+- ``_serialize_prediction_for_mcp`` surfaces ``composer_engagement`` only
+  when the prediction is composer_intent-sourced AND has metadata.
+- Non-composer predictions get NO ``composer_engagement`` key (existing
+  card payloads stay byte-identical).
+- The conformance fixtures still round-trip cleanly.
+"""
+
+from __future__ import annotations
+
+from vaner.intent.prediction import (
+    PredictedPrompt,
+    PredictionArtifacts,
+    PredictionRun,
+    PredictionSpec,
+    prediction_id,
+)
+from vaner.mcp.contracts import Provenance, Resolution
+from vaner.mcp.server import _serialize_prediction_for_mcp
+
+
+def _make_prompt(*, source: str, anchor: str, composer_metadata: dict | None = None) -> PredictedPrompt:
+    spec = PredictionSpec(
+        id=prediction_id(source, anchor, "test"),
+        label="test",
+        description="test",
+        source=source,  # type: ignore[arg-type]
+        anchor=anchor,
+        confidence=0.7,
+        hypothesis_type="likely_next",
+        specificity="concrete",
+        created_at=0.0,
+    )
+    run = PredictionRun(weight=0.5, token_budget=1000)
+    artifacts = PredictionArtifacts()
+    if composer_metadata is not None:
+        artifacts.composer_metadata = composer_metadata
+    return PredictedPrompt(spec=spec, run=run, artifacts=artifacts)
+
+
+class TestResolutionComposerEventId:
+    def test_defaults_to_none(self) -> None:
+        provenance = Provenance(mode="predictive_hit", cache="warm", freshness="fresh")
+        resolution = Resolution(
+            intent="test",
+            confidence=0.5,
+            summary="test",
+            provenance=provenance,
+            resolution_id="r-1",
+        )
+        assert resolution.composer_event_id is None
+
+    def test_round_trips_when_set(self) -> None:
+        provenance = Provenance(mode="predictive_hit", cache="warm", freshness="fresh")
+        resolution = Resolution(
+            intent="test",
+            confidence=0.5,
+            summary="test",
+            provenance=provenance,
+            resolution_id="r-1",
+            composer_event_id="evt-abc",
+        )
+        encoded = resolution.model_dump_json()
+        decoded = Resolution.model_validate_json(encoded)
+        assert decoded.composer_event_id == "evt-abc"
+
+
+class TestArtifactsComposerMetadata:
+    def test_defaults_to_empty_dict(self) -> None:
+        artifacts = PredictionArtifacts()
+        assert artifacts.composer_metadata == {}
+
+    def test_can_be_populated(self) -> None:
+        artifacts = PredictionArtifacts()
+        artifacts.composer_metadata = {
+            "composer_event_id": "evt-1",
+            "lifecycle_state": "submitted",
+        }
+        assert artifacts.composer_metadata["composer_event_id"] == "evt-1"
+
+
+class TestSerializeComposerEngagement:
+    def test_non_composer_prediction_has_no_engagement_key(self) -> None:
+        prompt = _make_prompt(source="arc", anchor="some-anchor")
+        payload = _serialize_prediction_for_mcp(prompt)
+        assert "composer_engagement" not in payload
+
+    def test_composer_intent_without_metadata_has_no_engagement_key(self) -> None:
+        # composer_intent source but no metadata yet — payload omits the
+        # field entirely (rather than emitting an empty stub).
+        prompt = _make_prompt(source="composer_intent", anchor="session-abc")
+        payload = _serialize_prediction_for_mcp(prompt)
+        assert "composer_engagement" not in payload
+
+    def test_composer_intent_with_metadata_surfaces_engagement(self) -> None:
+        prompt = _make_prompt(
+            source="composer_intent",
+            anchor="session-abc",
+            composer_metadata={
+                "composer_event_id": "evt-1",
+                "lifecycle_state": "submitted",
+                "inferred_intent_label": "rewrite",
+                "inferred_intent_confidence": 0.85,
+            },
+        )
+        payload = _serialize_prediction_for_mcp(prompt)
+        assert "composer_engagement" in payload
+        engagement = payload["composer_engagement"]
+        assert engagement["composer_event_id"] == "evt-1"
+        assert engagement["lifecycle_state"] == "submitted"
+        assert engagement["inferred_intent_label"] == "rewrite"
+        assert engagement["inferred_intent_confidence"] == 0.85
+
+    def test_composer_intent_with_partial_metadata_omits_unset_fields(self) -> None:
+        prompt = _make_prompt(
+            source="composer_intent",
+            anchor="session-abc",
+            composer_metadata={
+                "composer_event_id": "evt-2",
+                "lifecycle_state": "submitted",
+            },
+        )
+        payload = _serialize_prediction_for_mcp(prompt)
+        engagement = payload["composer_engagement"]
+        assert engagement["composer_event_id"] == "evt-2"
+        # Optional fields default to None — caller may render or not.
+        assert engagement["inferred_intent_label"] is None
+        assert engagement["inferred_intent_confidence"] is None

--- a/tests/test_telemetry/test_draft_events_migration.py
+++ b/tests/test_telemetry/test_draft_events_migration.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the 0.8.7 WS6 ``draft_events.event_type`` migration.
+
+Validates:
+
+- A pre-0.8.7 schema (``draft_events`` without ``event_type``) is
+  migrated idempotently on first ``initialize()``.
+- Migration is repeatable (running ``initialize()`` twice is a no-op).
+- Pre-existing rows default to ``event_type='legacy_draft'``.
+- ``record_draft_event`` writes ``event_type='legacy_draft'`` and bumps
+  only the ``draft_*`` counter prefix (not ``composer_*``).
+- ``record_composer_lifecycle_event`` writes
+  ``event_type='composer_lifecycle'`` and bumps only the ``composer_*``
+  counter prefix (not ``draft_*``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import aiosqlite
+
+from vaner.telemetry.metrics import MetricsStore
+
+
+def _new_store(temp_repo):
+    return MetricsStore(temp_repo / ".vaner" / "metrics.db")
+
+
+async def _table_columns(db_path) -> set[str]:
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute("PRAGMA table_info(draft_events)")
+        rows = await cursor.fetchall()
+    return {str(row[1]) for row in rows}
+
+
+async def _seed_pre_0_8_7_db(db_path) -> None:
+    """Create a draft_events table missing the event_type column."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            """
+            CREATE TABLE draft_events (
+                id TEXT PRIMARY KEY,
+                timestamp REAL NOT NULL,
+                status TEXT NOT NULL,
+                predicted_prompt_similarity REAL NOT NULL DEFAULT 0.0,
+                evidence_overlap REAL NOT NULL DEFAULT 0.0,
+                answer_reuse_ratio REAL NOT NULL DEFAULT 0.0,
+                directional_correct INTEGER NOT NULL DEFAULT 0,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            )
+            """
+        )
+        # One pre-existing legacy row.
+        await db.execute(
+            """
+            INSERT INTO draft_events
+                (id, timestamp, status, predicted_prompt_similarity,
+                 evidence_overlap, answer_reuse_ratio, directional_correct,
+                 metadata_json)
+            VALUES ('pre-0.8.7-row', 1.0, 'served', 0.5, 0.5, 0.5, 0, '{}')
+            """
+        )
+        await db.commit()
+
+
+def test_migration_adds_event_type_column_to_pre_0_8_7_db(temp_repo):
+    store = _new_store(temp_repo)
+
+    async def _run() -> set[str]:
+        await _seed_pre_0_8_7_db(store.db_path)
+        # Sanity: the seeded DB does not have event_type yet.
+        assert "event_type" not in await _table_columns(store.db_path)
+        await store.initialize()
+        return await _table_columns(store.db_path)
+
+    columns = asyncio.run(_run())
+    assert "event_type" in columns
+
+
+def test_migration_is_idempotent(temp_repo):
+    store = _new_store(temp_repo)
+
+    async def _run() -> set[str]:
+        await _seed_pre_0_8_7_db(store.db_path)
+        await store.initialize()
+        # Run again — must not raise (the helper is idempotent).
+        await store.initialize()
+        return await _table_columns(store.db_path)
+
+    columns = asyncio.run(_run())
+    assert "event_type" in columns
+
+
+def test_pre_existing_rows_default_to_legacy_draft(temp_repo):
+    store = _new_store(temp_repo)
+
+    async def _run() -> str:
+        await _seed_pre_0_8_7_db(store.db_path)
+        await store.initialize()
+        async with aiosqlite.connect(store.db_path) as db:
+            cursor = await db.execute(
+                "SELECT event_type FROM draft_events WHERE id = ?",
+                ("pre-0.8.7-row",),
+            )
+            row = await cursor.fetchone()
+        assert row is not None
+        return str(row[0])
+
+    event_type = asyncio.run(_run())
+    assert event_type == "legacy_draft"
+
+
+def test_record_draft_event_writes_legacy_draft_event_type(temp_repo):
+    store = _new_store(temp_repo)
+
+    async def _run() -> str:
+        await store.initialize()
+        await store.record_draft_event(status="served")
+        async with aiosqlite.connect(store.db_path) as db:
+            cursor = await db.execute("SELECT event_type FROM draft_events")
+            row = await cursor.fetchone()
+        assert row is not None
+        return str(row[0])
+
+    event_type = asyncio.run(_run())
+    assert event_type == "legacy_draft"
+
+
+def test_record_composer_lifecycle_event_writes_composer_event_type(temp_repo):
+    store = _new_store(temp_repo)
+
+    async def _run() -> tuple[str, str]:
+        await store.initialize()
+        await store.record_composer_lifecycle_event(
+            session_id="s1",
+            snapshot_id="snap-1",
+            lifecycle_state="submitted",
+            text_hash="0" * 64,
+            length_chars=10,
+            composer_event_id="evt-1",
+        )
+        async with aiosqlite.connect(store.db_path) as db:
+            cursor = await db.execute("SELECT event_type, status FROM draft_events")
+            row = await cursor.fetchone()
+        assert row is not None
+        return str(row[0]), str(row[1])
+
+    event_type, status = asyncio.run(_run())
+    assert event_type == "composer_lifecycle"
+    assert status == "submitted"
+
+
+def test_counter_namespace_is_isolated(temp_repo):
+    """Composer rows must NOT bump existing draft_*_total counters.
+
+    0.8.6 dashboards index by ``draft_{served|useful|wrong|unused}_total``.
+    A composer-lifecycle write that mistakenly fed those counters would
+    silently corrupt the dashboards. WS6's invariant: composer events
+    write only to ``composer_*_total``.
+    """
+    store = _new_store(temp_repo)
+
+    async def _run() -> dict[str, float]:
+        await store.initialize()
+        # One composer event with status='submitted'.
+        await store.record_composer_lifecycle_event(
+            session_id="s1",
+            snapshot_id="snap-1",
+            lifecycle_state="submitted",
+            text_hash="0" * 64,
+            length_chars=10,
+            composer_event_id="evt-1",
+        )
+        async with aiosqlite.connect(store.db_path) as db:
+            cursor = await db.execute("SELECT name, value FROM memory_quality_counters")
+            rows = await cursor.fetchall()
+        return {str(row[0]): float(row[1]) for row in rows}
+
+    counters = asyncio.run(_run())
+    assert counters.get("composer_submitted_total") == 1.0
+    # The 0.8.6 draft counters MUST be untouched.
+    for legacy in (
+        "draft_served_total",
+        "draft_useful_total",
+        "draft_wrong_total",
+        "draft_unused_total",
+    ):
+        assert legacy not in counters, f"composer event corrupted legacy counter {legacy!r}"
+
+
+def test_metadata_carries_audit_fields_not_raw_text(temp_repo):
+    """The composer-lifecycle metadata must NEVER carry raw text."""
+    store = _new_store(temp_repo)
+
+    async def _run() -> dict:
+        await store.initialize()
+        await store.record_composer_lifecycle_event(
+            session_id="s1",
+            snapshot_id="snap-1",
+            lifecycle_state="submitted",
+            text_hash="0" * 64,
+            length_chars=42,
+            composer_event_id="evt-1",
+        )
+        async with aiosqlite.connect(store.db_path) as db:
+            cursor = await db.execute("SELECT metadata_json FROM draft_events")
+            row = await cursor.fetchone()
+        assert row is not None
+        import json
+
+        return json.loads(row[0])
+
+    meta = asyncio.run(_run())
+    assert meta["session_id"] == "s1"
+    assert meta["snapshot_id"] == "snap-1"
+    assert meta["text_hash"] == "0" * 64
+    assert meta["length_chars"] == 42
+    assert meta["composer_event_id"] == "evt-1"
+    # Pin the privacy invariant: no raw-text key under any reasonable name.
+    for forbidden in ("text", "draft_text", "raw_text", "preview", "prompt"):
+        assert forbidden not in meta

--- a/tests/test_telemetry/test_draft_events_migration.py
+++ b/tests/test_telemetry/test_draft_events_migration.py
@@ -191,7 +191,15 @@ def test_counter_namespace_is_isolated(temp_repo):
 
 
 def test_metadata_carries_audit_fields_not_raw_text(temp_repo):
-    """The composer-lifecycle metadata must NEVER carry raw text."""
+    """The composer-lifecycle metadata must NEVER carry raw text.
+
+    0.8.7 hardening (H2): the telemetry metadata also drops the
+    ``text_hash`` copy and replaces exact ``length_chars`` with a
+    coarse ``length_bucket``. The signal_events row keeps the full
+    snapshot for audit; reducing the cross-store correlation surface
+    defeats the trivial brute-force-sha256-over-known-length attack
+    that the metadata copy was enabling.
+    """
     store = _new_store(temp_repo)
 
     async def _run() -> dict:
@@ -215,9 +223,56 @@ def test_metadata_carries_audit_fields_not_raw_text(temp_repo):
     meta = asyncio.run(_run())
     assert meta["session_id"] == "s1"
     assert meta["snapshot_id"] == "snap-1"
-    assert meta["text_hash"] == "0" * 64
-    assert meta["length_chars"] == 42
     assert meta["composer_event_id"] == "evt-1"
+    # 0.8.7 hardening H2: bucketed, not exact.
+    assert meta["length_bucket"] == "10_49"
+    assert "length_chars" not in meta
+    # 0.8.7 hardening H2: text_hash redundant copy removed from
+    # telemetry surface. signal_events.payload retains it for audit.
+    assert "text_hash" not in meta
     # Pin the privacy invariant: no raw-text key under any reasonable name.
     for forbidden in ("text", "draft_text", "raw_text", "preview", "prompt"):
         assert forbidden not in meta
+
+
+def test_length_bucket_boundaries(temp_repo):
+    """Pin the bucket boundaries — defeats the side-channel only if the
+    bands are wide enough that a brute-force enumeration over the band
+    is infeasible.
+    """
+    from vaner.telemetry.metrics import _length_bucket
+
+    cases = [
+        (0, "0_9"),
+        (9, "0_9"),
+        (10, "10_49"),
+        (49, "10_49"),
+        (50, "50_249"),
+        (250, "250_999"),
+        (1000, "1000_4999"),
+        (5000, "5000_plus"),
+        (1_000_000, "5000_plus"),
+        (-1, "0_9"),  # clamps
+    ]
+    for n, expected in cases:
+        assert _length_bucket(n) == expected, f"length={n}"
+
+
+def test_concurrent_first_use_migration_does_not_lose(temp_repo):
+    """0.8.7 hardening (H3): two concurrent first-time initialize()
+    calls on a pre-0.8.7 DB must not error or lose the migration. One
+    of the two ALTERs may race; the duplicate-column error is swallowed
+    and the post-state is correct.
+    """
+    store = _new_store(temp_repo)
+
+    async def _run() -> set[str]:
+        await _seed_pre_0_8_7_db(store.db_path)
+        # Race two initialize() calls — both will PRAGMA, both will see
+        # no event_type column, both will attempt ALTER. The second's
+        # OperationalError("duplicate column name") MUST be swallowed.
+        await asyncio.gather(store.initialize(), store.initialize())
+        return await _table_columns(store.db_path)
+
+    columns = asyncio.run(_run())
+    assert "event_type" in columns

--- a/tests/test_telemetry/test_draft_events_migration.py
+++ b/tests/test_telemetry/test_draft_events_migration.py
@@ -179,7 +179,7 @@ def test_counter_namespace_is_isolated(temp_repo):
         return {str(row[0]): float(row[1]) for row in rows}
 
     counters = asyncio.run(_run())
-    assert counters.get("composer_submitted_total") == 1.0
+    assert counters.get("composer_lifecycle_submitted_total") == 1.0
     # The 0.8.6 draft counters MUST be untouched.
     for legacy in (
         "draft_served_total",


### PR DESCRIPTION
## Summary

Lands the foundation for **Live Intent Capture** (8 workstreams) plus the two carry-overs from v0.8.6 (SLSA verify-chain decouple + ComposerAdapter docs page in vaner-docs). Includes a full hardening pass that addresses 2 critical, 4 high, and 6 medium findings from independent code reviews.

Plan: [`/home/abo/.claude/plans/ok-we-will-now-zesty-wreath.md`](https://github.com/Borgels/Vaner/blob/main/) (project-private).

## Workstreams

| WS | Title | Commit |
|----|-------|--------|
| WS1 | SLSA verify-chain decouple | [`711599d`](../commit/711599d) |
| WS2 | `ComposerAdapter` contract + JSON Schema | [`51867a5`](../commit/51867a5) |
| WS3 | Composer-lifecycle signal ingestion | [`a9a115d`](../commit/a9a115d) |
| WS6 | Telemetry `event_type` column + composer counters | [`e2704e3`](../commit/e2704e3) |
| WS4 | `composer_intent` prediction source + invalidation | [`4037d8a`](../commit/4037d8a) |
| WS5 | Frontier source multiplier + work-style composer prior | [`dd3f559`](../commit/dd3f559) |
| WS8 | `Resolution.composer_event_id` + `composer_engagement` card field | [`b5a2286`](../commit/b5a2286) |
| WS7 | L0 Claude Code adapter (`UserPromptSubmit` hook + daemon route) | [`8398ff8`](../commit/8398ff8) |

## Hardening pass (post-WS commits)

Two independent review subagents found 2 critical / 4 high / 6 medium issues. All addressed:

- [`b79603a`](../commit/b79603a) **C1 + C2 + L4 + M2 + dead-code:** scrub pydantic `input` from error envelopes (defeats raw-text reflection); `text_hash` sha256-hex regex; ISO-8601 timestamp pattern; `emits` `min_length=1`; isinstance type-checks on adopt-card metadata; remove unused `ComposerEvent` envelope.
- [`9cfe122`](../commit/9cfe122) **H1 + M5 + M6:** `engine.observe()` persists before pump publish; pump snapshots subscribers once + `strict=True` zip; counter prefix `composer_*` → `composer_lifecycle_*`.
- [`f7962a2`](../commit/f7962a2) **M3 + L3 + WS8 fixtures:** translator `try/except BaseException → exit 0`; 3.8+ datetime compat; Rust `composer_intent_round_trips` test; new conformance fixtures `predictions_active_composer_sample.json` + `adopt_response_composer.json`.
- [`77bf0cd`](../commit/77bf0cd) **M1 docs:** three pieces of v0.8.7 plumbing have NO consumer in v0.8.7; documented loudly as v0.8.8 wiring gaps rather than removed.
- [`05aba4d`](../commit/05aba4d) **H2 + H3:** drop redundant text_hash from telemetry metadata + bucket length_chars (defeats short-prompt brute-force); race-safe migration catches duplicate-column.
- [`fd08f8b`](../commit/fd08f8b) **SQLite + Rust + cargo fmt:** `PRAGMA busy_timeout = 5000` for concurrent `initialize()`; Rust struct-init updates for new optional fields; `cargo fmt --all` (unblocks the rust workflow which has been red since 0.8.6).

## Privacy invariants

The contract is: **the raw draft text NEVER crosses the adapter boundary.**

Pinned at every layer:
- **Contract** (`tests/signals/composer/test_contract.py`): no field for `text`/`preview`/`draft_text`/`raw_text`; `text_hash` regex-pinned to sha256 hex.
- **Daemon** (`tests/test_daemon/test_signals_composer_endpoint.py`): error envelope sentinel test asserts the offending input value is never reflected back to the client.
- **Telemetry** (`tests/test_telemetry/test_draft_events_migration.py`): metadata carries `length_bucket` (coarse) not `length_chars` (exact); `text_hash` removed from telemetry surface (signal_events keeps it for audit).
- **Translator** (`tests/test_daemon/test_composer_submit_translator.py`): subprocess test asserts the raw prompt string never appears in the daemon-bound JSON.

## v0.8.8 wiring gaps (intentional)

Three pieces of v0.8.7 plumbing have NO consumer in v0.8.7 — documented loudly as data backbone:
1. `PredictionRun.compose_signal_strength` (no producer, no consumer)
2. `IntentPriorAdjustments.composer_signal_weight_multiplier` (populated per WorkStyle, never read by frontier)
3. `ComposerSignalPump` (publishes but no production subscriber)

Default-0/1.0/no-subscriber invariants preserve byte-identical engine behavior for default-config users (`mixed`-is-identity invariant from 0.8.6 WS4). v0.8.8 plugs in the consumer (composer signal → registry update → frontier scoring) without retro changes.

## Test plan

- [x] Pre-commit (all-files): clean
- [x] mypy (all 3 CI scopes): clean
- [x] pip-audit: no known vulnerabilities
- [x] actionlint: clean
- [x] AGENTS.md primer + plugin parity scripts: clean
- [x] Replay regression: pass
- [x] Full pytest suite: **1654 passed, 14 skipped**, 1 unrelated pre-existing failure (`test_post_policy_refresh_503_on_engine_exception` fails identically on `main`)
- [x] cargo fmt --all --check: clean (after `fd08f8b`)
- [x] cargo clippy --all-targets -D warnings: clean
- [x] cargo test (default + ts-rs + no-default-features): 9/9 passing
- [x] claude plugin validate: pass
- [x] moat-guard: clean

## Cross-repo (Borgels/vaner-docs)

- ✅ **PR #25** — ComposerAdapter integration docs page. Hold-merge until v0.8.7 ships.
- ✅ **Issue #26** — tracking the 5-page lychee exclusion removal (blocked on 0.8.6 docs PR merging + docs.vaner.ai redeploy).
- ⏸ Screenshots for 0.8.6 placeholder pages — deferred (Claude can't take UI captures from this env, user-blessed defer).

## Out of scope / explicitly deferred to v0.8.8

- Inline composer UI (Phase 3 — `Prepared` / `Preparing` pills)
- Real Level-1 adapters (true pre-submit draft lifecycle) — needs ecosystem partner
- `text_preview` / `local_text_ref` fields (need redaction module first)
- Cloud processing of unsent draft text (opt-in policy work)
- The three v0.8.8 wiring-gap consumers documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)