### PR TITLE
fix(release): harden tag workflow verification

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -97,33 +97,6 @@ jobs:
           fi
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" vsix/*.sigstore.json --clobber
 
-      - name: Attest VSIX provenance
-        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
-        with:
-          subject-path: "vsix/*.vsix"
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-
-      - name: Sign VSIX blobs (keyless)
-        run: |
-          set -euo pipefail
-          for f in vsix/*.vsix; do
-            cosign sign-blob --yes --bundle "${f}.sigstore.json" "$f"
-          done
-
-      - name: Upload VSIX signatures to GitHub release
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --generate-notes
-          fi
-          gh release upload "$TAG" vsix/*.sigstore.json --clobber
-
       - name: Publish to VS Code Marketplace
         if: ${{ env.VSCE_PAT != '' && steps.resolve_run.outputs.skip_publish != '1' }}
         run: npx @vscode/vsce publish --packagePath ./vsix/*.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,11 @@ jobs:
           for artifact in dist-assets/dist/*; do
             gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY"
             bundle="${artifact}.sigstore.json"
-            cosign verify-blob --bundle "$bundle" "$artifact"
+            cosign verify-blob \
+              --bundle "$bundle" \
+              --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/v.*" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "$artifact"
             if [ -n "$provenance_file" ]; then
               slsa-verifier verify-artifact "$artifact" \
                 --provenance-path "$provenance_file" \


### PR DESCRIPTION
## Summary
- add explicit cosign keyless verification identity for release assets
- remove duplicated VSIX attestation/signing steps so tag publishes skip cleanly when no VSIX artifact exists

## Validation
- diff check passed locally
- GitHub Actions will validate workflow syntax and release smoke on this PR