### PR TITLE
docs: vaner-desktop-linux → vaner-desktop rename + Windows desktop coverage

### DIFF
--- a/crates/vaner-contract/README.md
+++ b/crates/vaner-contract/README.md
@@ -4,10 +4,11 @@ Cross-platform contract integration layer for Vaner desktop clients.
 
 This crate is consumed by:
 
-- The Linux Tauri app (`github.com/Borgels/vaner-linux`).
-- The future Windows Tauri app (same repo, different bundle target).
+- The cross-platform Tauri app (`github.com/Borgels/vaner-desktop`),
+  which builds Linux `.deb`/`.AppImage` and Windows `.exe` from one
+  codebase.
 
-The macOS SwiftUI app (`github.com/Borgels/vaner-desktop`) does **not** compile
+The macOS SwiftUI app (`github.com/Borgels/vaner-desktop-macos`) does **not** compile
 against this crate. It runs the same JSON conformance fixtures (published
 under `tests/conformance-fixtures/` in this monorepo) through its own
 `Codable` models, so spec drift between Swift and Rust fails CI on
@@ -32,12 +33,12 @@ whichever side has fallen behind.
 - `sse` — event stream (requires `http`).
 - `ts-rs` — emit TypeScript types for the SvelteKit frontend; run `cargo test --features ts-rs` to regenerate.
 
-## TypeScript bindings (Linux desktop consumption)
+## TypeScript bindings (Tauri desktop consumption)
 
-`vaner-desktop-linux` (the SvelteKit/Tauri app) consumes these types
-through `ts-rs`-generated TypeScript declarations. The bindings dir is
-**gitignored** at the workspace root — every consumer regenerates
-locally so the source of truth stays in Rust.
+`vaner-desktop` (the SvelteKit/Tauri app shared by Linux + Windows)
+consumes these types through `ts-rs`-generated TypeScript declarations.
+The bindings dir is **gitignored** at the workspace root — every
+consumer regenerates locally so the source of truth stays in Rust.
 
 ### Regenerate
 
@@ -54,14 +55,14 @@ cargo run --example export_bindings --features ts-rs --package vaner-contract
 
 Both paths emit the same files; pick whichever suits your tooling.
 
-### Consume from `vaner-desktop-linux`
+### Consume from `vaner-desktop`
 
-The Linux desktop's preferred pattern is to copy or symlink
+The Tauri desktop's preferred pattern is to copy or symlink
 `crates/vaner-contract/bindings/` into its own `src/lib/contract/`
 tree at build time. A typical Tauri pre-build script:
 
 ```sh
-# In vaner-desktop-linux's package.json `scripts.predev` /
+# In vaner-desktop's package.json `scripts.predev` /
 # `scripts.prebuild`:
 cargo run --example export_bindings --features ts-rs \
   --manifest-path ../Vaner/Cargo.toml --package vaner-contract
@@ -70,14 +71,14 @@ rsync -a ../Vaner/crates/vaner-contract/bindings/ src/lib/contract/
 
 Don't commit the copy; treat it as a generated artefact. The CI step
 `test (ts-rs feature)` in `rust.yml` regenerates on every push and
-fails the build if any annotated type can't export, so the Linux side
+fails the build if any annotated type can't export, so the Tauri side
 gets a clean cross-repo signal when a contract change lands.
 
 ### macOS does NOT consume these bindings
 
 `vaner-desktop-macos` (Swift) compiles its own `Codable` mirrors and
 runs the same conformance fixtures from `tests/conformance-fixtures/`.
-The bindings dir is irrelevant to the macOS build — Linux-desktop-only.
+The bindings dir is irrelevant to the macOS build — Tauri-desktop-only.
 
 ### When new public types are added
 

--- a/plugins/vaner/skills/next/SKILL.md
+++ b/plugins/vaner/skills/next/SKILL.md
@@ -5,7 +5,7 @@ description: Show the top candidate next moves Vaner has prepared context for. U
 
 When the user invokes `/vaner:next`, surface the most-ready next candidates Vaner has prepared:
 
-0. **First, check the desktop handoff file.** The Vaner desktop apps (`vaner-desktop-macos`, `vaner-desktop-linux`) drop the full `Resolution` of an adopted prediction at a well-known path when the user clicks **Adopt**. If that's what happened, the user has already picked a candidate — inject it and skip the listing step.
+0. **First, check the desktop handoff file.** The Vaner desktop apps (`vaner-desktop-macos`, `vaner-desktop` for Linux + Windows) drop the full `Resolution` of an adopted prediction at a well-known path when the user clicks **Adopt**. If that's what happened, the user has already picked a candidate — inject it and skip the listing step.
 
    - Look for the handoff file at:
      - Linux: `$XDG_STATE_HOME/vaner/pending-adopt.json` (fall back to `~/.local/state/vaner/pending-adopt.json` when unset).


### PR DESCRIPTION
## Summary

The Tauri desktop repo (`vaner-desktop-linux`) was renamed to `vaner-desktop` and now ships a Windows NSIS bundle alongside the Linux `.deb` / `.AppImage` from one tag. See [Borgels/vaner-desktop#4](https://github.com/Borgels/vaner-desktop/pull/4).

This PR updates the cross-references in the main Vaner repo:

- `crates/vaner-contract/README.md` — drop the "future Windows app" qualifier; rename `vaner-linux` / `vaner-desktop-linux` → `vaner-desktop`; correct the macOS repo link to `vaner-desktop-macos`.
- `plugins/vaner/skills/next/SKILL.md` — the desktop handoff list now names `vaner-desktop` for Linux + Windows.

No code changes; documentation only.

## Test plan

- [x] No code references to the old repo names remain in active docs.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)