### PR TITLE
fix: harden config and MCP contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,10 @@ jobs:
         run: pytest tests -m "not slow and not integration"
       - name: Tests (windows)
         if: matrix.test-kind == 'windows'
-        # Keep a lightweight Windows signal until asyncio/CLI teardown flakes are stabilized.
+          # Keep a lightweight Windows signal until asyncio/CLI teardown
+          # flakes are stabilized. This is intentionally a compatibility
+          # signal rather than the required full-suite gate; see
+          # CONTRIBUTING.md for the local/CI test matrix.
         run: |
           pytest tests/test_api.py tests/test_broker tests/test_policy tests/test_store -p no:randomly
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Vaner is a local-first predictive context engine for coding assistants.
 
 ## Core packages
 
-- `src/vaner/engine/`: orchestration and runtime loop
+- `src/vaner/engine.py`: orchestration and runtime loop
 - `src/vaner/intent/`: prediction, scoring, and frontier state
 - `src/vaner/store/`: persistence and retrieval for artefacts/signals
 - `src/vaner/broker/`: context selection and package assembly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,18 +27,39 @@ Local contributor checks:
 ```bash
 ruff check .
 ruff format --check .
-mypy src
-pytest
+# CI currently runs a curated mypy scope from `.github/workflows/ci.yml`.
+# `mypy src` is useful locally when tightening types, but it is broader than
+# the required merge gate.
+mypy src/vaner/__init__.py src/vaner/server.py src/vaner/cli/main.py
+pytest tests -m "not slow and not integration"
 pre-commit run --all-files
+```
+
+`slow` and `integration` tests are opt-in locally because they may need external
+services or longer-running model/runtime setup. Run them explicitly when your
+change touches those paths:
+
+```bash
+pytest tests -m slow
+pytest tests -m integration
 ```
 
 CI checks on pull requests and pushes:
 
 - Lint and formatting checks
 - Type checking
-- Automated test suite (`pytest`)
+- Automated test suite (`pytest tests -m "not slow and not integration"`)
 - Pre-commit hooks
 - Security checks such as `pip-audit`
+
+Compatibility CI also runs a Linux/macOS matrix plus a lightweight Windows
+subset. The Windows job is a signal while CLI/async teardown behavior is being
+stabilized, not the full required test gate.
+
+Release builds run from the release workflow's pinned Python version, currently
+Python 3.11, while the primary quality job runs on Python 3.12 and compatibility
+adds Python 3.11/3.13 signals. Rust contract checks are path-gated to
+`Cargo.toml`, `crates/**`, conformance fixtures, and the Rust workflow itself.
 
 Pull requests are expected to pass required CI checks before merge.
 
@@ -95,7 +116,7 @@ Run checks before opening a PR:
 ruff check .
 ruff format --check .
 mypy src
-pytest
+pytest tests -m "not slow and not integration"
 pre-commit run --all-files
 ```
 

--- a/crates/vaner-contract/src/handoff.rs
+++ b/crates/vaner-contract/src/handoff.rs
@@ -172,6 +172,7 @@ mod tests {
             briefing_token_used: 100,
             briefing_token_budget: 2048,
             adopted_from_prediction_id: Some("p-1".into()),
+            context_envelope: None,
             alternatives_considered: vec![],
             gaps: vec![],
             next_actions: vec![],

--- a/crates/vaner-contract/src/lib.rs
+++ b/crates/vaner-contract/src/lib.rs
@@ -41,8 +41,8 @@ pub use enums::{EtaBucket, HypothesisType, PredictionSource, Readiness, Specific
 pub use errors::EngineClientError;
 pub use handoff::{AdoptHandoffError, handoff_path, stash_adopt};
 pub use models::{
-    EngineStatus, PredictedPrompt, PredictionArtifacts, PredictionRun, PredictionSpec, Provenance,
-    Resolution, ResolutionAlternative, ResolutionEvidence,
+    ContextEnvelope, EngineStatus, PredictedPrompt, PredictionArtifacts, PredictionRun,
+    PredictionSpec, Provenance, Resolution, ResolutionAlternative, ResolutionEvidence,
 };
 pub use reducer::{ReducerInputs, VanerState, reduce};
 pub use setup::{

--- a/crates/vaner-contract/src/models.rs
+++ b/crates/vaner-contract/src/models.rs
@@ -56,6 +56,19 @@ pub struct PredictedPrompt {
     pub suppression_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_label: Option<String>,
+    /// Additive trust/freshness metadata for prediction cards.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invalidated_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub watched_sources: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_sources: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic_status: Option<String>,
     /// 0.8.7 WS8: present when the prediction is anchored to a live
     /// composer session. Lets host UIs render draft-derived predictions
     /// distinctly (without hard-coding `source == ComposerIntent`).
@@ -158,6 +171,8 @@ pub struct Resolution {
     pub briefing_token_budget: u64,
     #[serde(default)]
     pub adopted_from_prediction_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_envelope: Option<ContextEnvelope>,
     /// 0.8.0 WS8: populated by `resolve_query`; empty on the adopt path.
     #[serde(default)]
     pub alternatives_considered: Vec<ResolutionAlternative>,
@@ -181,8 +196,41 @@ pub struct ResolutionEvidence {
     pub id: Option<String>,
     #[serde(default)]
     pub source: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locator: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overlay: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captured_at: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validated_at: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(TS), ts(export))]
+pub struct ContextEnvelope {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_artifact: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selection: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recent_queries: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_goal: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/vaner-contract/src/reducer.rs
+++ b/crates/vaner-contract/src/reducer.rs
@@ -154,6 +154,12 @@ mod tests {
             ui_summary: None,
             suppression_reason: None,
             source_label: None,
+            trust_status: None,
+            freshness: None,
+            invalidated_by: vec![],
+            watched_sources: vec![],
+            changed_sources: vec![],
+            diagnostic_status: None,
             composer_engagement: None,
         }
     }

--- a/crates/vaner-contract/tests/conformance.rs
+++ b/crates/vaner-contract/tests/conformance.rs
@@ -64,6 +64,14 @@ fn predictions_active_envelope_decodes() {
     );
     assert_eq!(ready.suppression_reason, None);
     assert_eq!(ready.source_label.as_deref(), Some("Arc"));
+    assert_eq!(ready.trust_status.as_deref(), Some("ready"));
+    assert_eq!(ready.freshness.as_deref(), Some("fresh"));
+    assert_eq!(
+        ready.watched_sources,
+        vec!["payments-svc/webhook.js".to_string()]
+    );
+    assert!(ready.changed_sources.is_empty());
+    assert!(ready.invalidated_by.is_empty());
 
     let goal = &envelope.predictions[1];
     assert_eq!(goal.spec.source, PredictionSource::Goal);
@@ -99,6 +107,7 @@ fn predictions_single_decodes() {
     assert_eq!(prediction.eta_bucket, Some(EtaBucket::ReadyNow));
     assert_eq!(prediction.rank, Some(1));
     assert_eq!(prediction.adoptable, Some(true));
+    assert_eq!(prediction.trust_status.as_deref(), Some("ready"));
 }
 
 #[test]
@@ -115,6 +124,18 @@ fn adopt_rich_response_decodes_including_ws8_fields() {
     assert_eq!(resolution.provenance.mode, "predictive_hit");
     assert!(resolution.prepared_briefing.as_deref().is_some());
     assert!(resolution.predicted_response.as_deref().is_some());
+    assert_eq!(
+        resolution
+            .context_envelope
+            .as_ref()
+            .and_then(|c| c.domain.as_deref()),
+        Some("code")
+    );
+    assert_eq!(
+        resolution.evidence[0].overlay.as_deref(),
+        Some("working_tree")
+    );
+    assert_eq!(resolution.evidence[0].freshness.as_deref(), Some("fresh"));
 
     // WS8 additive fields (0.8.0) — populated only on the rich sample.
     assert_eq!(resolution.alternatives_considered.len(), 1);

--- a/docs/0.8.6-gap-analysis.md
+++ b/docs/0.8.6-gap-analysis.md
@@ -1,5 +1,9 @@
 # 0.8.6 Hardening + Gap Analysis
 
+Historical note: this document is a point-in-time release hardening record for
+0.8.6. Treat `CHANGELOG.md`, `README.md`, and the current source/tests as the
+authoritative references for present behavior.
+
 ## Final stack
 
 ```

--- a/docs/mcp-migration.md
+++ b/docs/mcp-migration.md
@@ -1,6 +1,10 @@
 # MCP v1.0 Migration
 
-Vaner MCP v1.0 is a breaking rewrite from the legacy 5-tool scenario API to a 10-tool predictive context surface with explicit confidence, provenance, gaps, and memory metadata.
+Vaner MCP v1.0 started as a breaking rewrite from the legacy 5-tool scenario API
+to a 10-tool predictive context surface with explicit confidence, provenance,
+gaps, and memory metadata. The live tool surface has grown since then; use
+`tools/list` from `src/vaner/mcp/server.py` as the source of truth for current
+names.
 
 - `list_scenarios` -> `vaner.status` plus `vaner.resolve`
 - `get_scenario` -> `vaner.resolve` (query) or `vaner.inspect` (by id)
@@ -33,11 +37,11 @@ The resolve tool returns `evidence` pointers and a 400-char `summary` by default
 That's shape-compatible with naive RAG responses. To receive the richer output
 Vaner actually assembles internally, pass one or both of these flags:
 
-- `include_briefing: bool` (default `false`) — adds `prepared_briefing` to the
+- `include_briefing: bool` (default `true`) — adds `prepared_briefing` to the
   response: the full formatted markdown of pre-compiled artefact summaries.
   Accompanied by `briefing_token_used` + `briefing_token_budget` for sizing the
   downstream prompt.
-- `include_predicted_response: bool` (default `false`) — adds `predicted_response`
+- `include_predicted_response: bool` (default `true`) — adds `predicted_response`
   when a draft answer was speculatively cached during precompute (null when
   none is available).
 - `include_metrics: bool` (default `false`) — adds a `metrics` object to the
@@ -47,4 +51,6 @@ Vaner actually assembles internally, pass one or both of these flags:
   Pair with the optional `estimated_cost_per_1k_tokens` request field (e.g.
   `2.50` for gpt-4o input pricing) to get a dollar estimate per resolve call.
 
-All three flags are additive; default callers see the legacy shape unchanged.
+`include_metrics` is additive. Briefing and predicted-response fields are now
+included by default for parity with the daemon HTTP `/resolve` surface; callers
+that need the lean legacy shape can pass either include flag as `false`.

--- a/docs/memory-semantics.md
+++ b/docs/memory-semantics.md
@@ -16,7 +16,8 @@ Memory does not auto-promote on every `useful` feedback. Promotion to `trusted` 
 - explicit pin intent (`preferred_items`)
 - repeated useful outcomes (`>= 2` streak)
 - high confidence + multi-evidence + low contradiction
-- correction later confirmed by useful feedback
+- correction later confirmed by useful feedback (a previously wrong candidate
+  receives later `useful` feedback)
 
 `partial` keeps candidate memory, `wrong`/`irrelevant` drive demotion or staleness.
 

--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -1974,6 +1974,41 @@ def doctor(
             "fix": "Run `vaner up --path .` (or `vaner daemon start --path . --no-once`).",
         }
     )
+    try:
+        status_response = httpx.get(f"{cockpit_url.rstrip('/')}/status", timeout=1.5)
+        status_response.raise_for_status()
+        status_payload = status_response.json()
+        prediction_health = status_payload.get("prediction_health", {}) if isinstance(status_payload, dict) else {}
+        active_predictions = int(prediction_health.get("active_prediction_count", 0) or 0)
+        engine_available = bool(prediction_health.get("engine_available", False))
+        checks.append(
+            {
+                "name": "prediction_engine_available",
+                "ok": engine_available,
+                "level": "warn" if not engine_available else "pass",
+                "detail": prediction_health.get("diagnostic_status", "unknown"),
+                "fix": "Start the daemon with `vaner daemon serve-http --with-engine` so predictions can mature.",
+            }
+        )
+        checks.append(
+            {
+                "name": "active_predictions_present",
+                "ok": active_predictions > 0,
+                "level": "warn" if active_predictions == 0 else "pass",
+                "detail": f"active={active_predictions} readiness={prediction_health.get('readiness_counts', {})}",
+                "fix": "Let a precompute cycle run, submit a composer signal, or check stale evidence/invalidation diagnostics.",
+            }
+        )
+    except Exception as exc:
+        checks.append(
+            {
+                "name": "prediction_health_status",
+                "ok": False,
+                "level": "warn",
+                "detail": str(exc),
+                "fix": "Start the HTTP daemon and retry `vaner doctor`.",
+            }
+        )
 
     cursor_mcp_path = repo_root / ".cursor" / "mcp.json"
     claude_mcp_path = Path.home() / ".claude" / "claude_desktop_config.json"

--- a/src/vaner/cli/commands/config.py
+++ b/src/vaner/cli/commands/config.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
 
 from vaner.models.config import (
     BackendConfig,
@@ -14,12 +17,20 @@ from vaner.models.config import (
     ExplorationConfig,
     GatewayConfig,
     GenerationConfig,
+    IntegrationsConfig,
     IntentConfig,
     MCPConfig,
+    PolicyConfig,
     PrivacyConfig,
     ProxyConfig,
+    RefinementConfig,
+    SetupConfig,
+    SourcesConfig,
     VanerConfig,
 )
+
+logger = logging.getLogger(__name__)
+ConfigModelT = TypeVar("ConfigModelT", bound=BaseModel)
 
 
 def global_config_path() -> Path:
@@ -34,8 +45,42 @@ def _load_toml_if_exists(path: Path) -> dict[str, object]:
         return {}
     try:
         return tomllib.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning("Ignoring invalid Vaner config TOML at %s: %s", path, exc)
         return {}
+    except OSError as exc:
+        logger.warning("Unable to read Vaner config at %s: %s", path, exc)
+        return {}
+
+
+def _section_dict(parsed: dict[str, object], section_name: str) -> dict[str, object]:
+    section = parsed.get(section_name, {})
+    return section if isinstance(section, dict) else {}
+
+
+def _build_section(
+    model: type[ConfigModelT],
+    section_name: str,
+    section: object,
+) -> ConfigModelT:
+    if not isinstance(section, dict):
+        return model()
+    try:
+        return model(**section)
+    except ValidationError as exc:
+        logger.warning("Ignoring invalid Vaner config section [%s]: %s", section_name, exc)
+        return model()
+
+
+def _coerce_limit(limits_section: object, key: str, default: int) -> int:
+    if not isinstance(limits_section, dict):
+        return default
+    raw = limits_section.get(key, default)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid Vaner config value [limits].%s=%r; using %s", key, raw, default)
+        return default
 
 
 def load_config(repo_root: Path) -> VanerConfig:
@@ -51,21 +96,26 @@ def load_config(repo_root: Path) -> VanerConfig:
         else:
             parsed[key] = value
 
-    backend_section = parsed.get("backend", {})
-    generation_section = parsed.get("generation", {})
-    privacy_section = parsed.get("privacy", {})
-    proxy_section = parsed.get("proxy", {})
-    gateway_section = parsed.get("gateway", {})
-    mcp_section = parsed.get("mcp", {})
-    intent_section = parsed.get("intent", {})
-    compute_section = parsed.get("compute", {})
-    exploration_section = parsed.get("exploration", {})
-    limits_section = parsed.get("limits", {})
+    backend_section = _section_dict(parsed, "backend")
+    generation_section = _section_dict(parsed, "generation")
+    privacy_section = _section_dict(parsed, "privacy")
+    proxy_section = _section_dict(parsed, "proxy")
+    gateway_section = _section_dict(parsed, "gateway")
+    mcp_section = _section_dict(parsed, "mcp")
+    intent_section = _section_dict(parsed, "intent")
+    compute_section = _section_dict(parsed, "compute")
+    exploration_section = _section_dict(parsed, "exploration")
+    sources_section = _section_dict(parsed, "sources")
+    refinement_section = _section_dict(parsed, "refinement")
+    integrations_section = _section_dict(parsed, "integrations")
+    setup_section = _section_dict(parsed, "setup")
+    policy_section = _section_dict(parsed, "policy")
+    limits_section = _section_dict(parsed, "limits")
 
-    backend = BackendConfig(**backend_section) if isinstance(backend_section, dict) else BackendConfig()
-    privacy = PrivacyConfig(**privacy_section) if isinstance(privacy_section, dict) else PrivacyConfig()
-    generation = GenerationConfig(**generation_section) if isinstance(generation_section, dict) else GenerationConfig()
-    proxy = ProxyConfig(**proxy_section) if isinstance(proxy_section, dict) else ProxyConfig()
+    backend = _build_section(BackendConfig, "backend", backend_section)
+    privacy = _build_section(PrivacyConfig, "privacy", privacy_section)
+    generation = _build_section(GenerationConfig, "generation", generation_section)
+    proxy = _build_section(ProxyConfig, "proxy", proxy_section)
     if isinstance(gateway_section, dict):
         passthrough_section = gateway_section.get("passthrough", {})
         annotate_section = gateway_section.get("annotate", {})
@@ -85,7 +135,7 @@ def load_config(repo_root: Path) -> VanerConfig:
         )
     else:
         gateway = GatewayConfig()
-    mcp = MCPConfig(**mcp_section) if isinstance(mcp_section, dict) else MCPConfig()
+    mcp = _build_section(MCPConfig, "mcp", mcp_section)
     if isinstance(intent_section, dict):
         skills_loop_section = intent_section.get("skills_loop", {})
         skill_roots = intent_section.get("skill_roots", [".cursor/skills", ".claude/skills", "skills"])
@@ -108,7 +158,7 @@ def load_config(repo_root: Path) -> VanerConfig:
         )
     else:
         intent = IntentConfig()
-    compute = ComputeConfig(**compute_section) if isinstance(compute_section, dict) else ComputeConfig()
+    compute = _build_section(ComputeConfig, "compute", compute_section)
     if isinstance(exploration_section, dict):
         mapped_exploration = {
             "exploration_endpoint": exploration_section.get("endpoint", ""),
@@ -120,9 +170,14 @@ def load_config(repo_root: Path) -> VanerConfig:
         exploration = ExplorationConfig(**mapped_exploration)
     else:
         exploration = ExplorationConfig()
+    sources = _build_section(SourcesConfig, "sources", sources_section)
+    refinement = _build_section(RefinementConfig, "refinement", refinement_section)
+    integrations = _build_section(IntegrationsConfig, "integrations", integrations_section)
+    setup = _build_section(SetupConfig, "setup", setup_section)
+    policy = _build_section(PolicyConfig, "policy", policy_section)
 
-    max_age_seconds = int(limits_section.get("max_age_seconds", 3600)) if isinstance(limits_section, dict) else 3600
-    max_context_tokens = int(limits_section.get("max_context_tokens", 4096)) if isinstance(limits_section, dict) else 4096
+    max_age_seconds = _coerce_limit(limits_section, "max_age_seconds", 3600)
+    max_context_tokens = _coerce_limit(limits_section, "max_context_tokens", 4096)
 
     store_path = repo_root / ".vaner" / "store.db"
     telemetry_path = repo_root / ".vaner" / "telemetry.db"
@@ -141,6 +196,11 @@ def load_config(repo_root: Path) -> VanerConfig:
         intent=intent,
         compute=compute,
         exploration=exploration,
+        sources=sources,
+        refinement=refinement,
+        integrations=integrations,
+        setup=setup,
+        policy=policy,
     )
 
 

--- a/src/vaner/cli/commands/integrations.py
+++ b/src/vaner/cli/commands/integrations.py
@@ -157,6 +157,7 @@ def _probe_daemon(url: str) -> dict[str, Any]:
         "reachable": True,
         "url": status["url"],
         "status": status.get("payload", status.get("status", "ok")),
+        "prediction_health": (status.get("payload") or {}).get("prediction_health", {}) if isinstance(status.get("payload"), dict) else {},
         "guidance_endpoint_ok": guidance_ok,
     }
 
@@ -245,6 +246,13 @@ def _render_pretty(report: dict[str, Any]) -> None:
     daemon = report["daemon"]
     if daemon["reachable"]:
         console.print(f"Daemon: [green]reachable[/green]  guidance endpoint: {'ok' if daemon['guidance_endpoint_ok'] else 'FAIL'}")
