### PR TITLE
fix(release): loop gh attestation verify per artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,12 +177,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh attestation verify dist-assets/dist/* --repo "$GITHUB_REPOSITORY"
+          # 0.8.8 fix: the newer ``gh attestation verify`` CLI takes a
+          # SINGLE file path, not a glob. v0.8.7's release verify failed
+          # with "too many arguments" when the wildcard expanded to
+          # wheel + sdist. Loop one artifact at a time.
           provenance_file=""
           if compgen -G "provenance/*.intoto.jsonl" > /dev/null; then
             provenance_file="$(printf '%s\n' provenance/*.intoto.jsonl | head -n 1)"
           fi
           for artifact in dist-assets/dist/*; do
+            gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY"
             bundle="${artifact}.sigstore.json"
             cosign verify-blob --bundle "$bundle" "$artifact"
             if [ -n "$provenance_file" ]; then


### PR DESCRIPTION
## Summary

The newer `gh attestation verify` CLI takes a SINGLE file path, not a glob. v0.8.7's release.yml verify step failed with "too many arguments" when `dist-assets/dist/*` expanded to wheel + sdist.

Loop one artifact at a time, matching the cosign + slsa-verifier loops below. The release itself still ships when verify fails (the `publish` job uploads + signs everything before verify runs), but a green verify job is what lets the SLSA-3 chain claim hold post-release.

## Test plan

- [ ] Next release tag (v0.8.8) shows verify=success on the release.yml run
- [ ] gh attestation verify exits 0 per artifact
- [ ] cosign verify-blob + slsa-verifier loops unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)