+        prediction_health = daemon.get("prediction_health") or {}
+        if prediction_health:
+            console.print(
+                "Prediction health: "
+                f"{prediction_health.get('diagnostic_status', 'unknown')} "
+                f"(active={prediction_health.get('active_prediction_count', 0)})"
+            )
     else:
         console.print(f"Daemon: [red]unreachable[/red]  ({daemon.get('error', 'unknown')})")
     handoff = report["handoff"]

--- a/src/vaner/cli/commands/integrations.py
+++ b/src/vaner/cli/commands/integrations.py
@@ -15,6 +15,12 @@ from rich.console import Console
 from rich.table import Table
 
 from vaner.cli.commands.config import load_config
+from vaner.clients.daemon import (
+    DAEMON_PROBE_TIMEOUT,
+    DEFAULT_BASE_URL,
+    daemon_base_url_from_env,
+    probe_daemon_status,
+)
 from vaner.integrations.guidance import current_version, load_guidance
 
 integrations_app = typer.Typer(
@@ -22,7 +28,7 @@ integrations_app = typer.Typer(
     no_args_is_help=True,
 )
 
-_DAEMON_URL = "http://127.0.0.1:8473"
+_DAEMON_URL = daemon_base_url_from_env(DEFAULT_BASE_URL)
 
 
 @integrations_app.command("doctor", help="Run the integration-layer health check.")
@@ -138,20 +144,21 @@ def _check_primer_parity(agents_md: Path) -> dict[str, Any]:
 
 
 def _probe_daemon(url: str) -> dict[str, Any]:
-    try:
-        with httpx.Client(timeout=1.5) as client:
-            resp = client.get(f"{url}/health")
-            resp.raise_for_status()
-            guidance_resp = client.get(f"{url}/integrations/guidance")
+    with httpx.Client(timeout=DAEMON_PROBE_TIMEOUT) as client:
+        status = probe_daemon_status(url, client=client)
+        if not status.get("reachable"):
+            return status
+        try:
+            guidance_resp = client.get(f"{url.rstrip('/')}/integrations/guidance")
             guidance_ok = guidance_resp.status_code == 200
-            return {
-                "reachable": True,
-                "url": url,
-                "health": resp.json() if resp.headers.get("content-type", "").startswith("application/json") else "ok",
-                "guidance_endpoint_ok": guidance_ok,
-            }
-    except httpx.HTTPError as exc:
-        return {"reachable": False, "url": url, "error": f"{type(exc).__name__}: {exc}"}
+        except httpx.HTTPError as exc:
+            return {"reachable": False, "url": url, "error": f"{type(exc).__name__}: {exc}"}
+    return {
+        "reachable": True,
+        "url": status["url"],
+        "status": status.get("payload", status.get("status", "ok")),
+        "guidance_endpoint_ok": guidance_ok,
+    }
 
 
 def _probe_handoff(repo_root: Path) -> dict[str, Any]:

--- a/src/vaner/cli/commands/setup.py
+++ b/src/vaner/cli/commands/setup.py
@@ -38,12 +38,10 @@ import os
 import shutil
 import subprocess
 import sys
-import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any
 
-import httpx
 import typer
 from rich.console import Console
 from rich.panel import Panel
@@ -51,6 +49,7 @@ from rich.table import Table
 
 from vaner.cli.commands.config import load_config
 from vaner.cli.commands.init import init_repo
+from vaner.clients.daemon import DEFAULT_BASE_URL, daemon_base_url_from_env, probe_daemon_status
 from vaner.setup.answers import SetupAnswers
 from vaner.setup.apply import (
     WIDENS_CLOUD_POSTURE_SENTINEL,
@@ -58,6 +57,13 @@ from vaner.setup.apply import (
     apply_policy_bundle,
 )
 from vaner.setup.catalog import bundle_by_id
+from vaner.setup.config_io import (
+    persist_setup_and_policy,
+    read_policy_section,
+    read_setup_section,
+    toml_literal,
+    update_toml_section,
+)
 from vaner.setup.hardware import HardwareProfile, detect
 from vaner.setup.select import SelectionResult, select_policy_bundle
 from vaner.setup.serializers import (
@@ -74,7 +80,7 @@ setup_app = typer.Typer(
 )
 
 _console = Console()
-_DAEMON_URL = "http://127.0.0.1:8473"
+_DAEMON_URL = DEFAULT_BASE_URL
 
 # ---------------------------------------------------------------------------
 # Path / config helpers
@@ -102,29 +108,13 @@ def _read_setup_section(repo_root: Path) -> dict[str, Any]:
     Returns an empty dict when the file or section is absent.
     """
 
-    config_path = repo_root / ".vaner" / "config.toml"
-    if not config_path.exists():
-        return {}
-    try:
-        parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
-    section = parsed.get("setup", {})
-    return section if isinstance(section, dict) else {}
+    return read_setup_section(repo_root)
 
 
 def _read_policy_section(repo_root: Path) -> dict[str, Any]:
     """Read the raw ``[policy]`` table from ``.vaner/config.toml``."""
 
-    config_path = repo_root / ".vaner" / "config.toml"
-    if not config_path.exists():
-        return {}
-    try:
-        parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
-    section = parsed.get("policy", {})
-    return section if isinstance(section, dict) else {}
+    return read_policy_section(repo_root)
 
 
 def _toml_literal(value: object) -> str:
@@ -136,23 +126,7 @@ def _toml_literal(value: object) -> str:
     arrays — not the JSON-string the init helper would emit.
     """
 
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, (int, float)):
-        return str(value)
-    if value is None:
-        return '""'
-    if isinstance(value, list):
-        items = []
-        for item in value:
-            if isinstance(item, str):
-                escaped = item.replace("\\", "\\\\").replace('"', '\\"')
-                items.append(f'"{escaped}"')
-            else:
-                items.append(_toml_literal(item))
-        return "[" + ", ".join(items) + "]"
-    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
+    return toml_literal(value)
 
 
 def _update_section(text: str, section: str, values: dict[str, object]) -> str:
@@ -163,43 +137,7 @@ def _update_section(text: str, section: str, values: dict[str, object]) -> str:
     matches the shape the wizard writes.
     """
 
-    if not values:
-        return text
-    lines = text.splitlines()
-    header = f"[{section}]"
-    start: int | None = None
-    for idx, line in enumerate(lines):
-        if line.strip() == header:
-            start = idx
-            break
-    if start is None:
-        lines.append("")
-        lines.append(header)
-        for key, val in values.items():
-            lines.append(f"{key} = {_toml_literal(val)}")
-        return "\n".join(lines) + ("\n" if not text.endswith("\n") else "")
-
-    end = len(lines)
-    for idx in range(start + 1, len(lines)):
-        stripped = lines[idx].strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            end = idx
-            break
-    remaining = dict(values)
-    for idx in range(start + 1, end):
-        stripped = lines[idx].lstrip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        key = stripped.split("=", 1)[0].strip()
-        if key in remaining:
-            lines[idx] = f"{key} = {_toml_literal(remaining.pop(key))}"
-    if remaining:
-        insert_at = end
-        for key, val in remaining.items():
-            lines.insert(insert_at, f"{key} = {_toml_literal(val)}")
-            insert_at += 1
-    out = "\n".join(lines)
-    return out + ("\n" if not out.endswith("\n") else "")
+    return update_toml_section(text, section, values)
 
 
 def _persist_setup_and_policy(
@@ -216,27 +154,7 @@ def _persist_setup_and_policy(
     responsible for any user confirmation upstream.
     """
 
-    config_path = init_repo(repo_root)
-    text = config_path.read_text(encoding="utf-8")
-    setup_values: dict[str, object] = {
-        "mode": "simple",
-        "work_styles": list(answers.work_styles),
-        "priority": answers.priority,
-        "compute_posture": answers.compute_posture,
-        "cloud_posture": answers.cloud_posture,
-        "background_posture": answers.background_posture,
-        "version": 1,
-    }
-    if completed_at is not None:
-        setup_values["completed_at"] = completed_at.isoformat()
-    text = _update_section(text, "setup", setup_values)
-    text = _update_section(
-        text,
-        "policy",
-        {"selected_bundle_id": bundle_id, "auto_select": True},
-    )
-    config_path.write_text(text, encoding="utf-8")
-    return config_path
+    return persist_setup_and_policy(repo_root, answers, bundle_id, completed_at=completed_at)
 
 
 # ---------------------------------------------------------------------------
@@ -597,8 +515,8 @@ def wizard_cmd(
 
     config = load_config(repo_root)
     # Reflect the on-disk previous bundle id into the runtime config so
-    # the cloud-widening guard fires correctly. ``load_config`` does
-    # not yet re-read ``[policy]`` so we patch it from the raw section.
+    # the cloud-widening guard fires correctly even for caller-constructed
+    # configs that were not hydrated through load_config().
     prior_policy_section = _read_policy_section(repo_root)
     prior_bundle_id = prior_policy_section.get("selected_bundle_id")
     if isinstance(prior_bundle_id, str) and prior_bundle_id:
@@ -1013,7 +931,7 @@ def hardware_cmd(
 # ---------------------------------------------------------------------------
 
 
-def _ping_daemon_for_refresh() -> dict[str, Any]:
+def _ping_daemon_for_refresh(base_url: str | None = None) -> dict[str, Any]:
     """Best-effort liveness probe of the local daemon HTTP surface.
 
     Returns a dict suitable for JSON output. The daemon currently has
@@ -1023,26 +941,10 @@ def _ping_daemon_for_refresh() -> dict[str, Any]:
     config writes propagate without a daemon restart.
     """
 
-    try:
-        with httpx.Client(timeout=1.0) as client:
-            resp = client.get(f"{_DAEMON_URL}/status")
-            if resp.status_code == 200:
-                return {
-                    "reachable": True,
-                    "url": _DAEMON_URL,
-                    "note": "daemon will pick up changes on next config reload",
-                }
-            return {
-                "reachable": False,
-                "url": _DAEMON_URL,
-                "status_code": resp.status_code,
-            }
-    except (httpx.HTTPError, OSError) as exc:
-        return {
-            "reachable": False,
-            "url": _DAEMON_URL,
-            "error": f"{type(exc).__name__}: {exc}",
-        }
+    result = probe_daemon_status(base_url or daemon_base_url_from_env(_DAEMON_URL))
+    if result.get("reachable"):
+        result["note"] = "daemon will pick up changes on next config reload"
+    return result
 
 
 # Defensive: keep ``dataclasses`` imported even if unused above so that

--- a/src/vaner/clients/daemon.py
+++ b/src/vaner/clients/daemon.py
@@ -24,6 +24,7 @@ from "daemon rejected the request". Fire-and-forget style callers
 
 from __future__ import annotations
 
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -34,6 +35,16 @@ from vaner.mcp.contracts import Resolution
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8473"
 DEFAULT_TIMEOUT = 5.0
+DAEMON_STATUS_PATH = "/status"
+DAEMON_PROBE_TIMEOUT = 1.0
+RESOLVE_INCLUDE_BRIEFING_DEFAULT = True
+RESOLVE_INCLUDE_PREDICTED_RESPONSE_DEFAULT = True
+
+
+def daemon_base_url_from_env(default: str = DEFAULT_BASE_URL) -> str:
+    """Return the configured daemon HTTP base URL for CLI-style callers."""
+
+    return os.environ.get("VANER_DAEMON_URL", "").strip() or default
 
 
 class VanerDaemonError(Exception):
@@ -93,7 +104,7 @@ class VanerDaemonClient:
         """GET /status — returns the daemon's health + config snapshot."""
         async with self._session() as client:
             try:
-                response = await client.get(f"{self._base}/status")
+                response = await client.get(f"{self._base}{DAEMON_STATUS_PATH}")
             except (httpx.TransportError, httpx.TimeoutException) as exc:
                 raise VanerDaemonUnavailable(f"daemon unreachable at {self._base}: {exc}") from exc
             if response.status_code >= 500:
@@ -192,8 +203,8 @@ class VanerDaemonClient:
         query: str,
         *,
         context: dict[str, Any] | None = None,
-        include_briefing: bool = False,
-        include_predicted_response: bool = False,
+        include_briefing: bool = RESOLVE_INCLUDE_BRIEFING_DEFAULT,
+        include_predicted_response: bool = RESOLVE_INCLUDE_PREDICTED_RESPONSE_DEFAULT,
     ) -> Resolution:
         """POST /resolve — forward a query to the daemon's engine.resolve_query.
 
@@ -236,3 +247,36 @@ class VanerDaemonClient:
                 raise VanerDaemonUnavailable(f"daemon returned {response.status_code}")
             response.raise_for_status()
             return Resolution.model_validate(response.json())
+
+
+def probe_daemon_status(
+    base_url: str = DEFAULT_BASE_URL,
+    *,
+    timeout: float = DAEMON_PROBE_TIMEOUT,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Best-effort synchronous daemon reachability probe for CLI commands."""
+
+    base = base_url.rstrip("/")
+
+    def _probe(active_client: httpx.Client) -> dict[str, Any]:
+        try:
+            response = active_client.get(f"{base}{DAEMON_STATUS_PATH}")
+        except (httpx.HTTPError, OSError) as exc:
+            return {"reachable": False, "url": base, "error": str(exc)}
+        if response.status_code == 200:
+            payload: dict[str, Any] | None
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = None
+            result: dict[str, Any] = {"reachable": True, "url": base, "status": "ok"}
+            if payload is not None:
+                result["payload"] = payload
+            return result
+        return {"reachable": False, "url": base, "status_code": response.status_code}
+
+    if client is not None:
+        return _probe(client)
+    with httpx.Client(timeout=timeout) as active_client:
+        return _probe(active_client)

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -250,20 +250,17 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         read — no side effects.
         """
 
-        from vaner.cli.commands.setup import (
-            _default_answers,
-            _read_policy_section,
-            _read_setup_section,
-        )
+        from vaner.cli.commands.setup import _default_answers
         from vaner.intent.deep_run_defaults import (
             deep_run_defaults_for,
             defaults_to_dict,
         )
         from vaner.setup.answers import SetupAnswers
         from vaner.setup.catalog import bundle_by_id
+        from vaner.setup.config_io import read_policy_section, read_setup_section
 
         repo_root = config.repo_root
-        policy_section = _read_policy_section(repo_root)
+        policy_section = read_policy_section(repo_root)
         selected_bundle_id = policy_section.get("selected_bundle_id") or "hybrid_balanced"
         try:
             bundle = bundle_by_id(str(selected_bundle_id))
@@ -273,13 +270,13 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
                 detail=f"unknown bundle id {selected_bundle_id!r}; run `vaner setup wizard`",
             ) from None
 
-        setup_section = _read_setup_section(repo_root)
+        setup_section = read_setup_section(repo_root)
         answers: SetupAnswers
         if setup_section:
             try:
-                from vaner.cli.commands.setup import _answers_from_payload
+                from vaner.setup.serializers import answers_from_payload
 
-                answers = _answers_from_payload(setup_section)
+                answers = answers_from_payload(setup_section)
             except Exception:
                 answers = _default_answers()
         else:
@@ -291,9 +288,9 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
     # ------------------------------------------------------------------
     # 0.8.6 WS8 — Setup HTTP surface. Mirrors the WS7 MCP tools so
     # desktop apps that prefer HTTP can drive the wizard end-to-end.
-    # Reuses WS6's serialisation helpers (vaner.cli.commands.setup) as
-    # the canonical contract for the JSON shapes; the MCP tools use the
-    # same helpers so both surfaces stay in lock-step.
+    # Reuses setup serialisation helpers as the canonical contract for
+    # the JSON shapes; the MCP tools use the same helpers so both
+    # surfaces stay in lock-step.
     #
     # Hardware detection is cached for the daemon process lifetime
     # because probing reaches into /sys, runs subprocesses, etc — once
@@ -320,132 +317,50 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
     app.state.engine = engine
 
     def _read_setup_section_for_http(repo_root: Path) -> dict[str, Any]:
-        from vaner.cli.commands.setup import _read_setup_section
+        from vaner.setup.config_io import read_setup_section
 
-        return _read_setup_section(repo_root)
+        return read_setup_section(repo_root)
 
     def _read_policy_section_for_http(repo_root: Path) -> dict[str, Any]:
-        from vaner.cli.commands.setup import _read_policy_section
+        from vaner.setup.config_io import read_policy_section
 
-        return _read_policy_section(repo_root)
+        return read_policy_section(repo_root)
 
     def _bundle_to_dict_http(bundle: Any) -> dict[str, Any]:
-        from vaner.cli.commands.setup import _bundle_to_dict
+        from vaner.setup.serializers import bundle_to_dict
 
-        return _bundle_to_dict(bundle)
+        return bundle_to_dict(bundle)
 
     def _selection_to_dict_http(result: Any) -> dict[str, Any]:
-        from vaner.cli.commands.setup import _selection_to_dict
+        from vaner.setup.serializers import selection_to_dict
 
-        return _selection_to_dict(result)
+        return selection_to_dict(result)
 
     def _hardware_to_dict_http(hw: Any) -> dict[str, Any]:
-        from vaner.cli.commands.setup import _hardware_to_dict
+        from vaner.setup.serializers import hardware_to_dict
 
-        return _hardware_to_dict(hw)
+        return hardware_to_dict(hw)
 
     def _answers_from_payload_http(raw: Any) -> Any:
-        # Mirror the CLI helper but raise HTTPException(400) on bad input
-        # — typer.BadParameter would 500 the request.
-        from vaner.setup.answers import SetupAnswers
+        from vaner.setup.serializers import (
+            AnswersValidationError,
+            answers_from_payload,
+        )
 
-        if not isinstance(raw, dict):
-            raise HTTPException(status_code=400, detail="answers must be a JSON object")
-        work_styles = raw.get("work_styles") or ["mixed"]
-        if isinstance(work_styles, str):
-            work_styles = [work_styles]
-        if not isinstance(work_styles, list) or not all(isinstance(s, str) for s in work_styles):
-            raise HTTPException(status_code=400, detail="work_styles must be a list of strings")
         try:
-            return SetupAnswers(
-                work_styles=tuple(work_styles),
-                priority=str(raw.get("priority", "balanced")),  # type: ignore[arg-type]
-                compute_posture=str(raw.get("compute_posture", "balanced")),  # type: ignore[arg-type]
-                cloud_posture=str(raw.get("cloud_posture", "ask_first")),  # type: ignore[arg-type]
-                background_posture=str(raw.get("background_posture", "normal")),  # type: ignore[arg-type]
-            )
+            return answers_from_payload(raw)
+        except AnswersValidationError as exc:
+            detail = str(exc)
+            if detail == "answers payload must be a JSON object":
+                detail = "answers must be a JSON object"
+            raise HTTPException(status_code=400, detail=detail) from exc
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    # The five Simple-Mode questions in the wire shape MCP + HTTP both
-    # consume. Kept as a constant so /setup/questions is a pure read.
-    _SETUP_QUESTIONS_PAYLOAD: dict[str, Any] = {
-        "version": 1,
-        "questions": [
-            {
-                "id": "work_styles",
-                "title": "What kind of work do you want help with?",
-                "kind": "multi",
-                "default": ["mixed"],
-                "choices": [
-                    {"value": "writing", "label": "Writing — drafting, editing, narrative"},
-                    {"value": "research", "label": "Research — surveys, deep reading, citations"},
-                    {"value": "planning", "label": "Planning — design docs, roadmaps, project layout"},
-                    {"value": "support", "label": "Support — answering questions, troubleshooting"},
-                    {"value": "learning", "label": "Learning — studying, exploring a new domain"},
-                    {"value": "coding", "label": "Coding — software development"},
-                    {"value": "general", "label": "General — knowledge work, mixed light tasks"},
-                    {"value": "mixed", "label": "Mixed — a bit of everything (safe default)"},
-                    {"value": "unsure", "label": "Unsure — I'd rather Vaner picks for me"},
-                ],
-            },
-            {
-                "id": "priority",
-                "title": "What matters most?",
-                "kind": "single",
-                "default": "balanced",
-                "choices": [
-                    {"value": "balanced", "label": "Balanced — a sensible middle"},
-                    {"value": "speed", "label": "Speed — snappy responses"},
-                    {"value": "quality", "label": "Quality — best answer, even if slow"},
-                    {"value": "privacy", "label": "Privacy — keep data on this machine"},
-                    {"value": "cost", "label": "Cost — minimise spend"},
-                    {"value": "low_resource", "label": "Low-resource — go easy on this machine"},
-                ],
-            },
-            {
-                "id": "compute_posture",
-                "title": "How hard should this machine work for you?",
-                "kind": "single",
-                "default": "balanced",
-                "choices": [
-                    {"value": "light", "label": "Light — barely use the CPU/GPU"},
-                    {"value": "balanced", "label": "Balanced — work with what's idle"},
-                    {"value": "available_power", "label": "Available-power — use what this box has"},
-                ],
-            },
-            {
-                "id": "cloud_posture",
-                "title": "How do you feel about cloud LLMs?",
-                "kind": "single",
-                "default": "ask_first",
-                "choices": [
-                    {"value": "local_only", "label": "Local only — never reach for cloud LLMs"},
-                    {"value": "ask_first", "label": "Ask first — confirm before any cloud call"},
-                    {
-                        "value": "hybrid_when_worth_it",
-                        "label": "Hybrid — cloud when it's clearly worth it",
-                    },
-                    {"value": "best_available", "label": "Best available — use the best model for the job"},
-                ],
-            },
-            {
-                "id": "background_posture",
-                "title": "How aggressive should background pondering be?",
-                "kind": "single",
-                "default": "normal",
-                "choices": [
-                    {"value": "minimal", "label": "Minimal — barely ponder when idle"},
-                    {"value": "normal", "label": "Normal — moderate background pondering"},
-                    {"value": "idle_more", "label": "Idle-more — ponder broadly when the box is idle"},
-                    {
-                        "value": "deep_run_aggressive",
-                        "label": "Deep-Run-aggressive — happy to run overnight",
-                    },
-                ],
-            },
-        ],
-    }
+    from vaner.setup.questions import setup_questions_for_http
+
+    # The five Simple-Mode questions in the stable daemon wire shape.
+    _SETUP_QUESTIONS_PAYLOAD = setup_questions_for_http()
 
     @app.get("/setup/questions")
     async def setup_questions() -> JSONResponse:
@@ -496,17 +411,15 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         ``written=false`` unless ``confirm_cloud_widening=true``.
         """
 
-        from vaner.cli.commands.setup import (
-            _answers_from_payload,
-            _default_answers,
-            _persist_setup_and_policy,
-        )
+        from vaner.cli.commands.setup import _default_answers
         from vaner.setup.apply import (
             WIDENS_CLOUD_POSTURE_SENTINEL,
             apply_policy_bundle,
         )
         from vaner.setup.catalog import bundle_by_id
+        from vaner.setup.config_io import persist_setup_and_policy
         from vaner.setup.select import select_policy_bundle
+        from vaner.setup.serializers import answers_from_payload
 
         try:
             body = await request.json()
@@ -536,7 +449,7 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
                 existing = _read_setup_section_for_http(repo_root)
                 if existing:
                     try:
-                        answers = _answers_from_payload(existing)
+                        answers = answers_from_payload(existing)
                     except Exception:
                         answers = _default_answers()
                 else:
@@ -556,7 +469,7 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
                         ),
                     )
                 try:
-                    answers = _answers_from_payload(existing)
+                    answers = answers_from_payload(existing)
                 except Exception as exc:
                     raise HTTPException(
                         status_code=400,
@@ -612,7 +525,7 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
             )
 
         completed_at = datetime.now(UTC)
-        config_path = _persist_setup_and_policy(repo_root, answers, chosen_bundle_id, completed_at=completed_at)
+        config_path = persist_setup_and_policy(repo_root, answers, chosen_bundle_id, completed_at=completed_at)
 
         return JSONResponse(
             {
@@ -1210,10 +1123,15 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
                 {"code": "invalid_input", "message": "query is required"},
                 status_code=400,
             )
+        from vaner.clients.daemon import (
+            RESOLVE_INCLUDE_BRIEFING_DEFAULT,
+            RESOLVE_INCLUDE_PREDICTED_RESPONSE_DEFAULT,
+        )
+
         context_raw = body.get("context")
         context = context_raw if isinstance(context_raw, dict) else None
-        include_briefing = bool(body.get("include_briefing", True))
-        include_predicted_response = bool(body.get("include_predicted_response", True))
+        include_briefing = bool(body.get("include_briefing", RESOLVE_INCLUDE_BRIEFING_DEFAULT))
+        include_predicted_response = bool(body.get("include_predicted_response", RESOLVE_INCLUDE_PREDICTED_RESPONSE_DEFAULT))
         resolution = await engine.resolve_query(
             query,
             context=context,

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -112,6 +112,45 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
 
     app = FastAPI(title="Vaner Cockpit", version="0.2.0", lifespan=lifespan)
 
+    def _prediction_health() -> dict[str, Any]:
+        readiness_counts = {state: 0 for state in ["queued", "grounding", "evidence_gathering", "drafting", "ready", "stale"]}
+        if engine is None or getattr(engine, "prediction_registry", None) is None:
+            return {
+                "engine_available": engine is not None,
+                "daemon_with_engine": engine is not None,
+                "active_prediction_count": 0,
+                "total_prediction_count": 0,
+                "readiness_counts": readiness_counts,
+                "pending_adoption_outcomes": 0,
+                "stale_or_invalidated_reasons": [],
+                "diagnostic_status": "engine_unavailable" if engine is None else "cold",
+            }
+        registry = engine.prediction_registry
+        prompts = registry.all()
+        stale_reasons: list[str] = []
+        for prompt in prompts:
+            readiness_counts[prompt.run.readiness] = readiness_counts.get(prompt.run.readiness, 0) + 1
+            if prompt.run.invalidation_reason:
+                stale_reasons.append(prompt.run.invalidation_reason)
+        pending_lock = getattr(registry, "_pending_adoption_lock", None)
+        pending_queue = getattr(registry, "_pending_adoption_descriptors", [])
+        if pending_lock is not None:
+            with pending_lock:
+                pending_adoptions = len(pending_queue)
+        else:
+            pending_adoptions = len(pending_queue)
+        active_count = len(registry.active())
+        return {
+            "engine_available": True,
+            "daemon_with_engine": True,
+            "active_prediction_count": active_count,
+            "total_prediction_count": len(prompts),
+            "readiness_counts": readiness_counts,
+            "pending_adoption_outcomes": pending_adoptions,
+            "stale_or_invalidated_reasons": stale_reasons[-8:],
+            "diagnostic_status": "healthy" if active_count > 0 else "cold",
+        }
+
     @app.get("/health")
     async def health() -> dict[str, str]:
         return {"status": "ok"}
@@ -144,6 +183,7 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
                 "top_scenario": top[0].id if top else None,
                 "prediction_metrics": prediction_metrics,
                 "prediction_calibration": calibration,
+                "prediction_health": _prediction_health(),
             }
         )
 
@@ -790,39 +830,9 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
 
     def _serialize_prediction(prompt: Any) -> dict[str, Any]:
         """Render a PredictedPrompt into a JSON-safe dict."""
-        spec = prompt.spec
-        run = prompt.run
-        artifacts = prompt.artifacts
-        return {
-            "id": spec.id,
-            "spec": {
-                "label": spec.label,
-                "description": spec.description,
-                "source": spec.source,
-                "anchor": spec.anchor,
-                "confidence": spec.confidence,
-                "hypothesis_type": spec.hypothesis_type,
-                "specificity": spec.specificity,
-                "created_at": spec.created_at,
-            },
-            "run": {
-                "weight": run.weight,
-                "token_budget": run.token_budget,
-                "tokens_used": run.tokens_used,
-                "model_calls": run.model_calls,
-                "scenarios_spawned": run.scenarios_spawned,
-                "scenarios_complete": run.scenarios_complete,
-                "readiness": run.readiness,
-                "updated_at": run.updated_at,
-            },
-            "artifacts": {
-                "scenario_ids": list(artifacts.scenario_ids),
-                "evidence_score": artifacts.evidence_score,
-                "has_draft": artifacts.draft_answer is not None,
-                "has_briefing": artifacts.prepared_briefing is not None,
-                "thinking_trace_count": len(artifacts.thinking_traces),
-            },
-        }
+        from vaner.intent.prediction_serialization import serialize_prediction_nested
+
+        return serialize_prediction_nested(prompt)
 
     @app.get("/predictions/active")
     async def predictions_active() -> JSONResponse:
@@ -968,6 +978,11 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         from vaner.mcp.server import _build_adopt_resolution
 
         resolution = _build_adopt_resolution(prompt)
+        try:
+            async with engine.prediction_registry.lock:
+                engine.prediction_registry.record_adoption(pid)
+        except Exception:
+            pass
         return JSONResponse(resolution.model_dump(mode="json"))
 
     @app.post("/signals/composer")

--- a/src/vaner/engine.py
+++ b/src/vaner/engine.py
@@ -2211,22 +2211,41 @@ class VanerEngine:
         and reports real token counts via the assembler's tokenizer
         path.
 
-        ``context`` is accepted for symmetry with the MCP surface but
-        not consumed here; future goal-aware biasing (WS7 scoring
-        integration) can read from it. ``include_briefing`` /
-        ``include_predicted_response`` mirror the MCP opt-in flags.
+        ``context`` is parsed into a ContextEnvelope and used as a light
+        domain/goal bias for prediction reuse and evidence labelling.
+        ``include_briefing`` / ``include_predicted_response`` mirror the MCP
+        opt-in flags.
         """
         await self.initialize()
         # Late import keeps the engine module free of pydantic at
         # import time for callers that only need precompute_cycle.
         from vaner.mcp.contracts import (
             Alternative,
+            ContextEnvelope,
             EvidenceItem,
             Provenance,
             Resolution,
         )
 
         resolution_id = f"resolve-{uuid.uuid4().hex[:12]}"
+        context_envelope: ContextEnvelope | None = None
+        if isinstance(context, dict):
+            try:
+                context_envelope = ContextEnvelope.model_validate(context)
+            except Exception:
+                context_envelope = None
+        domain = context_envelope.domain if context_envelope is not None else "code"
+        domain_kind = {
+            "code": "file",
+            "docs": "doc",
+            "research": "doc",
+            "planning": "record",
+            "learning": "doc",
+            "writing": "doc",
+            "support": "record",
+            "operations": "record",
+            "general": "record",
+        }.get(domain, "record")
 
         # Step 1: prediction-registry match on label similarity.
         matched_prediction: PredictedPrompt | None = None
@@ -2239,6 +2258,10 @@ class VanerEngine:
             # contains-check in both directions; a more refined
             # similarity score is a WS8.1 follow-up.
             query_lower = query.lower()
+            goal_tokens = set()
+            if context_envelope is not None and context_envelope.agent_goal:
+                goal_tokens = set(w for w in context_envelope.agent_goal.lower().split() if len(w) > 2)
+            artifact_hint = (context_envelope.current_artifact or "").lower() if context_envelope is not None else ""
             candidates: list[tuple[float, PredictedPrompt]] = []
             for prompt in active:
                 label_lower = prompt.spec.label.lower()
@@ -2252,8 +2275,12 @@ class VanerEngine:
                     l_tokens = set(w for w in label_lower.split() if len(w) > 2)
                     if q_tokens and l_tokens:
                         overlap = len(q_tokens & l_tokens) / max(1, len(q_tokens | l_tokens))
+                    if goal_tokens and l_tokens:
+                        overlap += min(0.15, len(goal_tokens & l_tokens) * 0.05)
+                if artifact_hint and prompt.spec.anchor and prompt.spec.anchor.lower() in artifact_hint:
+                    overlap += 0.1
                 if overlap > 0:
-                    candidates.append((overlap, prompt))
+                    candidates.append((min(1.0, overlap), prompt))
             candidates.sort(key=lambda pair: pair[0], reverse=True)
             if candidates and candidates[0][0] >= 0.5:
                 matched_prediction = candidates[0][1]
@@ -2279,6 +2306,9 @@ class VanerEngine:
                         "scenario_id": sid,
                     },
                     reason=(f"scenario explored under prediction {matched_prediction.spec.label!r}"),
+                    overlay="predicted",
+                    freshness="fresh",
+                    confidence=float(matched_prediction.spec.confidence),
                 )
                 for sid in matched_prediction.artifacts.scenario_ids
             ]
@@ -2288,6 +2318,7 @@ class VanerEngine:
                 summary=matched_prediction.spec.description or matched_prediction.spec.label,
                 evidence=evidence,
                 alternatives_considered=alternatives,
+                context_envelope=context_envelope,
                 provenance=Provenance(
                     mode="predictive_hit",
                     cache="warm",
@@ -2327,9 +2358,12 @@ class VanerEngine:
             EvidenceItem(
                 id=sel.artefact_key,
                 source=tier,
-                kind="file",
+                kind=domain_kind,
                 locator={"path": sel.source_path, "artefact_key": sel.artefact_key},
                 reason=sel.rationale or f"selected by tier={tier}",
+                overlay="indexed",
+                freshness="fresh",
+                confidence=0.5 if tier == "miss" else 0.7,
             )
             for sel in package.selections[:8]
         ]
@@ -2339,6 +2373,7 @@ class VanerEngine:
             summary=f"Heuristic context for: {query}",
             evidence=evidence,
             alternatives_considered=alternatives,
+            context_envelope=context_envelope,
             provenance=Provenance(
                 mode=provenance_mode,  # type: ignore[arg-type]
                 cache=cache_label,  # type: ignore[arg-type]

--- a/src/vaner/intent/prediction_serialization.py
+++ b/src/vaner/intent/prediction_serialization.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared prediction wire serialization helpers.
+
+MCP and daemon HTTP expose predictions through different transports, but
+clients should see the same additive card and trust fields. Keep this module
+free of MCP/FastAPI imports so both surfaces can use it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vaner.intent.prediction import PredictedPrompt
+from vaner.intent.prediction_card import derive_card_fields
+
+
+def composer_engagement_payload(prompt: PredictedPrompt) -> dict[str, Any] | None:
+    """Return validated composer-engagement metadata for a composer prediction."""
+
+    if prompt.spec.source != "composer_intent":
+        return None
+    metadata: dict[str, Any] = prompt.artifacts.composer_metadata or {}
+    composer_event_id = metadata.get("composer_event_id")
+    if not isinstance(composer_event_id, str) or not composer_event_id:
+        return None
+    lifecycle_state = metadata.get("lifecycle_state", "submitted")
+    if not isinstance(lifecycle_state, str):
+        lifecycle_state = "submitted"
+    inferred_intent_label = metadata.get("inferred_intent_label")
+    if inferred_intent_label is not None and not isinstance(inferred_intent_label, str):
+        inferred_intent_label = None
+    inferred_intent_confidence = metadata.get("inferred_intent_confidence")
+    if inferred_intent_confidence is not None and not isinstance(inferred_intent_confidence, (int, float)):
+        inferred_intent_confidence = None
+    return {
+        "composer_event_id": composer_event_id,
+        "lifecycle_state": lifecycle_state,
+        "inferred_intent_label": inferred_intent_label,
+        "inferred_intent_confidence": inferred_intent_confidence,
+    }
+
+
+def prediction_trust_payload(prompt: PredictedPrompt) -> dict[str, Any]:
+    """Compute lightweight trust metadata for a prediction card.
+
+    This is intentionally conservative. It reports what the prediction already
+    knows: whether it is stale, whether it has watched sources, and whether any
+    diagnostic verdict is attached. Live file comparison remains the registry's
+    invalidation job, not a serializer side effect.
+    """
+
+    run = prompt.run
+    artifacts = prompt.artifacts
+    watched_sources = sorted(artifacts.file_content_hashes)
+    invalidated_by: list[str] = []
+    changed_sources: list[str] = []
+    diagnostic_status = "not_checked"
+
+    diagnostic_status = "not_checked"
+
+    if run.readiness == "stale":
+        trust_status = "invalidated"
+        freshness = "stale"
+        invalidated_by.append(run.invalidation_reason or "readiness_stale")
+        diagnostic_status = "invalidated"
+    elif run.readiness in {"ready", "drafting"} and (artifacts.prepared_briefing or artifacts.draft_answer):
+        trust_status = "ready"
+        freshness = "fresh" if watched_sources else "recent"
+        diagnostic_status = "verified" if watched_sources else "unverified"
+    else:
+        trust_status = "preparing"
+        freshness = "recent"
+
+    return {
+        "trust_status": trust_status,
+        "freshness": freshness,
+        "invalidated_by": invalidated_by,
+        "watched_sources": watched_sources,
+        "changed_sources": changed_sources,
+        "diagnostic_status": diagnostic_status,
+    }
+
+
+def prediction_card_payload(prompt: PredictedPrompt, *, rank: int | None = None) -> dict[str, Any]:
+    """Return additive card/trust fields shared by MCP and daemon HTTP."""
+
+    card = derive_card_fields(prompt)
+    payload: dict[str, Any] = {
+        "readiness_label": card.readiness_label,
+        "eta_bucket": card.eta_bucket,
+        "eta_bucket_label": card.eta_bucket_label,
+        "adoptable": card.adoptable,
+        "suppression_reason": card.suppression_reason,
+        "source_label": card.source_label,
+        "ui_summary": card.ui_summary,
+        **prediction_trust_payload(prompt),
+    }
+    if rank is not None:
+        payload["rank"] = rank
+    composer_engagement = composer_engagement_payload(prompt)
+    if composer_engagement is not None:
+        payload["composer_engagement"] = composer_engagement
+    return payload
+
+
+def serialize_prediction_flat(prompt: PredictedPrompt, *, rank: int | None = None) -> dict[str, Any]:
+    """Render the flat MCP prediction-card shape."""
+
+    spec = prompt.spec
+    run = prompt.run
+    artifacts = prompt.artifacts
+    payload: dict[str, Any] = {
+        "id": spec.id,
+        "label": spec.label,
+        "description": spec.description,
+        "source": spec.source,
+        "confidence": spec.confidence,
+        "hypothesis_type": spec.hypothesis_type,
+        "specificity": spec.specificity,
+        "readiness": run.readiness,
+        "weight": run.weight,
+        "token_budget": run.token_budget,
+        "tokens_used": run.tokens_used,
+        "scenarios_complete": run.scenarios_complete,
+        "scenarios_spawned": run.scenarios_spawned,
+        "evidence_score": artifacts.evidence_score,
+        "has_draft": artifacts.draft_answer is not None,
+        "has_briefing": artifacts.prepared_briefing is not None,
+    }
+    payload.update(prediction_card_payload(prompt, rank=rank))
+    return payload
+
+
+def serialize_prediction_nested(prompt: PredictedPrompt, *, rank: int | None = None) -> dict[str, Any]:
+    """Render the daemon's nested prediction shape plus additive card fields."""
+
+    spec = prompt.spec
+    run = prompt.run
+    artifacts = prompt.artifacts
+    payload: dict[str, Any] = {
+        "id": spec.id,
+        "spec": {
+            "label": spec.label,
+            "description": spec.description,
+            "source": spec.source,
+            "anchor": spec.anchor,
+            "confidence": spec.confidence,
+            "hypothesis_type": spec.hypothesis_type,
+            "specificity": spec.specificity,
+            "created_at": spec.created_at,
+        },
+        "run": {
+            "weight": run.weight,
+            "token_budget": run.token_budget,
+            "tokens_used": run.tokens_used,
+            "model_calls": run.model_calls,
+            "scenarios_spawned": run.scenarios_spawned,
+            "scenarios_complete": run.scenarios_complete,
+            "readiness": run.readiness,
+            "updated_at": run.updated_at,
+        },
+        "artifacts": {
+            "scenario_ids": list(artifacts.scenario_ids),
+            "evidence_score": artifacts.evidence_score,
+            "has_draft": artifacts.draft_answer is not None,
+            "has_briefing": artifacts.prepared_briefing is not None,
+            "thinking_trace_count": len(artifacts.thinking_traces),
+        },
+    }
+    payload.update(prediction_card_payload(prompt, rank=rank))
+    return payload

--- a/src/vaner/mcp/contracts.py
+++ b/src/vaner/mcp/contracts.py
@@ -6,7 +6,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-Domain = Literal["code", "docs", "support", "operations", "research", "general"]
+Domain = Literal["code", "docs", "support", "operations", "research", "planning", "learning", "writing", "general"]
+EvidenceOverlay = Literal["indexed", "working_tree", "staged", "live", "predicted", "memory", "external"]
 ProvenanceMode = Literal["predictive_hit", "cached_result", "fresh_resolution", "retrieval_fallback"]
 Budget = Literal["low", "medium", "high"]
 AbstainReason = Literal["low_confidence", "ambiguous_intent", "insufficient_evidence", "memory_conflict"]
@@ -32,6 +33,12 @@ class EvidenceItem(BaseModel):
     locator: dict = Field(default_factory=dict)
     reason: str = ""
     fingerprint: str | None = None
+    overlay: EvidenceOverlay | None = None
+    freshness: Literal["fresh", "recent", "stale"] | None = None
+    captured_at: float | None = None
+    validated_at: float | None = None
+    confidence: float | None = None
+    dependencies: list[dict] = Field(default_factory=list)
 
 
 class Alternative(BaseModel):

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -121,79 +121,13 @@ def _ensure_backend(config: Any) -> bool:
 def _setup_question_schema() -> list[dict[str, Any]]:
     """Static ordered schema for the five Simple-Mode questions.
 
-    Mirrors the choice tables in :mod:`vaner.cli.commands.setup`. Static
-    data — no engine state — so cockpit / desktop UIs can render the
-    same prompts without hardcoding strings.
+    Static data — no engine state — so cockpit / desktop UIs can render
+    the same prompts without hardcoding strings.
     """
 
-    return [
-        {
-            "id": "work_styles",
-            "prompt": "What kind of work do you want help with?",
-            "kind": "multi",
-            "default": ["mixed"],
-            "options": [
-                {"value": "writing", "label": "Writing — drafting, editing, narrative"},
-                {"value": "research", "label": "Research — surveys, deep reading, citations"},
-                {"value": "planning", "label": "Planning — design docs, roadmaps, project layout"},
-                {"value": "support", "label": "Support — answering questions, troubleshooting"},
-                {"value": "learning", "label": "Learning — studying, exploring a new domain"},
-                {"value": "coding", "label": "Coding — software development"},
-                {"value": "general", "label": "General — knowledge work, mixed light tasks"},
-                {"value": "mixed", "label": "Mixed — a bit of everything (safe default)"},
-                {"value": "unsure", "label": "Unsure — I'd rather Vaner picks for me"},
-            ],
-        },
-        {
-            "id": "priority",
-            "prompt": "What matters most?",
-            "kind": "single",
-            "default": "balanced",
-            "options": [
-                {"value": "balanced", "label": "Balanced — a sensible middle"},
-                {"value": "speed", "label": "Speed — snappy responses"},
-                {"value": "quality", "label": "Quality — best answer, even if slow"},
-                {"value": "privacy", "label": "Privacy — keep data on this machine"},
-                {"value": "cost", "label": "Cost — minimise spend"},
-                {"value": "low_resource", "label": "Low-resource — go easy on this machine"},
-            ],
-        },
-        {
-            "id": "compute_posture",
-            "prompt": "How hard should this machine work for you?",
-            "kind": "single",
-            "default": "balanced",
-            "options": [
-                {"value": "light", "label": "Light — barely use the CPU/GPU"},
-                {"value": "balanced", "label": "Balanced — work with what's idle"},
-                {"value": "available_power", "label": "Available-power — use what this box has"},
-            ],
-        },
-        {
-            "id": "cloud_posture",
-            "prompt": "How do you feel about cloud LLMs?",
-            "kind": "single",
-            "default": "ask_first",
-            "options": [
-                {"value": "local_only", "label": "Local only — never reach for cloud LLMs"},
-                {"value": "ask_first", "label": "Ask first — confirm before any cloud call"},
-                {"value": "hybrid_when_worth_it", "label": "Hybrid — cloud when it's clearly worth it"},
-                {"value": "best_available", "label": "Best available — use the best model for the job"},
-            ],
-        },
-        {
-            "id": "background_posture",
-            "prompt": "How aggressive should background pondering be?",
-            "kind": "single",
-            "default": "normal",
-            "options": [
-                {"value": "minimal", "label": "Minimal — barely ponder when idle"},
-                {"value": "normal", "label": "Normal — moderate background pondering"},
-                {"value": "idle_more", "label": "Idle-more — ponder broadly when the box is idle"},
-                {"value": "deep_run_aggressive", "label": "Deep-Run-aggressive — happy to run overnight"},
-            ],
-        },
-    ]
+    from vaner.setup.questions import setup_questions_for_mcp
+
+    return setup_questions_for_mcp()
 
 
 def _setup_apply_handler(repo_root: Path, args: dict[str, Any]) -> CallToolResult:
@@ -209,16 +143,16 @@ def _setup_apply_handler(repo_root: Path, args: dict[str, Any]) -> CallToolResul
     from datetime import UTC, datetime
 
     from vaner.cli.commands.config import load_config as _load_config
-    from vaner.cli.commands.setup import (
-        _persist_setup_and_policy,
-        _read_policy_section,
-        _read_setup_section,
-    )
     from vaner.setup.apply import (
         WIDENS_CLOUD_POSTURE_SENTINEL,
         apply_policy_bundle,
     )
     from vaner.setup.catalog import bundle_by_id
+    from vaner.setup.config_io import (
+        persist_setup_and_policy,
+        read_policy_section,
+        read_setup_section,
+    )
     from vaner.setup.hardware import detect as _hw_detect
     from vaner.setup.select import select_policy_bundle as _select_bundle
     from vaner.setup.serializers import (
@@ -245,7 +179,7 @@ def _setup_apply_handler(repo_root: Path, args: dict[str, Any]) -> CallToolResul
                 is_error=True,
             )
         chosen_bundle_id = bundle.id
-        existing_setup = _read_setup_section(repo_root)
+        existing_setup = read_setup_section(repo_root)
         if existing_setup:
             try:
                 answers = answers_from_payload(existing_setup)
@@ -300,7 +234,7 @@ def _setup_apply_handler(repo_root: Path, args: dict[str, Any]) -> CallToolResul
     # 2. Compute overrides + cloud-widening flag.
     # ------------------------------------------------------------------
     config = _load_config(repo_root)
-    prior_policy_section = _read_policy_section(repo_root)
+    prior_policy_section = read_policy_section(repo_root)
     prior_bundle_id = prior_policy_section.get("selected_bundle_id")
     if isinstance(prior_bundle_id, str) and prior_bundle_id:
         config = config.model_copy(update={"policy": config.policy.model_copy(update={"selected_bundle_id": prior_bundle_id})})
@@ -319,7 +253,7 @@ def _setup_apply_handler(repo_root: Path, args: dict[str, Any]) -> CallToolResul
         block_reason = "WIDENS_CLOUD_POSTURE: refusing to widen cloud posture without confirm_cloud_widening=True"
     else:
         try:
-            _persist_setup_and_policy(
+            persist_setup_and_policy(
                 repo_root,
                 answers,
                 chosen_bundle_id,
@@ -351,17 +285,14 @@ def _setup_status_handler(repo_root: Path) -> CallToolResult:
     """
 
     from vaner.cli.commands.config import load_config as _load_config
-    from vaner.cli.commands.setup import (
-        _read_policy_section,
-        _read_setup_section,
-    )
     from vaner.setup.apply import apply_policy_bundle
     from vaner.setup.catalog import bundle_by_id
+    from vaner.setup.config_io import read_policy_section, read_setup_section
     from vaner.setup.hardware import detect as _hw_detect
     from vaner.setup.serializers import hardware_to_dict
 
-    setup_section = _read_setup_section(repo_root)
-    policy_section = _read_policy_section(repo_root)
+    setup_section = read_setup_section(repo_root)
+    policy_section = read_policy_section(repo_root)
     hardware = _hw_detect()
 
     mode = setup_section.get("mode") if isinstance(setup_section, dict) else None
@@ -409,12 +340,12 @@ def _policy_show_handler(repo_root: Path) -> CallToolResult:
     """
 
     from vaner.cli.commands.config import load_config as _load_config
-    from vaner.cli.commands.setup import _read_policy_section
     from vaner.setup.apply import apply_policy_bundle
     from vaner.setup.catalog import bundle_by_id
+    from vaner.setup.config_io import read_policy_section
     from vaner.setup.serializers import bundle_to_dict
 
-    policy_section = _read_policy_section(repo_root)
+    policy_section = read_policy_section(repo_root)
     selected_bundle_id = policy_section.get("selected_bundle_id") or "hybrid_balanced"
     try:
         bundle = bundle_by_id(str(selected_bundle_id))
@@ -593,40 +524,15 @@ def _composer_engagement_payload(prompt: Any) -> dict[str, Any] | None:
     }
 
 
-_RESOURCE_METRIC_TASKS: set[Any] = set()
-"""Keep strong refs to background metric tasks until they settle.
-
-Without this, `asyncio.run()` can tear the loop down before the task
-completes, producing `Event loop is closed` warnings. Tracked via
-`add_done_callback(discard)` so entries clear themselves when the task
-finishes.
-"""
-
-
-def _increment_resource_metric(name: str, repo_root: Path) -> None:
-    """Fire-and-forget metric increment for resource-read events.
-
-    0.8.5 WS8: `read_resource` is a sync entry point in the SDK API, so we
-    can't `await` on `MetricsStore`. Spawn an asyncio task when a loop is
-    running; otherwise silently drop — metrics are best-effort.
-    """
-    import asyncio as _asyncio
-
-    async def _do() -> None:
-        try:
-            store = MetricsStore(repo_root / ".vaner" / "metrics.db")
-            await store.initialize()
-            await store.increment_counter(name)
-        except Exception:  # pragma: no cover - defensive metrics
-            pass
+async def _increment_resource_metric(name: str, repo_root: Path) -> None:
+    """Best-effort metric increment for resource-read events."""
 
     try:
-        loop = _asyncio.get_running_loop()
-    except RuntimeError:
-        return
-    task = loop.create_task(_do())
-    _RESOURCE_METRIC_TASKS.add(task)
-    task.add_done_callback(_RESOURCE_METRIC_TASKS.discard)
+        store = MetricsStore(repo_root / ".vaner" / "metrics.db")
+        await store.initialize()
+        await store.increment_counter(name)
+    except Exception:  # pragma: no cover - defensive metrics
+        pass
 
 
 def _dashboard_fallback_text(cards: list[dict[str, Any]]) -> str:
@@ -747,6 +653,8 @@ def build_server(
     # Lazy import keeps MCP server import-free of pydantic/httpx when the
     # tools surface is unused (e.g. CLI --help).
     from vaner.clients.daemon import (
+        RESOLVE_INCLUDE_BRIEFING_DEFAULT,
+        RESOLVE_INCLUDE_PREDICTED_RESPONSE_DEFAULT,
         VanerDaemonClient,
         VanerDaemonNotFound,
         VanerDaemonUnavailable,
@@ -828,10 +736,22 @@ def build_server(
                             "query": {"type": "string"},
                             "suggestion_id": {"type": "string"},
                             "context": {"type": "object"},
-                            "budget": {"type": "string", "enum": ["low", "medium", "high"], "default": "medium"},
-                            "max_evidence_items": {"type": "integer", "default": 8},
-                            "include_briefing": {"type": "boolean", "default": False},
-                            "include_predicted_response": {"type": "boolean", "default": False},
+                            "budget": {
+                                "type": "string",
+                                "enum": ["low", "medium", "high"],
+                                "default": "medium",
+                                "description": "Reserved for future engine budget shaping; currently accepted but not applied.",
+                            },
+                            "max_evidence_items": {
+                                "type": "integer",
+                                "default": 8,
+                                "description": "Reserved for future evidence limiting; currently accepted but not applied.",
+                            },
+                            "include_briefing": {"type": "boolean", "default": RESOLVE_INCLUDE_BRIEFING_DEFAULT},
+                            "include_predicted_response": {
+                                "type": "boolean",
+                                "default": RESOLVE_INCLUDE_PREDICTED_RESPONSE_DEFAULT,
+                            },
                             "include_metrics": {"type": "boolean", "default": False},
                             "estimated_cost_per_1k_tokens": {"type": "number", "default": 0.0},
                         },
@@ -1262,14 +1182,43 @@ def build_server(
                             "work_styles": {
                                 "anyOf": [
                                     {"type": "string"},
-                                    {"type": "array", "items": {"type": "string"}},
+                                    {"type": "array"},
                                 ],
-                                "description": "WorkStyle id(s); single string or list.",
+                                "description": ("WorkStyle id(s). Handler validates list items for structured errors."),
                             },
-                            "priority": {"type": "string"},
-                            "compute_posture": {"type": "string"},
-                            "cloud_posture": {"type": "string"},
-                            "background_posture": {"type": "string"},
+                            "priority": {
+                                "type": "string",
+                                "enum": [
+                                    "balanced",
+                                    "speed",
+                                    "quality",
+                                    "privacy",
+                                    "cost",
+                                    "low_resource",
+                                ],
+                            },
+                            "compute_posture": {
+                                "type": "string",
+                                "enum": ["light", "balanced", "available_power"],
+                            },
+                            "cloud_posture": {
+                                "type": "string",
+                                "enum": [
+                                    "local_only",
+                                    "ask_first",
+                                    "hybrid_when_worth_it",
+                                    "best_available",
+                                ],
+                            },
+                            "background_posture": {
+                                "type": "string",
+                                "enum": [
+                                    "minimal",
+                                    "normal",
+                                    "idle_more",
+                                    "deep_run_aggressive",
+                                ],
+                            },
                         },
                     },
                 ),
@@ -1336,7 +1285,7 @@ def build_server(
             from mcp.types import Resource as _Resource
         except ModuleNotFoundError:  # pragma: no cover - optional dependency path
             return []
-        from vaner.integrations.guidance import current_version
+        from vaner.integrations.guidance import available_variants, current_version
 
         resources: list[Any] = [
             _Resource(
@@ -1351,6 +1300,21 @@ def build_server(
                 mimeType="text/markdown",
             )
         ]
+        for variant in available_variants():
+            if variant == "canonical":
+                continue
+            resources.append(
+                _Resource(
+                    uri=f"vaner://guidance/current?variant={variant}",  # type: ignore[arg-type]
+                    name=f"Vaner Guidance ({variant})",
+                    title=f"Vaner operational guidance ({variant})",
+                    description=(
+                        "Alternate operational guidance variant for agents using Vaner. "
+                        "Canonical remains available at vaner://guidance/current."
+                    ),
+                    mimeType="text/markdown",
+                )
+            )
         try:
             cfg = load_config(repo_root)
             if getattr(cfg.mcp, "apps_ui_enabled", True):
@@ -1394,7 +1358,7 @@ def build_server(
 
         # MCP Apps UI bundle.
         if uri_str == ACTIVE_PREDICTIONS_URI:
-            _increment_resource_metric("mcp_apps_bundle_read", repo_root)
+            await _increment_resource_metric("mcp_apps_bundle_read", repo_root)
             return [
                 ReadResourceContents(
                     content=ACTIVE_PREDICTIONS_HTML,
@@ -1423,7 +1387,7 @@ def build_server(
         if variant is None:
             raise ValueError(f"unknown vaner resource: {uri_str!r}")
         body = load_guidance(variant).as_text()  # type: ignore[arg-type]
-        _increment_resource_metric(f"guidance_resource_read_{variant}", repo_root)
+        await _increment_resource_metric(f"guidance_resource_read_{variant}", repo_root)
         return [ReadResourceContents(content=body, mime_type="text/markdown")]
 
     @server.call_tool()
@@ -1615,8 +1579,8 @@ def build_server(
                 # resolve picks up the canonical form even when the caller's
                 # query text is terse.
                 query = str(suggestion_cache[suggestion_id].get("label") or query)
-            include_briefing = bool(args.get("include_briefing", False))
-            include_predicted_response = bool(args.get("include_predicted_response", False))
+            include_briefing = bool(args.get("include_briefing", RESOLVE_INCLUDE_BRIEFING_DEFAULT))
+            include_predicted_response = bool(args.get("include_predicted_response", RESOLVE_INCLUDE_PREDICTED_RESPONSE_DEFAULT))
             include_metrics = bool(args.get("include_metrics", False))
 
             try:
@@ -1893,7 +1857,7 @@ def build_server(
                         contradiction_signal=float(scenario.contradiction_signal),
                         prior_successes=int(scenario.prior_successes),
                         has_explicit_pin=bool(preferred_items),
-                        correction_confirmed=False,
+                        correction_confirmed=rating == "useful" and scenario.last_outcome == "wrong",
                     ),
                     scenario.memory_state,
                 )
@@ -1948,6 +1912,7 @@ def build_server(
             )
             legacy_outcome = "wrong" if rating == "wrong" else rating
             await scenario_store.record_outcome(scenario_id, legacy_outcome)
+            updated = await scenario_store.get(scenario_id)
             try:
                 await metrics_store.record_scenario_outcome(scenario_id=scenario_id, result=legacy_outcome, note=correction[:200])
             except Exception:
@@ -1962,16 +1927,16 @@ def build_server(
                     await metrics_store.record_draft_event(status="unused", directional_correct=False, metadata={"source": "feedback"})
             except Exception:
                 pass
-            if rating == "useful" and scenario.memory_state == "trusted":
+            post_memory_state = updated.memory_state if updated else scenario.memory_state
+            if rating == "useful" and post_memory_state == "trusted":
                 await metrics_store.increment_counter("promotions_still_trusted_total")
-            if rating == "useful" and scenario.last_outcome == "wrong":
+            if rating == "useful" and scenario.last_outcome == "wrong" and post_memory_state == "trusted":
                 await metrics_store.increment_counter("corrections_survived_total")
-            if rating in {"useful", "partial"} and scenario.memory_state == "demoted":
+            if rating in {"useful", "partial"} and scenario.memory_state == "demoted" and post_memory_state != "demoted":
                 await metrics_store.increment_counter("demotion_recovery_total")
             promotion_ring.append(transition)
             if len(promotion_ring) > 5:
                 del promotion_ring[0]
-            updated = await scenario_store.get(scenario_id)
             append_log(
                 repo_root,
                 tool=name,
@@ -2180,6 +2145,7 @@ def build_server(
                     )
                     return CallToolResult(
                         content=[link, *_make_text(json.dumps(dashboard_payload))],
+                        structuredContent=dashboard_payload,
                     )
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.debug("ResourceLink attach failed, falling back: %s", exc)
@@ -2665,7 +2631,7 @@ def build_server(
                 )
             await _record("error")
             return _json_result(
-                {"code": "invalid_input", "message": f"unknown goals tool: {name}"},
+                {"code": "invalid_input", "message": f"unknown artefacts/sources tool: {name}"},
                 is_error=True,
             )
 
@@ -2761,19 +2727,16 @@ def build_server(
 
             if name == "vaner.deep_run.defaults":
                 # WS9: bundle-derived seeds for the Deep-Run start dialog.
-                from vaner.cli.commands.setup import (
-                    _answers_from_payload,
-                    _default_answers,
-                    _read_policy_section,
-                    _read_setup_section,
-                )
+                from vaner.cli.commands.setup import _default_answers
                 from vaner.intent.deep_run_defaults import (
                     deep_run_defaults_for,
                     defaults_to_dict,
                 )
                 from vaner.setup.catalog import bundle_by_id
+                from vaner.setup.config_io import read_policy_section, read_setup_section
+                from vaner.setup.serializers import answers_from_payload
 
-                policy_section = _read_policy_section(active_repo_root)
+                policy_section = read_policy_section(active_repo_root)
                 selected_bundle_id = policy_section.get("selected_bundle_id") or "hybrid_balanced"
                 try:
                     bundle = bundle_by_id(str(selected_bundle_id))
@@ -2786,10 +2749,10 @@ def build_server(
                         },
                         is_error=True,
                     )
-                setup_section = _read_setup_section(active_repo_root)
+                setup_section = read_setup_section(active_repo_root)
                 if setup_section:
                     try:
-                        answers = _answers_from_payload(setup_section)
+                        answers = answers_from_payload(setup_section)
                     except Exception:
                         answers = _default_answers()
                 else:

--- a/src/vaner/mcp/server.py
+++ b/src/vaner/mcp/server.py
@@ -411,7 +411,42 @@ def _is_managed_path(path: str) -> bool:
     return any(normalized.endswith(marker) for marker in _MANAGED_PATH_MARKERS)
 
 
-def _scenario_penalty(scenario: Scenario, query_tokens: set[str]) -> float:
+def _context_domain(context: Any) -> str:
+    if not isinstance(context, dict):
+        return "code"
+    domain = context.get("domain")
+    if isinstance(domain, str) and domain in {
+        "code",
+        "docs",
+        "support",
+        "operations",
+        "research",
+        "planning",
+        "learning",
+        "writing",
+        "general",
+    }:
+        return domain
+    return "code"
+
+
+def _prediction_row_label(row: dict[str, Any]) -> str:
+    label = row.get("label") or (row.get("spec") or {}).get("label")
+    return str(label or "")
+
+
+def _prediction_matches_query(row: dict[str, Any], query_tokens: set[str]) -> bool:
+    label_tokens = _tokenize(_prediction_row_label(row))
+    if not label_tokens or not query_tokens:
+        return False
+    overlap = len(query_tokens & label_tokens)
+    # Require a real relationship, not just any unrelated ready prediction.
+    return overlap >= 2 or overlap / max(1, len(query_tokens | label_tokens)) >= 0.35
+
+
+def _scenario_penalty(scenario: Scenario, query_tokens: set[str], *, domain: str = "code") -> float:
+    if domain != "code":
+        return 0.0
     if _query_targets_managed_files(query_tokens):
         return 0.0
     if any(_is_managed_path(path) for path in _scenario_paths(scenario)):
@@ -438,50 +473,9 @@ def _serialize_prediction_for_mcp(prompt: Any, *, rank: int | None = None) -> di
     fields are always present (optional in the Rust contract mirror) so
     MCP Apps clients and text-fallback renderers share one shape.
     """
-    from vaner.intent.prediction_card import derive_card_fields
+    from vaner.intent.prediction_serialization import serialize_prediction_flat
 
-    spec = prompt.spec
-    run = prompt.run
-    artifacts = prompt.artifacts
-    card = derive_card_fields(prompt)
-    payload: dict[str, Any] = {
-        "id": spec.id,
-        "label": spec.label,
-        "description": spec.description,
-        "source": spec.source,
-        "confidence": spec.confidence,
-        "hypothesis_type": spec.hypothesis_type,
-        "specificity": spec.specificity,
-        "readiness": run.readiness,
-        "weight": run.weight,
-        "token_budget": run.token_budget,
-        "tokens_used": run.tokens_used,
-        "scenarios_complete": run.scenarios_complete,
-        "scenarios_spawned": run.scenarios_spawned,
-        "evidence_score": artifacts.evidence_score,
-        "has_draft": artifacts.draft_answer is not None,
-        "has_briefing": artifacts.prepared_briefing is not None,
-        # 0.8.5 WS5 — UI card derivations.
-        "readiness_label": card.readiness_label,
-        "eta_bucket": card.eta_bucket,
-        "eta_bucket_label": card.eta_bucket_label,
-        "adoptable": card.adoptable,
-        "suppression_reason": card.suppression_reason,
-        "source_label": card.source_label,
-        "ui_summary": card.ui_summary,
-    }
-    if rank is not None:
-        payload["rank"] = rank
-    # 0.8.7 WS8: surface composer-engagement metadata only for
-    # composer_intent-sourced predictions. The data backbone is
-    # populated by WS7's daemon path; field is omitted entirely
-    # for non-composer predictions so existing card payloads stay
-    # byte-identical.
-    if spec.source == "composer_intent":
-        composer_engagement = _composer_engagement_payload(prompt)
-        if composer_engagement is not None:
-            payload["composer_engagement"] = composer_engagement
-    return payload
+    return serialize_prediction_flat(prompt, rank=rank)
 
 
 def _composer_engagement_payload(prompt: Any) -> dict[str, Any] | None:
@@ -695,6 +689,171 @@ def build_server(
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("capability detection skipped: %s", exc)
 
+    async def _build_intent_packet(
+        query: str,
+        *,
+        scenario_store_arg: ScenarioStore,
+        context_arg: Any,
+        engine_unavailable: bool = False,
+        limit: int = 5,
+    ) -> dict[str, Any]:
+        context_domain = _context_domain(context_arg)
+        context_envelope = context_arg if isinstance(context_arg, dict) else {"domain": context_domain}
+        query_tokens = _tokenize(query)
+        scenarios = await scenario_store_arg.list_top(limit=max(limit * 2, 10))
+        candidates: list[dict[str, Any]] = []
+        for scenario in scenarios:
+            overlap = len(query_tokens & set(tok.lower() for tok in scenario.entities))
+            score = round(
+                max(
+                    0.0,
+                    min(
+                        1.0,
+                        0.2 + overlap * 0.18 + scenario.score * 0.5 - _scenario_penalty(scenario, query_tokens, domain=context_domain),
+                    ),
+                ),
+                4,
+            )
+            candidates.append(
+                {
+                    "id": scenario.id,
+                    "kind": scenario.kind,
+                    "score": score,
+                    "memory_state": scenario.memory_state,
+                    "freshness": scenario.freshness,
+                    "entities": scenario.entities[:6],
+                    "reason": "domain-aware scenario overlap",
+                }
+            )
+        candidates.sort(key=lambda item: float(item["score"]), reverse=True)
+
+        predictions: list[dict[str, Any]] = []
+        adoption_not_used = "no_active_predictions"
+        try:
+            if engine is not None:
+                predictions = [_serialize_prediction_for_mcp(p) for p in engine.get_active_predictions()]
+            else:
+                body = await _daemon().get_predictions_active()
+                predictions = list(body.get("predictions", []))
+        except VanerDaemonUnavailable:
+            engine_unavailable = True
+            adoption_not_used = "engine_unavailable"
+
+        if predictions:
+            adoptable = [
+                p
+                for p in predictions
+                if p.get("adoptable") and p.get("trust_status") != "invalidated" and _prediction_matches_query(p, query_tokens)
+            ]
+            adoption_not_used = "stale_or_unrelated_predictions"
+            if adoptable:
+                adoption_not_used = "caller_requested_packet_instead_of_adoption"
+
+        suggested_tool = (
+            "vaner.predictions.adopt" if adoption_not_used == "caller_requested_packet_instead_of_adoption" else "vaner.resolve"
+        )
+        if engine_unavailable:
+            suggested_tool = "vaner.search" if candidates else "wait_for_precompute"
+        elif not predictions and not candidates:
+            suggested_tool = "wait_for_precompute"
+
+        gaps = []
+        if engine_unavailable:
+            gaps.append("no live prediction registry available")
+        if adoption_not_used != "caller_requested_packet_instead_of_adoption":
+            gaps.append("no adoptable prediction matched the current intent")
+
+        return {
+            "intent_packet": True,
+            "interpreted_intent": query,
+            "context_envelope": context_envelope,
+            "domain": context_domain,
+            "active_predictions_considered": [
+                {
+                    "id": p.get("id"),
+                    "label": _prediction_row_label(p),
+                    "readiness": p.get("readiness") or (p.get("run") or {}).get("readiness"),
+                    "adoptable": p.get("adoptable"),
+                    "matches_intent": _prediction_matches_query(p, query_tokens),
+                    "trust_status": p.get("trust_status"),
+                    "freshness": p.get("freshness"),
+                }
+                for p in predictions[:limit]
+            ],
+            "adoption_not_used": adoption_not_used,
+            "candidate_scenarios": candidates[:limit],
+            "gaps": gaps,
+            "suggested_next_action": {
+                "tool": suggested_tool,
+                "reason": adoption_not_used,
+                "arguments": {"query": query, "context": context_envelope} if suggested_tool == "vaner.resolve" else {},
+            },
+        }
+
+    async def _prediction_health_snapshot() -> dict[str, Any]:
+        readiness_counts = {state: 0 for state in ["queued", "grounding", "evidence_gathering", "drafting", "ready", "stale"]}
+        active_count = 0
+        total_count = 0
+        pending_adoptions = 0
+        stale_reasons: list[str] = []
+        engine_available = engine is not None
+        source = "engine" if engine is not None else "daemon"
+        try:
+            if engine is not None and getattr(engine, "prediction_registry", None) is not None:
+                registry = engine.prediction_registry
+                prompts = registry.all()
+                total_count = len(prompts)
+                active_count = len(registry.active())
+                for prompt in prompts:
+                    readiness_counts[prompt.run.readiness] = readiness_counts.get(prompt.run.readiness, 0) + 1
+                    if prompt.run.invalidation_reason:
+                        stale_reasons.append(prompt.run.invalidation_reason)
+                pending_lock = getattr(registry, "_pending_adoption_lock", None)
+                pending_queue = getattr(registry, "_pending_adoption_descriptors", [])
+                if pending_lock is not None:
+                    with pending_lock:
+                        pending_adoptions = len(pending_queue)
+                else:
+                    pending_adoptions = len(pending_queue)
+            elif engine is not None:
+                engine_available = True
+                source = "engine_no_registry"
+            else:
+                daemon = _daemon()
+                try:
+                    status_body = await daemon.get_status()
+                except (AttributeError, VanerDaemonUnavailable):
+                    status_body = {}
+                status_health = status_body.get("prediction_health") if isinstance(status_body, dict) else None
+                if isinstance(status_health, dict):
+                    return status_health
+                body = await daemon.get_predictions_active()
+                rows = list(body.get("predictions", []))
+                engine_available = True
+                total_count = len(rows)
+                active_count = len(rows)
+                for row in rows:
+                    readiness = row.get("readiness") or (row.get("run") or {}).get("readiness")
+                    if isinstance(readiness, str):
+                        readiness_counts[readiness] = readiness_counts.get(readiness, 0) + 1
+                    for reason in row.get("invalidated_by", []) or []:
+                        if isinstance(reason, str):
+                            stale_reasons.append(reason)
+        except VanerDaemonUnavailable:
+            engine_available = False
+        diagnostic_status = "healthy" if engine_available and active_count > 0 else ("cold" if engine_available else "engine_unavailable")
+        return {
+            "engine_available": engine_available,
+            "source": source,
+            "daemon_with_engine": engine_available if engine is None else None,
+            "active_prediction_count": active_count,
+            "total_prediction_count": total_count,
+            "readiness_counts": readiness_counts,
+            "pending_adoption_outcomes": pending_adoptions,
+            "stale_or_invalidated_reasons": stale_reasons[-8:],
+            "diagnostic_status": diagnostic_status,
+        }
+
     @server.list_tools()
     async def list_tools() -> ListToolsResult:
         _detect_and_record_tier()
@@ -753,6 +912,11 @@ def build_server(
                                 "default": RESOLVE_INCLUDE_PREDICTED_RESPONSE_DEFAULT,
                             },
                             "include_metrics": {"type": "boolean", "default": False},
+                            "intent_packet": {
+                                "type": "boolean",
+                                "default": False,
+                                "description": "Return a compact pre-resolution packet instead of a final Resolution.",
+                            },
                             "estimated_cost_per_1k_tokens": {"type": "number", "default": 0.0},
                         },
                         "required": ["query"],
@@ -788,6 +952,7 @@ def build_server(
                                 "default": "hybrid",
                             },
                             "limit": {"type": "integer", "default": 10},
+                            "context": {"type": "object"},
                         },
                         "required": ["query"],
                     },
@@ -1464,6 +1629,7 @@ def build_server(
                     "coverage_gaps": lint_report.coverage_gaps,
                 },
                 "memory": {"counts": memory_counts, "quality": quality, "calibration": calibration},
+                "prediction_health": await _prediction_health_snapshot(),
             }
             # 0.8.3 WS4: surface active Deep-Run session state under
             # ``deep_run`` so cockpit / desktop / agents can render the
@@ -1486,6 +1652,7 @@ def build_server(
         if name == "vaner.suggest":
             query = str(args.get("query", "")).strip()
             limit = max(1, int(args.get("limit", 5)))
+            context_domain = _context_domain(args.get("context"))
             if not query:
                 await _record("error")
                 return _json_result({"code": "invalid_input", "message": "query is required"}, is_error=True)
@@ -1496,7 +1663,13 @@ def build_server(
                 overlap = len(query_tokens & set(tok.lower() for tok in scenario.entities))
                 confidence = min(
                     0.98,
-                    max(0.0, 0.25 + (overlap * 0.15) + (scenario.score * 0.45) - _scenario_penalty(scenario, query_tokens)),
+                    max(
+                        0.0,
+                        0.25
+                        + (overlap * 0.15)
+                        + (scenario.score * 0.45)
+                        - _scenario_penalty(scenario, query_tokens, domain=context_domain),
+                    ),
                 )
                 label = f"{scenario.kind} / {' '.join(scenario.entities[:4]) or scenario.id}"
                 suggestion_id = f"sug_{hashlib.sha1((query + scenario.id).encode('utf-8')).hexdigest()[:8]}"
@@ -1513,7 +1686,83 @@ def build_server(
             for item in picked:
                 _put_suggestion(str(item["id"]), item)
             top_confidence = float(picked[0]["confidence"]) if picked else 0.0
-            payload = {"suggestions": picked, "needs_clarification": top_confidence < 0.4}
+            prediction_rows: list[dict[str, Any]] = []
+            engine_unavailable = False
+            try:
+                if engine is not None:
+                    prediction_rows = [_serialize_prediction_for_mcp(p) for p in engine.get_active_predictions()]
+                else:
+                    prediction_rows = list((await _daemon().get_predictions_active()).get("predictions", []))
+            except VanerDaemonUnavailable:
+                engine_unavailable = True
+            adoptable_predictions = [
+                row
+                for row in prediction_rows
+                if row.get("adoptable") is True
+                and row.get("trust_status") != "invalidated"
+                and _prediction_matches_query(row, query_tokens)
+            ]
+            actions: list[dict[str, Any]] = [
+                {
+                    "tool": "vaner.predictions.active",
+                    "reason": "inspect prepared predictions before spending resolve budget",
+                    "arguments": {},
+                    "priority": "first",
+                }
+            ]
+            if adoptable_predictions:
+                first = adoptable_predictions[0]
+                actions.append(
+                    {
+                        "tool": "vaner.predictions.adopt",
+                        "reason": "a fresh prepared prediction is adoptable",
+                        "arguments": {"prediction_id": first.get("id")},
+                        "priority": "preferred",
+                    }
+                )
+            elif engine_unavailable or top_confidence < 0.4:
+                actions.append(
+                    {
+                        "tool": "vaner.resolve",
+                        "reason": "build an intent packet before final resolution",
+                        "arguments": {"query": query, "context": args.get("context") or {}, "intent_packet": True},
+                        "priority": "preferred",
+                    }
+                )
+            else:
+                actions.append(
+                    {
+                        "tool": "vaner.resolve",
+                        "reason": "no matching prepared prediction; resolve from stored evidence",
+                        "arguments": {"query": query, "context": args.get("context") or {}},
+                        "priority": "preferred",
+                    }
+                )
+            if picked:
+                actions.append(
+                    {
+                        "tool": "vaner.expand",
+                        "reason": "expand the highest-ranked stored scenario if more detail is needed",
+                        "arguments": {"target_id": picked[0]["scenario_id"]},
+                        "priority": "optional",
+                    }
+                )
+            payload = {
+                "suggestions": picked,
+                "needs_clarification": top_confidence < 0.4,
+                "guidance": {
+                    "recommended_action": actions[1] if len(actions) > 1 else actions[0],
+                    "actions": actions,
+                    "guardrails": [
+                        "adopt at most one prediction per turn",
+                        "do not call vaner.resolve when a fresh adopted package is already available",
+                        "prefer intent_packet=true when predictions are stale, unrelated, or the engine is unavailable",
+                        "record vaner.feedback after using a returned Resolution",
+                    ],
+                    "engine_unavailable": engine_unavailable,
+                    "domain": context_domain,
+                },
+            }
             append_log(repo_root, tool=name, label=query[:60], decision_id=None, provenance_mode=None, memory_state=None)
             await _record("ok")
             return _json_result(payload)
@@ -1524,11 +1773,20 @@ def build_server(
             # the engine directly. Otherwise forward to the daemon's /resolve
             # endpoint via the shared VanerDaemonClient (mirrors the WS3
             # predictions.* forward pattern).
+            query = str(args.get("query", "")).strip()
+            context_arg = args.get("context") or {}
+            if bool(args.get("intent_packet", False)):
+                if not query:
+                    await _record("error")
+                    return _json_result({"code": "invalid_input", "message": "query is required"}, is_error=True)
+                payload = await _build_intent_packet(query, scenario_store_arg=scenario_store, context_arg=context_arg)
+                append_log(repo_root, tool=name, label=query[:60], decision_id=None, provenance_mode="intent_packet", memory_state=None)
+                await _record("ok")
+                return _json_result(payload)
             if not _ensure_backend(config):
                 await _record("error")
                 return _backend_error(degradable=False)
             resolve_started_monotonic = time.monotonic()
-            query = str(args.get("query", "")).strip()
             if not query:
                 await _record("error")
                 return _json_result({"code": "invalid_input", "message": "query is required"}, is_error=True)
@@ -1573,7 +1831,6 @@ def build_server(
                 payload["suppressed_reason"] = "fresh_adopted_package_handoff"
                 return _json_result(payload)
             suggestion_id = str(args.get("suggestion_id", "")).strip()
-            context_arg = args.get("context") or {}
             if suggestion_id and suggestion_id in suggestion_cache:
                 # Carry the suggestion's label through to the engine so the
                 # resolve picks up the canonical form even when the caller's
@@ -1750,6 +2007,7 @@ def build_server(
             query = str(args.get("query", "")).strip()
             mode = str(args.get("mode", "hybrid")).strip()
             limit = max(1, int(args.get("limit", 10)))
+            context_domain = _context_domain(args.get("context"))
             if not query:
                 await _record("error")
                 return _json_result({"code": "invalid_input", "message": "query is required"}, is_error=True)
@@ -1764,7 +2022,13 @@ def build_server(
                 if score <= 0 and mode == "lexical":
                     continue
                 final_score = round(
-                    max(0.0, min(1.0, 0.2 + score * 0.2 + scenario.score * 0.5 - _scenario_penalty(scenario, query_tokens))),
+                    max(
+                        0.0,
+                        min(
+                            1.0,
+                            0.2 + score * 0.2 + scenario.score * 0.5 - _scenario_penalty(scenario, query_tokens, domain=context_domain),
+                        ),
+                    ),
                     4,
                 )
                 results.append(
@@ -2819,6 +3083,7 @@ def build_server(
                 "decision": decision.model_dump(mode="json") if decision else None,
                 "memory_quality": await metrics_store.memory_quality_snapshot(),
                 "recent_promotions": promotion_ring[-5:],
+                "prediction_health": await _prediction_health_snapshot(),
             }
             append_log(
                 repo_root,

--- a/src/vaner/setup/config_io.py
+++ b/src/vaner/setup/config_io.py
@@ -152,6 +152,7 @@ def _atomic_write_text(path: Path, text: str) -> None:
         try:
             tmp_path.unlink()
         except FileNotFoundError:
+            # Successful replace moves the temp file into place before cleanup.
             pass
 
 

--- a/src/vaner/setup/config_io.py
+++ b/src/vaner/setup/config_io.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Read and write Simple-Mode setup sections in ``.vaner/config.toml``."""
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from vaner.setup.answers import SetupAnswers
+
+logger = logging.getLogger(__name__)
+
+
+def read_setup_section(repo_root: Path) -> dict[str, Any]:
+    """Read the raw ``[setup]`` table from ``.vaner/config.toml``."""
+
+    return _read_config_section(repo_root, "setup")
+
+
+def read_policy_section(repo_root: Path) -> dict[str, Any]:
+    """Read the raw ``[policy]`` table from ``.vaner/config.toml``."""
+
+    return _read_config_section(repo_root, "policy")
+
+
+def persist_setup_and_policy(
+    repo_root: Path,
+    answers: SetupAnswers,
+    bundle_id: str,
+    *,
+    completed_at: datetime | None = None,
+) -> Path:
+    """Write wizard answers and selected policy bundle to ``config.toml``.
+
+    The update is idempotent for the same inputs and leaves unrelated
+    sections/keys untouched.
+    """
+
+    config_path = _init_repo_config(repo_root)
+    text = config_path.read_text(encoding="utf-8")
+    setup_values: dict[str, object] = {
+        "mode": "simple",
+        "work_styles": list(answers.work_styles),
+        "priority": answers.priority,
+        "compute_posture": answers.compute_posture,
+        "cloud_posture": answers.cloud_posture,
+        "background_posture": answers.background_posture,
+        "version": 1,
+    }
+    if completed_at is not None:
+        setup_values["completed_at"] = completed_at.isoformat()
+    text = update_toml_section(text, "setup", setup_values)
+    text = update_toml_section(
+        text,
+        "policy",
+        {"selected_bundle_id": bundle_id, "auto_select": True},
+    )
+    _atomic_write_text(config_path, text)
+    return config_path
+
+
+def toml_literal(value: object) -> str:
+    """Render a Python scalar/list as the TOML literal shape setup writes."""
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if value is None:
+        return '""'
+    if isinstance(value, list):
+        items = []
+        for item in value:
+            if isinstance(item, str):
+                escaped = item.replace("\\", "\\\\").replace('"', '\\"')
+                items.append(f'"{escaped}"')
+            else:
+                items.append(toml_literal(item))
+        return "[" + ", ".join(items) + "]"
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def update_toml_section(text: str, section: str, values: dict[str, object]) -> str:
+    """Update keys within one TOML section, preserving unrelated content."""
+
+    if not values:
+        return text
+    lines = text.splitlines()
+    header = f"[{section}]"
+    start: int | None = None
+    for idx, line in enumerate(lines):
+        if line.strip() == header:
+            start = idx
+            break
+    if start is None:
+        lines.append("")
+        lines.append(header)
+        for key, val in values.items():
+            lines.append(f"{key} = {toml_literal(val)}")
+        out = "\n".join(lines)
+        return out + ("\n" if not out.endswith("\n") else "")
+
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        stripped = lines[idx].strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            end = idx
+            break
+    remaining = dict(values)
+    for idx in range(start + 1, end):
+        stripped = lines[idx].lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key = stripped.split("=", 1)[0].strip()
+        if key in remaining:
+            lines[idx] = f"{key} = {toml_literal(remaining.pop(key))}"
+    if remaining:
+        insert_at = end
+        for key, val in remaining.items():
+            lines.insert(insert_at, f"{key} = {toml_literal(val)}")
+            insert_at += 1
+    out = "\n".join(lines)
+    return out + ("\n" if not out.endswith("\n") else "")
+
+
+def _read_config_section(repo_root: Path, section_name: str) -> dict[str, Any]:
+    config_path = repo_root / ".vaner" / "config.toml"
+    if not config_path.exists():
+        return {}
+    try:
+        parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning("Ignoring invalid Vaner setup config TOML at %s: %s", config_path, exc)
+        return {}
+    except OSError as exc:
+        logger.warning("Unable to read Vaner setup config at %s: %s", config_path, exc)
+        return {}
+    section = parsed.get(section_name, {})
+    return section if isinstance(section, dict) else {}
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    tmp_path = path.with_name(f".{path.name}.tmp")
+    try:
+        tmp_path.write_text(text, encoding="utf-8")
+        tmp_path.replace(path)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _init_repo_config(repo_root: Path) -> Path:
+    # Keep setup config I/O behavior aligned with `vaner init` without
+    # importing Typer/Rich-heavy modules until a write is actually needed.
+    from vaner.cli.commands.init import init_repo
+
+    return init_repo(repo_root)

--- a/src/vaner/setup/questions.py
+++ b/src/vaner/setup/questions.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical Simple-Mode setup questions.
+
+MCP and daemon HTTP intentionally expose slightly different public key
+names for the same five questions. Keep the ordered question data here
+and project it into each wire shape at the boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+QuestionKind = Literal["single", "multi"]
+QuestionDefault = str | list[str]
+
+
+class _QuestionOption(TypedDict):
+    value: str
+    label: str
+
+
+class _SetupQuestion(TypedDict):
+    id: str
+    text: str
+    kind: QuestionKind
+    default: QuestionDefault
+    options: tuple[_QuestionOption, ...]
+
+
+_SETUP_QUESTIONS_VERSION = 1
+
+_SETUP_QUESTIONS: tuple[_SetupQuestion, ...] = (
+    {
+        "id": "work_styles",
+        "text": "What kind of work do you want help with?",
+        "kind": "multi",
+        "default": ["mixed"],
+        "options": (
+            {"value": "writing", "label": "Writing — drafting, editing, narrative"},
+            {"value": "research", "label": "Research — surveys, deep reading, citations"},
+            {"value": "planning", "label": "Planning — design docs, roadmaps, project layout"},
+            {"value": "support", "label": "Support — answering questions, troubleshooting"},
+            {"value": "learning", "label": "Learning — studying, exploring a new domain"},
+            {"value": "coding", "label": "Coding — software development"},
+            {"value": "general", "label": "General — knowledge work, mixed light tasks"},
+            {"value": "mixed", "label": "Mixed — a bit of everything (safe default)"},
+            {"value": "unsure", "label": "Unsure — I'd rather Vaner picks for me"},
+        ),
+    },
+    {
+        "id": "priority",
+        "text": "What matters most?",
+        "kind": "single",
+        "default": "balanced",
+        "options": (
+            {"value": "balanced", "label": "Balanced — a sensible middle"},
+            {"value": "speed", "label": "Speed — snappy responses"},
+            {"value": "quality", "label": "Quality — best answer, even if slow"},
+            {"value": "privacy", "label": "Privacy — keep data on this machine"},
+            {"value": "cost", "label": "Cost — minimise spend"},
+            {"value": "low_resource", "label": "Low-resource — go easy on this machine"},
+        ),
+    },
+    {
+        "id": "compute_posture",
+        "text": "How hard should this machine work for you?",
+        "kind": "single",
+        "default": "balanced",
+        "options": (
+            {"value": "light", "label": "Light — barely use the CPU/GPU"},
+            {"value": "balanced", "label": "Balanced — work with what's idle"},
+            {"value": "available_power", "label": "Available-power — use what this box has"},
+        ),
+    },
+    {
+        "id": "cloud_posture",
+        "text": "How do you feel about cloud LLMs?",
+        "kind": "single",
+        "default": "ask_first",
+        "options": (
+            {"value": "local_only", "label": "Local only — never reach for cloud LLMs"},
+            {"value": "ask_first", "label": "Ask first — confirm before any cloud call"},
+            {"value": "hybrid_when_worth_it", "label": "Hybrid — cloud when it's clearly worth it"},
+            {"value": "best_available", "label": "Best available — use the best model for the job"},
+        ),
+    },
+    {
+        "id": "background_posture",
+        "text": "How aggressive should background pondering be?",
+        "kind": "single",
+        "default": "normal",
+        "options": (
+            {"value": "minimal", "label": "Minimal — barely ponder when idle"},
+            {"value": "normal", "label": "Normal — moderate background pondering"},
+            {"value": "idle_more", "label": "Idle-more — ponder broadly when the box is idle"},
+            {"value": "deep_run_aggressive", "label": "Deep-Run-aggressive — happy to run overnight"},
+        ),
+    },
+)
+
+
+def _copy_default(default: QuestionDefault) -> QuestionDefault:
+    return list(default) if isinstance(default, list) else default
+
+
+def _copy_options(question: _SetupQuestion) -> list[dict[str, str]]:
+    return [dict(option) for option in question["options"]]
+
+
+def setup_questions_for_mcp() -> list[dict[str, Any]]:
+    """Return the MCP ``vaner.setup.questions`` wire shape."""
+
+    return [
+        {
+            "id": question["id"],
+            "prompt": question["text"],
+            "kind": question["kind"],
+            "default": _copy_default(question["default"]),
+            "options": _copy_options(question),
+        }
+        for question in _SETUP_QUESTIONS
+    ]
+
+
+def setup_questions_for_http() -> dict[str, Any]:
+    """Return the daemon ``GET /setup/questions`` wire shape."""
+
+    return {
+        "version": _SETUP_QUESTIONS_VERSION,
+        "questions": [
+            {
+                "id": question["id"],
+                "title": question["text"],
+                "kind": question["kind"],
+                "default": _copy_default(question["default"]),
+                "choices": _copy_options(question),
+            }
+            for question in _SETUP_QUESTIONS
+        ],
+    }

--- a/tests/conformance-fixtures/adopt_response_rich.json
+++ b/tests/conformance-fixtures/adopt_response_rich.json
@@ -9,7 +9,13 @@
       "kind": "file",
       "locator": { "start_line": 1, "end_line": 42 },
       "reason": "most recent test file in this module",
-      "fingerprint": "sha256:abc123"
+      "fingerprint": "sha256:abc123",
+      "overlay": "working_tree",
+      "freshness": "fresh",
+      "captured_at": 1000000000.0,
+      "validated_at": 1000000120.0,
+      "confidence": 0.86,
+      "dependencies": [{ "source": "payments-svc/webhook.js", "relationship": "covers" }]
     }
   ],
   "alternatives_considered": [

--- a/tests/conformance-fixtures/predictions_active_composer_sample.json
+++ b/tests/conformance-fixtures/predictions_active_composer_sample.json
@@ -37,6 +37,12 @@
       "ui_summary": "Composer-aligned rewrite continuation ready",
       "suppression_reason": null,
       "source_label": "From your current draft",
+      "trust_status": "ready",
+      "freshness": "recent",
+      "invalidated_by": [],
+      "watched_sources": [],
+      "changed_sources": [],
+      "diagnostic_status": "unverified",
       "composer_engagement": {
         "composer_event_id": "evt-01HX9Z3K7M",
         "lifecycle_state": "submitted",

--- a/tests/conformance-fixtures/predictions_active_sample.json
+++ b/tests/conformance-fixtures/predictions_active_sample.json
@@ -36,7 +36,13 @@
       "rank": 1,
       "ui_summary": "Ready test draft for webhook signing",
       "suppression_reason": null,
-      "source_label": "Arc"
+      "source_label": "Arc",
+      "trust_status": "ready",
+      "freshness": "fresh",
+      "invalidated_by": [],
+      "watched_sources": ["payments-svc/webhook.js"],
+      "changed_sources": [],
+      "diagnostic_status": "verified"
     },
     {
       "id": "pred-goal-0002",
@@ -74,7 +80,13 @@
       "rank": 2,
       "ui_summary": "JWT migration rollout is almost draft-ready",
       "suppression_reason": null,
-      "source_label": "Goal"
+      "source_label": "Goal",
+      "trust_status": "ready",
+      "freshness": "recent",
+      "invalidated_by": [],
+      "watched_sources": [],
+      "changed_sources": [],
+      "diagnostic_status": "unverified"
     },
     {
       "id": "pred-queued-0003",
@@ -112,7 +124,13 @@
       "rank": 3,
       "ui_summary": "OAuth refresh-token branch is still maturing",
       "suppression_reason": "low_confidence",
-      "source_label": "Macro"
+      "source_label": "Macro",
+      "trust_status": "preparing",
+      "freshness": "recent",
+      "invalidated_by": [],
+      "watched_sources": [],
+      "changed_sources": [],
+      "diagnostic_status": "not_checked"
     }
   ]
 }

--- a/tests/conformance-fixtures/predictions_single_sample.json
+++ b/tests/conformance-fixtures/predictions_single_sample.json
@@ -34,5 +34,11 @@
   "rank": 1,
   "ui_summary": "Next: write the webhook signing regression test.",
   "suppression_reason": null,
-  "source_label": "Conversation arc"
+  "source_label": "Conversation arc",
+  "trust_status": "ready",
+  "freshness": "fresh",
+  "invalidated_by": [],
+  "watched_sources": ["payments-svc/webhook.js"],
+  "changed_sources": [],
+  "diagnostic_status": "verified"
 }

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
+
 import pytest
 
 from vaner.cli.commands.config import load_config, set_compute_value
@@ -90,6 +93,39 @@ idle_gpu_threshold = 0.8
 embedding_device = "cuda"
 exploration_concurrency = 6
 max_parallel_precompute = 2
+
+[sources.intent_artefacts]
+enabled = false
+
+[sources.intent_artefacts.markdown_outline]
+enabled = true
+max_candidates = 42
+
+[refinement]
+enabled = false
+max_candidates_per_cycle = 2
+
+[integrations]
+guidance_variant = "strong"
+advertise_guidance_resource = false
+
+[integrations.context_injection]
+mode = "digest_only"
+digest_token_budget = 250
+
+[setup]
+mode = "advanced"
+work_styles = ["coding", "research"]
+priority = "quality"
+compute_posture = "available_power"
+cloud_posture = "hybrid_when_worth_it"
+background_posture = "deep_run_aggressive"
+completed_at = "2026-04-26T12:00:00+00:00"
+version = 1
+
+[policy]
+selected_bundle_id = "deep_research"
+auto_select = false
 """.strip(),
         encoding="utf-8",
     )
@@ -130,6 +166,120 @@ max_parallel_precompute = 2
     assert config.compute.embedding_device == "cuda"
     assert config.compute.exploration_concurrency == 6
     assert config.compute.max_parallel_precompute == 2
+    assert config.sources.intent_artefacts.enabled is False
+    assert config.sources.intent_artefacts.markdown_outline.enabled is True
+    assert config.sources.intent_artefacts.markdown_outline.max_candidates == 42
+    assert config.refinement.enabled is False
+    assert config.refinement.max_candidates_per_cycle == 2
+    assert config.integrations.guidance_variant == "strong"
+    assert config.integrations.advertise_guidance_resource is False
+    assert config.integrations.context_injection.mode == "digest_only"
+    assert config.integrations.context_injection.digest_token_budget == 250
+    assert config.setup.mode == "advanced"
+    assert config.setup.work_styles == ["coding", "research"]
+    assert config.setup.priority == "quality"
+    assert config.setup.compute_posture == "available_power"
+    assert config.setup.cloud_posture == "hybrid_when_worth_it"
+    assert config.setup.background_posture == "deep_run_aggressive"
+    assert config.setup.completed_at is not None
+    assert config.policy.selected_bundle_id == "deep_research"
+    assert config.policy.auto_select is False
+
+
+def test_load_config_merges_global_and_local_setup_policy(
+    temp_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    global_path = tmp_path / "global-config.toml"
+    global_path.write_text(
+        """
+[setup]
+priority = "speed"
+work_styles = ["writing"]
+
+[policy]
+selected_bundle_id = "cost_saver"
+auto_select = false
+""".strip(),
+        encoding="utf-8",
+    )
+    local_vaner_dir = temp_repo / ".vaner"
+    local_vaner_dir.mkdir(parents=True, exist_ok=True)
+    (local_vaner_dir / "config.toml").write_text(
+        """
+[setup]
+priority = "privacy"
+
+[policy]
+bundle_overrides = { max_context_tokens = 1024 }
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VANER_GLOBAL_CONFIG", str(global_path))
+
+    config = load_config(temp_repo)
+
+    assert config.setup.priority == "privacy"
+    assert config.setup.work_styles == ["writing"]
+    assert config.policy.selected_bundle_id == "cost_saver"
+    assert config.policy.auto_select is False
+    assert config.policy.bundle_overrides == {"max_context_tokens": 1024}
+
+
+def test_load_config_warns_for_invalid_local_toml(
+    temp_repo: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    vaner_dir = temp_repo / ".vaner"
+    vaner_dir.mkdir(parents=True, exist_ok=True)
+    (vaner_dir / "config.toml").write_text("[setup\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger="vaner.cli.commands.config"):
+        config = load_config(temp_repo)
+
+    assert config.setup.priority == "balanced"
+    assert "Ignoring invalid Vaner config TOML" in caplog.text
+    assert str(vaner_dir / "config.toml") in caplog.text
+
+
+def test_load_config_warns_and_defaults_invalid_semantic_sections(
+    temp_repo: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    vaner_dir = temp_repo / ".vaner"
+    vaner_dir.mkdir(parents=True, exist_ok=True)
+    (vaner_dir / "config.toml").write_text(
+        """
+[setup]
+priority = "not-a-priority"
+
+[policy]
+bundle_overrides = "not-a-table"
+
+[integrations]
+guidance_variant = "loud"
+
+[limits]
+max_age_seconds = "forever"
+max_context_tokens = { bad = "shape" }
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="vaner.cli.commands.config"):
+        config = load_config(temp_repo)
+
+    assert config.setup.priority == "balanced"
+    assert config.policy.bundle_overrides == {}
+    assert config.integrations.guidance_variant == "canonical"
+    assert config.max_age_seconds == 3600
+    assert config.max_context_tokens == 4096
+    assert "Ignoring invalid Vaner config section [setup]" in caplog.text
+    assert "Ignoring invalid Vaner config section [policy]" in caplog.text
+    assert "Ignoring invalid Vaner config section [integrations]" in caplog.text
+    assert "Ignoring invalid Vaner config value [limits].max_age_seconds" in caplog.text
+    assert "Ignoring invalid Vaner config value [limits].max_context_tokens" in caplog.text
 
 
 def test_set_compute_value_updates_existing_section(temp_repo):

--- a/tests/test_cli/test_setup_cli.py
+++ b/tests/test_cli/test_setup_cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from vaner.cli.commands import setup as setup_commands
 from vaner.cli.commands.app import app
 from vaner.cli.commands.setup import setup_app
 from vaner.setup.hardware import HardwareProfile
@@ -400,6 +401,22 @@ def test_hardware_json(fake_hardware: HardwareProfile) -> None:
     assert parsed["cpu_class"] == "mid"
     assert parsed["ram_gb"] == 16
     assert parsed["tier"] == "capable"
+
+
+def test_ping_daemon_for_refresh_uses_env_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    def _fake_probe(base_url: str) -> dict[str, object]:
+        seen["base_url"] = base_url
+        return {"reachable": True, "url": base_url}
+
+    monkeypatch.setenv("VANER_DAEMON_URL", "http://127.0.0.1:9999")
+    monkeypatch.setattr(setup_commands, "probe_daemon_status", _fake_probe)
+
+    result = setup_commands._ping_daemon_for_refresh()
+
+    assert seen["base_url"] == "http://127.0.0.1:9999"
+    assert result["note"] == "daemon will pick up changes on next config reload"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clients/test_daemon_client.py
+++ b/tests/test_clients/test_daemon_client.py
@@ -7,14 +7,20 @@ standing up a real daemon.
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 
 from vaner.clients.daemon import (
+    DAEMON_PROBE_TIMEOUT,
+    DAEMON_STATUS_PATH,
     DEFAULT_BASE_URL,
     VanerDaemonClient,
     VanerDaemonNotFound,
     VanerDaemonUnavailable,
+    daemon_base_url_from_env,
+    probe_daemon_status,
 )
 
 
@@ -207,6 +213,40 @@ async def test_adopt_prediction_5xx_raises_unavailable():
 
 
 # ---------------------------------------------------------------------------
+# resolve
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_defaults_include_briefing_and_predicted_response():
+    seen: dict[str, bytes] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen["json"] = request.read()
+        assert request.url.path == "/resolve"
+        payload = json.loads(seen["json"])
+        assert payload["include_briefing"] is True
+        assert payload["include_predicted_response"] is True
+        return httpx.Response(
+            200,
+            json={
+                "intent": "Do the thing",
+                "confidence": 0.8,
+                "summary": "resolved",
+                "evidence": [],
+                "provenance": {"mode": "predictive_hit"},
+                "resolution_id": "resolve-1",
+            },
+        )
+
+    client = _client(_handler)
+    resolution = await client.resolve("Do the thing")
+
+    assert resolution.resolution_id == "resolve-1"
+    assert seen["json"]
+
+
+# ---------------------------------------------------------------------------
 # Client construction defaults
 # ---------------------------------------------------------------------------
 
@@ -219,3 +259,38 @@ def test_default_base_url_is_localhost_8473():
 def test_base_url_trailing_slash_is_stripped():
     client = VanerDaemonClient(base_url="http://example.com/")
     assert client._base == "http://example.com"
+
+
+def test_daemon_base_url_from_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VANER_DAEMON_URL", "http://127.0.0.1:9999")
+
+    assert daemon_base_url_from_env() == "http://127.0.0.1:9999"
+
+
+def test_probe_daemon_status_uses_shared_status_path_and_success_shape():
+    seen: dict[str, str] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"health": "ok"})
+
+    transport = httpx.MockTransport(_handler)
+    with httpx.Client(transport=transport, base_url=DEFAULT_BASE_URL) as client:
+        result = probe_daemon_status(DEFAULT_BASE_URL, client=client)
+
+    assert seen["path"] == DAEMON_STATUS_PATH
+    assert result["reachable"] is True
+    assert result["url"] == DEFAULT_BASE_URL
+    assert result["payload"] == {"health": "ok"}
+
+
+def test_probe_daemon_status_reports_non_200_without_raising():
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="down")
+
+    transport = httpx.MockTransport(_handler)
+    with httpx.Client(transport=transport, base_url=DEFAULT_BASE_URL) as client:
+        result = probe_daemon_status(DEFAULT_BASE_URL, client=client)
+
+    assert result == {"reachable": False, "url": DEFAULT_BASE_URL, "status_code": 503}
+    assert DAEMON_PROBE_TIMEOUT == 1.0

--- a/tests/test_conformance/test_fixtures_match.py
+++ b/tests/test_conformance/test_fixtures_match.py
@@ -62,6 +62,14 @@ ARTIFACTS_KEYS = {
     "has_briefing": bool,
     "thinking_trace_count": int,
 }
+PREDICTION_TRUST_KEYS = {
+    "trust_status": str,
+    "freshness": str,
+    "invalidated_by": list,
+    "watched_sources": list,
+    "changed_sources": list,
+    "diagnostic_status": str,
+}
 
 
 def _assert_shape(row: dict, expected: dict[str, type]) -> None:
@@ -89,6 +97,7 @@ def test_predictions_active_envelope_shape():
 
     for row in body["predictions"]:
         _assert_shape(row, PREDICTION_SHAPE_KEYS)
+        _assert_shape(row, PREDICTION_TRUST_KEYS)
         _assert_shape(row["spec"], SPEC_KEYS)
         _assert_shape(row["run"], RUN_KEYS)
         _assert_shape(row["artifacts"], ARTIFACTS_KEYS)
@@ -113,11 +122,14 @@ def test_predictions_active_envelope_shape():
             "ready",
             "stale",
         }
+        assert row["trust_status"] in {"ready", "preparing", "invalidated"}
+        assert row["freshness"] in {"fresh", "recent", "stale"}
 
 
 def test_predictions_single_shape():
     row = _load("predictions_single_sample.json")
     _assert_shape(row, PREDICTION_SHAPE_KEYS)
+    _assert_shape(row, PREDICTION_TRUST_KEYS)
     _assert_shape(row["spec"], SPEC_KEYS)
     _assert_shape(row["run"], RUN_KEYS)
     _assert_shape(row["artifacts"], ARTIFACTS_KEYS)

--- a/tests/test_daemon/test_http.py
+++ b/tests/test_daemon/test_http.py
@@ -52,6 +52,8 @@ def test_status_payload_includes_backend(temp_repo) -> None:
     assert "backend" in payload
     assert payload["backend"]["base_url"] == config.backend.base_url
     assert payload["backend"]["model"] == config.backend.model
+    assert payload["prediction_health"]["engine_available"] is False
+    assert payload["prediction_health"]["diagnostic_status"] == "engine_unavailable"
 
 
 def test_ui_route_redirects_to_root(temp_repo) -> None:

--- a/tests/test_daemon/test_predictions_endpoint.py
+++ b/tests/test_daemon/test_predictions_endpoint.py
@@ -83,6 +83,11 @@ def test_predictions_active_returns_live_predictions(temp_repo):
     assert row["run"]["readiness"] == "queued"
     assert "token_budget" in row["run"]
     assert row["artifacts"]["has_draft"] is False
+    assert row["readiness_label"] == "Queued"
+    assert row["trust_status"] == "preparing"
+    assert row["freshness"] == "recent"
+    assert row["watched_sources"] == []
+    assert row["diagnostic_status"] == "not_checked"
 
 
 def test_predictions_single_returns_404_when_registry_absent(temp_repo):
@@ -165,6 +170,8 @@ def test_adopt_returns_resolution_with_prepared_package(temp_repo):
     assert body["predicted_response"] == "Here is a suggested answer."
     assert body["intent"] == "Write the next test"
     assert body["provenance"]["mode"] == "predictive_hit"
+    descriptors = registry.consume_pending_adoption_descriptors()
+    assert [item["prediction_id"] for item in descriptors] == [pid]
 
 
 def test_adopt_returns_404_for_unknown_id(temp_repo):

--- a/tests/test_daemon/test_setup_endpoints.py
+++ b/tests/test_daemon/test_setup_endpoints.py
@@ -116,6 +116,13 @@ def test_post_setup_recommend_invalid_work_styles(client: TestClient) -> None:
     bad["work_styles"] = [1, 2, 3]  # not strings
     resp = client.post("/setup/recommend", json=bad)
     assert resp.status_code == 400
+    assert resp.json()["detail"] == "work_styles must be a list of strings"
+
+
+def test_post_setup_recommend_non_object_body(client: TestClient) -> None:
+    resp = client.post("/setup/recommend", json=[])
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "answers must be a JSON object"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp/test_server_boot.py
+++ b/tests/test_mcp/test_server_boot.py
@@ -52,6 +52,10 @@ def test_server_boot_initialize_lists_tools_and_status(temp_repo) -> None:
                 "include_metrics",
                 "estimated_cost_per_1k_tokens",
             }
+            assert resolve_schema["properties"]["include_briefing"]["default"] is True
+            assert resolve_schema["properties"]["include_predicted_response"]["default"] is True
+            assert "currently accepted but not applied" in resolve_schema["properties"]["budget"]["description"]
+            assert "currently accepted but not applied" in resolve_schema["properties"]["max_evidence_items"]["description"]
             status = await session.call_tool("vaner.status", {})
             assert json.loads(status.content[0].text)["ready"] is True
 

--- a/tests/test_mcp/test_setup_tools.py
+++ b/tests/test_mcp/test_setup_tools.py
@@ -37,6 +37,16 @@ def _call(server, name: str, arguments: dict | None = None) -> dict:
     return asyncio.run(_run())
 
 
+def _list_tool_schemas(server) -> dict[str, dict]:
+    handler = server.request_handlers[ListToolsRequest]
+
+    async def _run() -> dict[str, dict]:
+        resp = await handler(ListToolsRequest(method="tools/list"))
+        return {tool.name: tool.inputSchema for tool in resp.root.tools}
+
+    return asyncio.run(_run())
+
+
 # ---------------------------------------------------------------------------
 # vaner.setup.questions
 # ---------------------------------------------------------------------------
@@ -123,6 +133,47 @@ def test_recommend_accepts_single_string_work_style(temp_repo) -> None:
     out = _call(server, "vaner.setup.recommend", {"work_styles": "coding"})
     assert out["isError"] is False
     assert out["payload"]["bundle"]["id"]
+
+
+def test_recommend_rejects_invalid_work_styles_with_structured_error(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.recommend", {"work_styles": [1, 2, 3]})
+    assert out["isError"] is True
+    assert out["payload"]["code"] == "invalid_input"
+    assert out["payload"]["message"] == "work_styles must be a list of strings"
+
+
+def test_recommend_schema_constrains_scalar_setup_fields(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+
+    schema = _list_tool_schemas(server)["vaner.setup.recommend"]
+    properties = schema["properties"]
+
+    assert properties["work_styles"]["anyOf"] == [{"type": "string"}, {"type": "array"}]
+    assert "items" not in properties["work_styles"]
+    assert set(properties["priority"]["enum"]) == {
+        "balanced",
+        "speed",
+        "quality",
+        "privacy",
+        "cost",
+        "low_resource",
+    }
+    assert properties["compute_posture"]["enum"] == ["light", "balanced", "available_power"]
+    assert properties["cloud_posture"]["enum"] == [
+        "local_only",
+        "ask_first",
+        "hybrid_when_worth_it",
+        "best_available",
+    ]
+    assert properties["background_posture"]["enum"] == [
+        "minimal",
+        "normal",
+        "idle_more",
+        "deep_run_aggressive",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +279,15 @@ def test_apply_requires_answers_or_bundle_id(temp_repo) -> None:
     out = _call(server, "vaner.setup.apply", {})
     assert out["isError"] is True
     assert out["payload"]["code"] == "invalid_input"
+
+
+def test_apply_rejects_invalid_answers_payload(temp_repo) -> None:
+    _seed_repo(temp_repo)
+    server = build_server(temp_repo)
+    out = _call(server, "vaner.setup.apply", {"answers": {"work_styles": [1, 2, 3]}})
+    assert out["isError"] is True
+    assert out["payload"]["code"] == "invalid_input"
+    assert out["payload"]["message"] == "work_styles must be a list of strings"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp/test_tool_registry_parity.py
+++ b/tests/test_mcp/test_tool_registry_parity.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import re
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from vaner.mcp import server as mcp_server
+
+
+def test_listed_mcp_tools_have_dispatch_branches(temp_repo) -> None:
+    """Catch drift between the public tool list and the call dispatcher."""
+
+    async def _run() -> None:
+        memory = pytest.importorskip("mcp.shared.memory")
+        server = mcp_server.build_server(temp_repo)
+        async with memory.create_connected_server_and_client_session(server) as session:
+            await session.initialize()
+            listed = {tool.name for tool in (await session.list_tools()).tools}
+
+        source = inspect.getsource(mcp_server.build_server)
+        handled = set(re.findall(r'if name == "(vaner\.[^"]+)"', source))
+
+        assert listed <= handled
+
+    asyncio.run(_run())
+
+
+def test_unknown_mcp_tool_uses_structured_error(temp_repo) -> None:
+    async def _run() -> None:
+        memory = pytest.importorskip("mcp.shared.memory")
+        server = mcp_server.build_server(temp_repo)
+        async with memory.create_connected_server_and_client_session(server) as session:
+            await session.initialize()
+            result = await session.call_tool("vaner.not_a_tool", {})
+
+        assert result.isError is True
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "unknown_tool"
+        assert result.structuredContent == payload
+
+    asyncio.run(_run())
+
+
+def test_unknown_artefacts_tool_error_names_subsystem(temp_repo) -> None:
+    source = inspect.getsource(mcp_server.build_server)
+    assert "unknown artefacts/sources tool" in source
+    assert "unknown goals tool: {name}" not in source
+
+
+def test_basic_mcp_success_sets_structured_content(temp_repo) -> None:
+    async def _run() -> None:
+        memory = pytest.importorskip("mcp.shared.memory")
+        server = mcp_server.build_server(temp_repo)
+        async with memory.create_connected_server_and_client_session(server) as session:
+            await session.initialize()
+            result = await session.call_tool("vaner.status", {})
+
+        assert result.isError is not True
+        payload = json.loads(result.content[0].text)
+        assert result.structuredContent == payload
+        assert payload["ready"] is True
+
+    asyncio.run(_run())

--- a/tests/test_mcp_apps/test_dashboard_tool.py
+++ b/tests/test_mcp_apps/test_dashboard_tool.py
@@ -8,12 +8,14 @@ import asyncio
 import importlib.util
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 if importlib.util.find_spec("mcp") is None:  # pragma: no cover - CI matrix dependent
     pytest.skip("mcp package is unavailable in this test environment", allow_module_level=True)
 
+from vaner.integrations.capability import detect_tier, record_tier, reset_cache
 from vaner.intent.prediction import (
     PredictedPrompt,
     PredictionArtifacts,
@@ -21,6 +23,13 @@ from vaner.intent.prediction import (
     PredictionSpec,
     prediction_id,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_capability_cache() -> None:
+    reset_cache()
+    yield
+    reset_cache()
 
 
 def _prompt(
@@ -66,8 +75,16 @@ class _StubEngine:
         return list(self._prompts)
 
 
-def _call(server, name: str, arguments: dict | None = None) -> dict:
-    async def _do() -> dict:
+def _json_payload_from_result(result) -> dict:
+    for item in result.root.content:
+        text = getattr(item, "text", None)
+        if text is not None:
+            return json.loads(text)
+    raise AssertionError("tool result did not include a JSON text payload")
+
+
+def _call_result(server, name: str, arguments: dict | None = None):
+    async def _do():
         from mcp.types import CallToolRequest, CallToolRequestParams
 
         handler = server.request_handlers[CallToolRequest]
@@ -75,10 +92,13 @@ def _call(server, name: str, arguments: dict | None = None) -> dict:
             method="tools/call",
             params=CallToolRequestParams(name=name, arguments=arguments or {}),
         )
-        result = await handler(req)
-        return json.loads(result.root.content[0].text)
+        return await handler(req)
 
     return asyncio.run(_do())
+
+
+def _call(server, name: str, arguments: dict | None = None) -> dict:
+    return _json_payload_from_result(_call_result(server, name, arguments))
 
 
 def _build(tmp_path: Path, prompts: list[PredictedPrompt]):
@@ -108,6 +128,42 @@ def test_dashboard_returns_cards_with_ui_available_false_by_default(tmp_path: Pa
     # Adoptable ordering: ready alpha first.
     assert payload["predictions"][0]["label"] == "Ready alpha"
     assert payload["predictions"][0]["rank"] == 1
+
+
+def test_dashboard_fallback_path_sets_structured_content(tmp_path: Path) -> None:
+    server = _build(tmp_path, [_prompt(label="one")])
+    result = _call_result(server, "vaner.predictions.dashboard")
+    payload = _json_payload_from_result(result)
+    assert result.root.structuredContent == payload
+
+
+def test_dashboard_resource_link_path_sets_structured_content(tmp_path: Path) -> None:
+    from mcp.server.lowlevel.server import RequestContext, request_ctx
+
+    class _Session:
+        pass
+
+    session = _Session()
+    session.client_params = SimpleNamespace(
+        clientInfo=SimpleNamespace(name="tier4-client", version="1.0"),
+        capabilities=SimpleNamespace(
+            experimental={"io.modelcontextprotocol/ui": {}},
+            roots=SimpleNamespace(),
+            sampling=None,
+        ),
+    )
+    record_tier(session, detect_tier(session.client_params))
+    token = request_ctx.set(RequestContext(request_id="test", meta=None, session=session, lifespan_context=None))
+    try:
+        server = _build(tmp_path, [_prompt(label="one")])
+        result = _call_result(server, "vaner.predictions.dashboard")
+    finally:
+        request_ctx.reset(token)
+
+    payload = _json_payload_from_result(result)
+    assert payload["ui_available"] is True
+    assert result.root.structuredContent == payload
+    assert any(getattr(item, "type", None) == "resource_link" for item in result.root.content)
 
 
 def test_dashboard_respects_limit(tmp_path: Path) -> None:

--- a/tests/test_mcp_apps/test_resource_registration.py
+++ b/tests/test_mcp_apps/test_resource_registration.py
@@ -40,6 +40,8 @@ def test_list_resources_includes_ui_bundle_when_enabled(tmp_path: Path) -> None:
     uris = {str(r.uri) for r in resources}
     assert "ui://vaner/active-predictions" in uris
     assert "vaner://guidance/current" in uris
+    assert "vaner://guidance/current?variant=weak" in uris
+    assert "vaner://guidance/current?variant=strong" in uris
 
 
 def test_list_resources_omits_ui_bundle_when_disabled(tmp_path: Path) -> None:
@@ -56,6 +58,7 @@ def test_list_resources_omits_ui_bundle_when_disabled(tmp_path: Path) -> None:
     uris = {str(r.uri) for r in resources}
     assert "ui://vaner/active-predictions" not in uris
     assert "vaner://guidance/current" in uris  # guidance resource still advertised
+    assert "vaner://guidance/current?variant=weak" in uris
 
 
 def test_read_resource_returns_ui_html(tmp_path: Path) -> None:
@@ -79,3 +82,41 @@ def test_read_resource_returns_ui_html(tmp_path: Path) -> None:
     html = asyncio.run(_run())
     assert "<!doctype html>" in html.lower()
     assert "Vaner" in html
+
+
+@pytest.mark.parametrize("apps_ui_enabled", [True, False])
+def test_listed_resources_are_readable(tmp_path: Path, apps_ui_enabled: bool) -> None:
+    server = _build(tmp_path, apps_ui_enabled=apps_ui_enabled)
+
+    async def _run() -> dict[str, str]:
+        from mcp.types import (
+            ListResourcesRequest,
+            ReadResourceRequest,
+            ReadResourceRequestParams,
+        )
+        from pydantic import AnyUrl
+
+        list_handler = server.request_handlers[ListResourcesRequest]
+        read_handler = server.request_handlers[ReadResourceRequest]
+        resources = list((await list_handler(ListResourcesRequest(method="resources/list"))).root.resources)
+        contents: dict[str, str] = {}
+        for resource in resources:
+            uri = str(resource.uri)
+            result = await read_handler(
+                ReadResourceRequest(
+                    method="resources/read",
+                    params=ReadResourceRequestParams(uri=AnyUrl(uri)),
+                )
+            )
+            contents[uri] = result.root.contents[0].text
+        return contents
+
+    contents_by_uri = asyncio.run(_run())
+    assert "vaner://guidance/current" in contents_by_uri
+    assert contents_by_uri["vaner://guidance/current"]
+    assert "vaner://guidance/current?variant=weak" in contents_by_uri
+    assert contents_by_uri["vaner://guidance/current?variant=weak"]
+    if apps_ui_enabled:
+        assert "<!doctype html>" in contents_by_uri["ui://vaner/active-predictions"].lower()
+    else:
+        assert "ui://vaner/active-predictions" not in contents_by_uri

--- a/tests/test_mcp_apps/test_serialize_prediction.py
+++ b/tests/test_mcp_apps/test_serialize_prediction.py
@@ -57,7 +57,11 @@ def _prompt(
         readiness=readiness,
         updated_at=0.0,
     )
-    artifacts = PredictionArtifacts(prepared_briefing=briefing, draft_answer=draft)
+    artifacts = PredictionArtifacts(
+        prepared_briefing=briefing,
+        draft_answer=draft,
+        file_content_hashes={"docs/plan.md": "sha256:abc123"} if briefing else {},
+    )
     return PredictedPrompt(spec=spec, run=run, artifacts=artifacts)
 
 
@@ -92,3 +96,13 @@ def test_scenarios_spawned_round_trips() -> None:
     payload = _serialize_prediction_for_mcp(_prompt())
     assert payload["scenarios_spawned"] == 4
     assert payload["scenarios_complete"] == 3
+
+
+def test_payload_contains_trust_fields() -> None:
+    payload = _serialize_prediction_for_mcp(_prompt())
+    assert payload["trust_status"] == "ready"
+    assert payload["freshness"] == "fresh"
+    assert payload["watched_sources"] == ["docs/plan.md"]
+    assert payload["changed_sources"] == []
+    assert payload["invalidated_by"] == []
+    assert payload["diagnostic_status"] == "verified"

--- a/tests/test_mcp_v2/test_debug_trace.py
+++ b/tests/test_mcp_v2/test_debug_trace.py
@@ -7,3 +7,11 @@ def test_debug_trace_disabled_by_default(mcp_server) -> None:
     result = call_tool(mcp_server, "vaner.debug.trace")
     payload = parse_content(result)
     assert payload["code"] == "debug_disabled"
+
+
+def test_debug_trace_includes_prediction_health_when_enabled(mcp_server, monkeypatch) -> None:
+    monkeypatch.setenv("VANER_MCP_DEBUG", "1")
+    result = call_tool(mcp_server, "vaner.debug.trace")
+    payload = parse_content(result)
+    assert "prediction_health" in payload
+    assert payload["prediction_health"]["diagnostic_status"] in {"healthy", "cold", "engine_unavailable"}

--- a/tests/test_mcp_v2/test_feedback.py
+++ b/tests/test_mcp_v2/test_feedback.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import time
+
+from vaner.models.decision import DecisionRecord, SelectionDecision
+from vaner.store.scenarios import ScenarioStore
+from vaner.telemetry.metrics import MetricsStore
 
 from .conftest import call_tool, parse_content, seed_scenario
 
@@ -23,3 +28,65 @@ def test_feedback_returns_memory_transition(temp_repo, mcp_server, monkeypatch) 
     feedback_payload = parse_content(feedback)
     assert feedback_payload["accepted"] is True
     assert "memory_transition" in feedback_payload
+
+
+def test_feedback_promotes_correction_confirmed_candidate_and_metrics_use_post_state(
+    temp_repo,
+    mcp_server,
+) -> None:
+    scenario_id = "scn_correction_confirmed"
+    seed_scenario(temp_repo, scenario_id=scenario_id, memory_state="candidate", confidence=0.4)
+
+    async def _prepare() -> None:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.record_outcome(scenario_id, "wrong")
+        metrics = MetricsStore(temp_repo / ".vaner" / "metrics.db")
+        await metrics.initialize()
+
+    asyncio.run(_prepare())
+    DecisionRecord(
+        id="decision-correction-confirmed",
+        prompt="auth",
+        prompt_hash="hash",
+        assembled_at=time.time(),
+        cache_tier="warm",
+        partial_similarity=0.2,
+        token_budget=1000,
+        token_used=100,
+        selections=[
+            SelectionDecision(
+                artefact_key=scenario_id,
+                source_path="src/auth.py",
+                final_score=0.7,
+                token_count=100,
+                stale=False,
+                kept=True,
+            )
+        ],
+    ).write(temp_repo)
+
+    feedback = call_tool(
+        mcp_server,
+        "vaner.feedback",
+        {
+            "resolution_id": "decision-correction-confirmed",
+            "rating": "useful",
+            "query": "auth",
+        },
+    )
+    feedback_payload = parse_content(feedback)
+
+    async def _assert() -> None:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        scenario = await store.get(scenario_id)
+        metrics = MetricsStore(temp_repo / ".vaner" / "metrics.db")
+        snapshot = await metrics.memory_quality_snapshot()
+        assert scenario is not None
+        assert scenario.memory_state == "trusted"
+        assert snapshot["promotion_precision"] == 1.0
+        assert snapshot["correction_survival_rate"] == 1.0
+
+    assert feedback_payload["memory_transition"]["reason"] == "correction_confirmed"
+    asyncio.run(_assert())

--- a/tests/test_mcp_v2/test_resolve.py
+++ b/tests/test_mcp_v2/test_resolve.py
@@ -17,7 +17,7 @@ What survives:
 - ``Abstain(reason="low_confidence")`` — MCP-surface concern, still
   applied against the engine's Resolution.confidence output.
 - ``include_briefing`` / ``include_predicted_response`` / ``include_metrics``
-  opt-in flags.
+    include flags.
 - ``resolution_id``, ``provenance.mode``, token accounting, evidence list.
 """
 
@@ -163,6 +163,16 @@ def test_resolve_forwards_opt_in_flags_to_engine(temp_repo) -> None:
     assert engine.calls[0]["include_predicted_response"] is True
 
 
+def test_resolve_defaults_include_briefing_and_predicted_response(temp_repo) -> None:
+    engine = _StubEngine(resolution=_build_resolution())
+    server = _make_server(temp_repo, engine=engine)
+
+    call_tool(server, "vaner.resolve", {"query": "default include flags"})
+
+    assert engine.calls[0]["include_briefing"] is True
+    assert engine.calls[0]["include_predicted_response"] is True
+
+
 def test_resolve_abstains_on_low_confidence(temp_repo) -> None:
     """The engine doesn't produce Abstain — the MCP shim applies the
     0.35 threshold as a surface-level policy."""
@@ -244,8 +254,8 @@ class _StubDaemonClient:
         query: str,
         *,
         context: dict | None = None,
-        include_briefing: bool = False,
-        include_predicted_response: bool = False,
+        include_briefing: bool = True,
+        include_predicted_response: bool = True,
     ) -> Resolution:
         self.calls.append(
             {
@@ -286,7 +296,7 @@ def test_resolve_forwards_to_injected_daemon_client_when_no_engine(temp_repo) ->
             "query": "delegated question",
             "context": {},
             "include_briefing": True,
-            "include_predicted_response": False,
+            "include_predicted_response": True,
         }
     ]
 

--- a/tests/test_mcp_v2/test_resolve.py
+++ b/tests/test_mcp_v2/test_resolve.py
@@ -36,7 +36,7 @@ from vaner.mcp.contracts import (
     Resolution,
 )
 
-from .conftest import call_tool, parse_content
+from .conftest import call_tool, parse_content, seed_scenario
 
 
 @dataclass
@@ -244,9 +244,16 @@ def test_resolve_include_metrics_returns_runtime_economics(temp_repo) -> None:
 class _StubDaemonClient:
     """Records calls + returns the injected Resolution (or raises)."""
 
-    def __init__(self, *, resolution: Resolution | None = None, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        resolution: Resolution | None = None,
+        error: Exception | None = None,
+        active_predictions: list[dict] | None = None,
+    ) -> None:
         self._resolution = resolution
         self._error = error
+        self._active_predictions = active_predictions or []
         self.calls: list[dict] = []
 
     async def resolve(
@@ -269,6 +276,11 @@ class _StubDaemonClient:
             raise self._error
         assert self._resolution is not None
         return self._resolution
+
+    async def get_predictions_active(self) -> dict:
+        if self._error is not None:
+            raise self._error
+        return {"predictions": list(self._active_predictions)}
 
 
 def test_resolve_forwards_to_injected_daemon_client_when_no_engine(temp_repo) -> None:
@@ -315,3 +327,51 @@ def test_resolve_returns_invalid_input_when_daemon_rejects(temp_repo) -> None:
     payload = parse_content(call_tool(server, "vaner.resolve", {"query": "q"}))
     assert payload["code"] == "invalid_input"
     assert "query is required" in payload["message"]
+
+
+def test_resolve_can_return_intent_packet_when_engine_unavailable(temp_repo) -> None:
+    seed_scenario(temp_repo, scenario_id="scn_packet")
+    daemon = _StubDaemonClient(error=VanerDaemonUnavailable("daemon connection refused"))
+    server = _make_server(temp_repo, daemon_client=daemon)
+
+    payload = parse_content(
+        call_tool(
+            server,
+            "vaner.resolve",
+            {"query": "where is auth enforced", "intent_packet": True, "context": {"domain": "support"}},
+        )
+    )
+
+    assert payload["intent_packet"] is True
+    assert payload["domain"] == "support"
+    assert payload["adoption_not_used"] == "engine_unavailable"
+    assert payload["suggested_next_action"]["tool"] == "vaner.search"
+    assert payload["candidate_scenarios"][0]["id"] == "scn_packet"
+
+
+def test_intent_packet_does_not_recommend_unrelated_adoption(temp_repo) -> None:
+    daemon = _StubDaemonClient(
+        active_predictions=[
+            {
+                "id": "pred-unrelated",
+                "label": "Rewrite the release notes",
+                "readiness": "ready",
+                "adoptable": True,
+                "trust_status": "ready",
+                "freshness": "fresh",
+            }
+        ]
+    )
+    server = _make_server(temp_repo, daemon_client=daemon)
+
+    payload = parse_content(
+        call_tool(
+            server,
+            "vaner.resolve",
+            {"query": "where is auth enforced", "intent_packet": True, "context": {"domain": "code"}},
+        )
+    )
+
+    assert payload["active_predictions_considered"][0]["matches_intent"] is False
+    assert payload["adoption_not_used"] == "stale_or_unrelated_predictions"
+    assert payload["suggested_next_action"]["tool"] != "vaner.predictions.adopt"

--- a/tests/test_mcp_v2/test_status.py
+++ b/tests/test_mcp_v2/test_status.py
@@ -9,3 +9,5 @@ def test_status_returns_health_payload(temp_repo, mcp_server) -> None:
     payload = parse_content(result)
     assert payload["ready"] is True
     assert "memory" in payload
+    assert payload["prediction_health"]["diagnostic_status"] in {"healthy", "cold", "engine_unavailable"}
+    assert "readiness_counts" in payload["prediction_health"]

--- a/tests/test_mcp_v2/test_suggest.py
+++ b/tests/test_mcp_v2/test_suggest.py
@@ -13,6 +13,8 @@ def test_suggest_returns_candidates(temp_repo, mcp_server) -> None:
     result = call_tool(mcp_server, "vaner.suggest", {"query": "where auth is enforced"})
     payload = parse_content(result)
     assert "suggestions" in payload
+    assert payload["guidance"]["recommended_action"]["tool"] in {"vaner.resolve", "vaner.predictions.adopt"}
+    assert "adopt at most one prediction per turn" in payload["guidance"]["guardrails"]
 
 
 def test_suggest_downranks_vaner_managed_files(temp_repo, mcp_server) -> None:
@@ -66,3 +68,38 @@ def test_suggest_downranks_vaner_managed_files(temp_repo, mcp_server) -> None:
     payload = parse_content(result)
 
     assert payload["suggestions"][0]["scenario_id"] == "scn_install"
+
+
+def test_suggest_keeps_managed_docs_when_domain_is_not_code(temp_repo, mcp_server) -> None:
+    async def _seed() -> None:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.upsert(
+            Scenario(
+                id="scn_feedback_skill",
+                kind="research",
+                score=0.95,
+                confidence=0.9,
+                entities=[".cursor/skills/vaner/vaner-feedback/SKILL.md", "feedback"],
+                evidence=[
+                    EvidenceRef(
+                        key="file_summary:.cursor/skills/vaner/vaner-feedback/SKILL.md",
+                        source_path=".cursor/skills/vaner/vaner-feedback/SKILL.md",
+                        excerpt="managed feedback skill",
+                        weight=1.0,
+                    )
+                ],
+                prepared_context="Managed Vaner feedback skill.",
+            )
+        )
+
+    asyncio.run(_seed())
+
+    result = call_tool(
+        mcp_server,
+        "vaner.suggest",
+        {"query": "How should feedback be recorded?", "limit": 1, "context": {"domain": "docs"}},
+    )
+    payload = parse_content(result)
+
+    assert payload["suggestions"][0]["scenario_id"] == "scn_feedback_skill"

--- a/tests/test_memory/test_policy_store_integration.py
+++ b/tests/test_memory/test_policy_store_integration.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from vaner.memory.policy import InvalidMemoryTransition, ReuseInput, decide_reuse
+from vaner.models.scenario import Scenario
+from vaner.store.scenarios.sqlite import ScenarioStore
+
+
+def test_stale_memory_from_store_is_not_reused_as_predictive_hit(temp_repo) -> None:
+    async def _run() -> None:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.upsert(
+            Scenario(
+                id="scn_stale_reuse_guard",
+                kind="debug",
+                score=0.9,
+                confidence=0.8,
+                entities=["router"],
+                prepared_context="Router path",
+                memory_state="trusted",
+                memory_confidence=0.9,
+                memory_evidence_hashes_json='["fp_old","fp_kept"]',
+                pinned=1,
+            )
+        )
+
+        await store.mark_stale_by_evidence("scn_stale_reuse_guard", evidence_hashes_now=["fp_kept"])
+        scenario = await store.get("scn_stale_reuse_guard")
+
+        assert scenario is not None
+        assert scenario.memory_state == "stale"
+        assert scenario.pinned == 0
+        assert (
+            decide_reuse(
+                ReuseInput(
+                    evidence_fresh=True,
+                    envelope_similarity=0.99,
+                    contradiction_since_last_validation=False,
+                    memory_state=scenario.memory_state,
+                )
+            )
+            == "ignore_prior"
+        )
+
+    asyncio.run(_run())
+
+
+def test_demoted_store_state_cannot_jump_directly_to_trusted(temp_repo) -> None:
+    async def _run() -> None:
+        store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+        await store.initialize()
+        await store.upsert(
+            Scenario(
+                id="scn_demoted_guard",
+                kind="debug",
+                score=0.5,
+                confidence=0.5,
+                entities=["auth"],
+                prepared_context="Auth path",
+                memory_state="demoted",
+                memory_confidence=0.2,
+            )
+        )
+
+        with pytest.raises(InvalidMemoryTransition):
+            await store.promote_scenario(
+                "scn_demoted_guard",
+                new_state="trusted",
+                confidence=0.9,
+                evidence_hashes=["fp"],
+                at=123.0,
+            )
+
+    asyncio.run(_run())

--- a/tests/test_setup/test_answers.py
+++ b/tests/test_setup/test_answers.py
@@ -8,6 +8,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 from vaner.setup.answers import SetupAnswers
+from vaner.setup.serializers import AnswersValidationError, answers_from_payload
 
 
 def _valid_answers() -> SetupAnswers:
@@ -64,3 +65,22 @@ def test_setup_answers_is_hashable() -> None:
     a2 = _valid_answers()
     assert hash(a1) == hash(a2)
     assert a1 == a2
+
+
+def test_answers_from_payload_normalizes_defaults_and_string_work_style() -> None:
+    answers = answers_from_payload({"work_styles": "coding"})
+    assert answers.work_styles == ("coding",)
+    assert answers.priority == "balanced"
+    assert answers.compute_posture == "balanced"
+    assert answers.cloud_posture == "ask_first"
+    assert answers.background_posture == "normal"
+
+
+def test_answers_from_payload_rejects_non_object() -> None:
+    with pytest.raises(AnswersValidationError, match="answers payload must be a JSON object"):
+        answers_from_payload([])
+
+
+def test_answers_from_payload_rejects_non_string_work_styles() -> None:
+    with pytest.raises(AnswersValidationError, match="work_styles must be a list of strings"):
+        answers_from_payload({"work_styles": [1, 2, 3]})

--- a/tests/test_setup/test_config_io.py
+++ b/tests/test_setup/test_config_io.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.config_io import (
+    persist_setup_and_policy,
+    read_policy_section,
+    read_setup_section,
+)
+
+
+def test_read_sections_return_empty_for_missing_config(tmp_path: Path) -> None:
+    assert read_setup_section(tmp_path) == {}
+    assert read_policy_section(tmp_path) == {}
+
+
+def test_read_sections_return_empty_for_corrupt_config(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config_dir = tmp_path / ".vaner"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text("[setup\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger="vaner.setup.config_io"):
+        assert read_setup_section(tmp_path) == {}
+    assert read_policy_section(tmp_path) == {}
+    assert "Ignoring invalid Vaner setup config TOML" in caplog.text
+
+
+def test_read_sections_ignore_non_table_sections(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".vaner"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text('setup = "not a table"\n', encoding="utf-8")
+
+    assert read_setup_section(tmp_path) == {}
+
+
+def test_persist_setup_and_policy_is_idempotent_and_preserves_sections(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".vaner"
+    config_dir.mkdir()
+    config_path = config_dir / "config.toml"
+    config_path.write_text(
+        '# custom config\n\n[backend]\nmodel = "local"\n\n[setup]\nmode = "simple"\n',
+        encoding="utf-8",
+    )
+    answers = SetupAnswers(
+        work_styles=("coding",),
+        priority="speed",
+        compute_posture="balanced",
+        cloud_posture="local_only",
+        background_posture="normal",
+    )
+    completed_at = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+
+    written = persist_setup_and_policy(
+        tmp_path,
+        answers,
+        "local_lightweight",
+        completed_at=completed_at,
+    )
+    first_text = written.read_text(encoding="utf-8")
+    persist_setup_and_policy(
+        tmp_path,
+        answers,
+        "local_lightweight",
+        completed_at=completed_at,
+    )
+
+    assert written == config_path
+    assert config_path.read_text(encoding="utf-8") == first_text
+    parsed = tomllib.loads(first_text)
+    assert parsed["backend"]["model"] == "local"
+    assert parsed["setup"]["work_styles"] == ["coding"]
+    assert parsed["setup"]["completed_at"] == completed_at.isoformat()
+    assert parsed["policy"]["selected_bundle_id"] == "local_lightweight"
+    assert not (config_dir / ".config.toml.tmp").exists()

--- a/tests/test_setup/test_questions.py
+++ b/tests/test_setup/test_questions.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from vaner.setup.questions import setup_questions_for_http, setup_questions_for_mcp
+
+
+def _normalise_mcp_question(question: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": question["id"],
+        "text": question["prompt"],
+        "kind": question["kind"],
+        "default": question["default"],
+        "options": question["options"],
+    }
+
+
+def _normalise_http_question(question: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": question["id"],
+        "text": question["title"],
+        "kind": question["kind"],
+        "default": question["default"],
+        "options": question["choices"],
+    }
+
+
+def test_setup_question_content_matches_between_mcp_and_http_shapes() -> None:
+    mcp_questions = setup_questions_for_mcp()
+    http_payload = setup_questions_for_http()
+
+    assert http_payload["version"] == 1
+    assert [_normalise_mcp_question(question) for question in mcp_questions] == [
+        _normalise_http_question(question) for question in http_payload["questions"]
+    ]
+
+
+def test_setup_question_projections_return_fresh_mutable_payloads() -> None:
+    mcp_questions = setup_questions_for_mcp()
+    http_payload = setup_questions_for_http()
+
+    mcp_questions[0]["default"].append("changed")
+    mcp_questions[0]["options"][0]["label"] = "changed"
+    http_payload["questions"][0]["default"].append("changed")
+    http_payload["questions"][0]["choices"][0]["label"] = "changed"
+
+    assert setup_questions_for_mcp()[0]["default"] == ["mixed"]
+    assert setup_questions_for_mcp()[0]["options"][0]["label"] == "Writing — drafting, editing, narrative"
+    assert setup_questions_for_http()["questions"][0]["default"] == ["mixed"]
+    assert setup_questions_for_http()["questions"][0]["choices"][0]["label"] == "Writing — drafting, editing, narrative"

--- a/tests/test_store/test_artefacts.py
+++ b/tests/test_store/test_artefacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 
+import aiosqlite
 import pytest
 
 from vaner.models.artefact import Artefact, ArtefactKind
@@ -27,3 +28,54 @@ async def test_store_upsert_and_list(tmp_path):
     rows = await store.list()
     assert len(rows) == 1
     assert rows[0].key == artefact.key
+
+
+@pytest.mark.asyncio
+async def test_store_initialize_migrates_synthetic_v6_database(tmp_path):
+    db_path = tmp_path / "store.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute("CREATE TABLE schema_version(version INTEGER PRIMARY KEY)")
+        await db.execute("INSERT INTO schema_version(version) VALUES (6)")
+        await db.execute(
+            """
+            CREATE TABLE prediction_cache (
+                cache_key TEXT PRIMARY KEY,
+                prompt_hint TEXT NOT NULL,
+                package_json TEXT,
+                enrichment_json TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                expires_at REAL NOT NULL
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE workspace_goals (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                source TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                created_at REAL NOT NULL,
+                last_observed_at REAL NOT NULL,
+                evidence_json TEXT NOT NULL DEFAULT '[]',
+                related_files_json TEXT NOT NULL DEFAULT '[]'
+            )
+            """
+        )
+        await db.commit()
+
+    store = ArtefactStore(db_path)
+    await store.initialize()
+
+    async with aiosqlite.connect(db_path) as db:
+        version_row = await (await db.execute("SELECT MAX(version) FROM schema_version")).fetchone()
+        prediction_columns = [row[1] for row in await (await db.execute("PRAGMA table_info(prediction_cache)")).fetchall()]
+        goal_columns = [row[1] for row in await (await db.execute("PRAGMA table_info(workspace_goals)")).fetchall()]
+
+    assert version_row[0] == 8
+    assert "last_accessed_at" in prediction_columns
+    assert "subgoal_of" in goal_columns
+    assert "pc_reconciliation_state" in goal_columns
+    assert "pc_unfinished_item_state" in goal_columns

--- a/tests/test_store/test_store_staleness.py
+++ b/tests/test_store/test_store_staleness.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import time
 
+import aiosqlite
 import pytest
 
 from vaner.models.artefact import Artefact, ArtefactKind
 from vaner.store.artefacts import ArtefactStore
+from vaner.store.scenarios.sqlite import ScenarioStore
 
 
 @pytest.mark.asyncio
@@ -71,3 +73,40 @@ async def test_purge_expired(tmp_path):
 
     assert removed == 1
     assert keys == [fresh.key]
+
+
+@pytest.mark.asyncio
+async def test_scenario_store_initialize_migrates_legacy_scenarios_table(tmp_path):
+    db_path = tmp_path / "scenarios.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            """
+            CREATE TABLE scenarios (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                score REAL NOT NULL,
+                confidence REAL NOT NULL,
+                entities_json TEXT NOT NULL,
+                prepared_context TEXT NOT NULL,
+                coverage_gaps_json TEXT NOT NULL,
+                freshness TEXT NOT NULL,
+                cost_to_expand TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                expanded_at REAL,
+                last_refreshed_at REAL NOT NULL,
+                last_outcome TEXT
+            )
+            """
+        )
+        await db.commit()
+
+    store = ScenarioStore(db_path)
+    await store.initialize()
+
+    async with aiosqlite.connect(db_path) as db:
+        columns = [row[1] for row in await (await db.execute("PRAGMA table_info(scenarios)")).fetchall()]
+
+    assert "memory_state" in columns
+    assert "memory_confidence" in columns
+    assert "memory_evidence_hashes_json" in columns
+    assert "prior_successes" in columns


### PR DESCRIPTION
## Summary
- Add safer config/setup IO handling with validation diagnostics, atomic setup persistence, and shared setup question/config helpers.
- Align MCP/HTTP resolve contracts, structured output guardrails, guidance resource discoverability, and memory feedback metrics semantics.
- Add focused regression coverage for setup/config parsing, MCP contracts/resources, memory policy, and old store migrations.

## Test plan
- `python -m ruff check ...` on changed Python files
- `python -m ruff format --check ...` on changed Python files
- `python -m pytest tests/test_cli/test_config.py tests/test_setup/test_config_io.py tests/test_cli/test_setup_cli.py tests/test_clients/test_daemon_client.py tests/test_mcp/test_server_boot.py tests/test_mcp_v2/test_resolve.py tests/test_mcp/test_tool_registry_parity.py tests/test_mcp_apps/test_resource_registration.py tests/test_mcp_v2/test_feedback.py tests/test_store/test_artefacts.py tests/test_store/test_store_staleness.py tests/test_daemon/test_predictions_endpoint.py -q`
- `python -m pytest tests -m "not slow and not integration" -q`

Made with [Cursor](https://cursor.com)