### PR TITLE
feat: cockpit refresh + model catalog refresher with proper sampling defaults

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -570,7 +570,7 @@ ensure_ollama_model() {
   if [[ "$VANER_WITH_OLLAMA" != "1" ]]; then
     return 0
   fi
-  local target_model="${VANER_BACKEND_MODEL:-qwen2.5-coder:7b}"
+  local target_model="${VANER_BACKEND_MODEL:-qwen3.5:8b}"
   ensure_ollama || return 1
   if ollama_has_model "$target_model"; then
     ui_success "Ollama model already available: $target_model"
@@ -600,7 +600,7 @@ ollama_has_model() {
 }
 
 select_existing_ollama_model() {
-  local default_model="${1:-qwen2.5-coder:7b}"
+  local default_model="${1:-qwen3.5:8b}"
   local models=()
   local idx=1
   local choice=""
@@ -950,7 +950,7 @@ collect_backend_details() {
   case "$VANER_BACKEND_PRESET" in
     ollama)
       VANER_BACKEND_URL="${VANER_BACKEND_URL:-http://127.0.0.1:11434/v1}"
-      local default_ollama_model="qwen2.5-coder:7b"
+      local default_ollama_model="qwen3.5:8b"
       if [[ -z "$VANER_BACKEND_MODEL" ]]; then
         VANER_BACKEND_MODEL="$(select_existing_ollama_model "$default_ollama_model")"
       fi

--- a/src/vaner/cli/commands/init.py
+++ b/src/vaner/cli/commands/init.py
@@ -33,7 +33,7 @@ DEFAULT_CONFIG = """# Vaner configuration
 # Examples:
 #   OpenAI:       base_url = "https://api.openai.com/v1"   model = "gpt-4o"
 #   Anthropic:    base_url = "https://api.anthropic.com/v1" model = "claude-opus-4-5"
-#   Ollama:       base_url = "http://127.0.0.1:11434/v1"   model = "qwen2.5-coder:32b"
+#   Ollama:       base_url = "http://127.0.0.1:11434/v1"   model = "qwen3.5:8b"
 #   vLLM/local:   base_url = "http://127.0.0.1:8000/v1"    model = "Qwen/Qwen2.5-Coder-32B"
 
 [backend]
@@ -65,7 +65,7 @@ max_generations_per_cycle = 200
 # Leave endpoint empty to auto-detect a local Ollama or vLLM instance.
 enabled = true
 endpoint = ""      # e.g. "http://127.0.0.1:11434" or "http://127.0.0.1:8000/v1"
-model = ""         # e.g. "qwen2.5-coder:32b" -- leave empty to auto-select
+model = ""         # e.g. "qwen3.5:8b" -- leave empty to auto-select
 backend = "auto"   # "auto" | "ollama" | "openai"
 
 [proxy]
@@ -178,7 +178,7 @@ BACKEND_PRESETS: dict[str, BackendPreset] = {
     "ollama": BackendPreset(
         name="ollama",
         base_url="http://127.0.0.1:11434/v1",
-        default_model="qwen2.5-coder:7b",
+        default_model="qwen3.5:8b",
     ),
     "lmstudio": BackendPreset(
         name="lmstudio",

--- a/src/vaner/cli/commands/setup.py
+++ b/src/vaner/cli/commands/setup.py
@@ -975,6 +975,101 @@ def advanced_cmd(
         raise typer.Exit(code=completed.returncode)
 
 
+catalog_app = typer.Typer(
+    help="Local model catalog: refresh registry from Hugging Face + Ollama, or inspect the bundled seed.",
+    no_args_is_help=True,
+)
+setup_app.add_typer(catalog_app, name="catalog")
+
+
+@catalog_app.command(
+    "refresh",
+    help=(
+        "Rebuild model_registry.json from catalog_seed.json + live Hugging "
+        "Face/Ollama lookups. --offline skips network and uses seed-only "
+        "values; --dry-run prints the result without writing."
+    ),
+)
+def catalog_refresh_cmd(
+    offline: Annotated[
+        bool,
+        typer.Option("--offline", help="Skip Hugging Face / Ollama lookups; use seed values only."),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Print the refreshed registry to stdout without writing."),
+    ] = False,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            help="Write to this path instead of the bundled defaults file.",
+        ),
+    ] = None,
+) -> None:
+    """Refresh ``model_registry.json`` from the curated seed."""
+
+    from vaner.setup.catalog_refresh import build_registry
+
+    payload = build_registry(online=not offline)
+    formatted = json.dumps(payload, indent=2, sort_keys=False)
+
+    if dry_run:
+        typer.echo(formatted)
+        return
+
+    if output:
+        target = Path(output)
+    else:
+        target = Path(__file__).resolve().parents[2] / "defaults" / "model_registry.json"
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(formatted + "\n", encoding="utf-8")
+    skipped = payload.get("skipped", []) or []
+    _console.print(
+        f"[green]Wrote[/green] {target} "
+        f"([dim]{len(payload['models'])} models, "
+        f"{'online' if not offline else 'offline'}, "
+        f"{len(skipped)} skipped[/dim])"
+    )
+    for entry in skipped:
+        _console.print(f"  [yellow]skipped[/yellow] {entry['id']} — {entry['reason']}")
+
+
+@catalog_app.command(
+    "show",
+    help="Print the current model registry (after any local refresh).",
+)
+def catalog_show_cmd() -> None:
+    """Display the loaded registry as JSON."""
+
+    from vaner.setup.model_recommendation import load_model_registry
+
+    registry = load_model_registry()
+    payload = {
+        "schema_version": registry.schema_version,
+        "verified_at": registry.verified_at,
+        "valid": registry.valid,
+        "warning": registry.warning,
+        "models": [
+            {
+                "id": model.id,
+                "display_name": model.display_name,
+                "runtime": model.runtime,
+                "quality_rank": model.quality_rank,
+                "stability_rank": model.stability_rank,
+                "recency_rank": model.recency_rank,
+                "download_size_gb": model.download_size_gb,
+                "min_effective_memory_gb": model.min_effective_memory_gb,
+                "recommended_effective_memory_gb": model.recommended_effective_memory_gb,
+                "workload_tags": list(model.workload_tags),
+                "parameters": model.parameters,
+            }
+            for model in registry.models
+        ],
+    }
+    typer.echo(json.dumps(payload, indent=2))
+
 
 @setup_app.command(
     "hardware",

--- a/src/vaner/cli/commands/setup.py
+++ b/src/vaner/cli/commands/setup.py
@@ -58,6 +58,7 @@ from vaner.setup.apply import (
 )
 from vaner.setup.catalog import bundle_by_id
 from vaner.setup.config_io import (
+    persist_runtime_recommendation,
     persist_setup_and_policy,
     read_policy_section,
     read_setup_section,
@@ -65,6 +66,7 @@ from vaner.setup.config_io import (
     update_toml_section,
 )
 from vaner.setup.hardware import HardwareProfile, detect
+from vaner.setup.model_recommendation import load_model_registry, recommend_local_model
 from vaner.setup.select import SelectionResult, select_policy_bundle
 from vaner.setup.serializers import (
     AnswersValidationError,
@@ -734,6 +736,64 @@ def recommend_cmd(
 
 
 @setup_app.command(
+    "models-recommended",
+    help="Emit Vaner's concrete runtime/model recommendation for this machine.",
+)
+def models_recommended_cmd(
+    answers_path: Annotated[
+        Path | None,
+        typer.Option("--answers", help="Optional JSON SetupAnswers file used for workload tags."),
+    ] = None,
+    work_styles: Annotated[
+        str | None,
+        typer.Option("--work-styles", help="Comma-separated work styles when no answers file is available."),
+    ] = None,
+    validate_registry_only: Annotated[
+        bool,
+        typer.Option("--validate-registry", help="Only validate the bundled model registry."),
+    ] = False,
+) -> None:
+    """Desktop-facing model recommendation surface. Always emits JSON."""
+
+    if validate_registry_only:
+        registry = load_model_registry()
+        payload = {
+            "schema_version": registry.schema_version,
+            "valid": registry.valid,
+            "verified_at": registry.verified_at,
+            "sources": list(registry.sources),
+            "model_count": len(registry.models),
+            "warning": registry.warning,
+        }
+        typer.echo(json.dumps(payload, indent=2))
+        raise typer.Exit(code=0 if registry.valid else 1)
+
+    answers: SetupAnswers | None = None
+    if answers_path is not None:
+        try:
+            answers = _load_answers_from_path(answers_path)
+        except FileNotFoundError as exc:
+            typer.secho(f"answers file not found: {answers_path}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=1) from exc
+        except (json.JSONDecodeError, ValueError, TypeError) as exc:
+            typer.secho(f"failed to parse answers: {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=1) from exc
+    elif work_styles:
+        styles = [part.strip() for part in work_styles.split(",") if part.strip()]
+        answers = _default_answers()
+        answers = SetupAnswers(
+            work_styles=tuple(styles) if styles else answers.work_styles,
+            priority=answers.priority,
+            compute_posture=answers.compute_posture,
+            cloud_posture=answers.cloud_posture,
+            background_posture=answers.background_posture,
+        )
+
+    payload = recommend_local_model(answers=answers, hardware=detect())
+    typer.echo(json.dumps(payload, indent=2, default=str))
+
+
+@setup_app.command(
     "apply",
     help=(
         "Persist answers (or an explicit --bundle-id) without prompts. Best-effort "
@@ -859,6 +919,8 @@ def apply_cmd(
         chosen_bundle.id,
         completed_at=completed_at,
     )
+    model_recommendation = recommend_local_model(answers=answers, hardware=detect())
+    persist_runtime_recommendation(repo_root, model_recommendation)
 
     daemon_status = _ping_daemon_for_refresh()
 
@@ -866,6 +928,7 @@ def apply_cmd(
         "config_path": str(config_path),
         "selected_bundle_id": chosen_bundle.id,
         "reasons": reasons,
+        "model_recommendation": model_recommendation.get("user"),
         "widens_cloud_posture": bool(warnings),
         "daemon": daemon_status,
     }
@@ -910,6 +973,7 @@ def advanced_cmd(
     completed = subprocess.run(cmd, check=False)
     if completed.returncode != 0:
         raise typer.Exit(code=completed.returncode)
+
 
 
 @setup_app.command(

--- a/src/vaner/daemon/cockpit_html.py
+++ b/src/vaner/daemon/cockpit_html.py
@@ -221,6 +221,43 @@ _COCKPIT_HTML = """<!DOCTYPE html>
         <div id="summaryChips" class="chips"></div>
       </section>
 
+      <section class="panel" id="enginePanel">
+        <h2>Engine state</h2>
+        <div class="subtle" id="engineHint">
+          Goals, prediction pipeline, prepared-work self-eval and recent
+          feedback. This degraded view is the fallback that ships with the
+          daemon when the React build is missing.
+        </div>
+        <div class="grid" style="margin-top:10px;">
+          <div>
+            <h3 style="font-size:0.95rem;margin:8px 0;">Goals</h3>
+            <div id="goalsList" class="scenario-list">
+              <div class="subtle">loading...</div>
+            </div>
+          </div>
+          <div>
+            <h3 style="font-size:0.95rem;margin:8px 0;">Prediction pipeline</h3>
+            <div id="predictionLanes" class="scenario-list">
+              <div class="subtle">loading...</div>
+            </div>
+          </div>
+        </div>
+        <div class="grid" style="margin-top:10px;">
+          <div>
+            <h3 style="font-size:0.95rem;margin:8px 0;">Prepared-work self-eval</h3>
+            <div id="preparedWorkList" class="scenario-list">
+              <div class="subtle">loading...</div>
+            </div>
+          </div>
+          <div>
+            <h3 style="font-size:0.95rem;margin:8px 0;">What Vaner learned</h3>
+            <div id="learningRecent" class="scenario-list">
+              <div class="subtle">loading...</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <div class="grid">
         <section class="panel" id="leftPanel">
           <h2 id="leftTitle">Top Scenarios</h2>
@@ -599,11 +636,230 @@ _COCKPIT_HTML = """<!DOCTYPE html>
         wireProxyStream();
       }
 
+      // ------- Cockpit refresh: degraded mirror of the React panels -------
+      const goalsList = document.getElementById("goalsList");
+      const predictionLanes = document.getElementById("predictionLanes");
+      const preparedWorkList = document.getElementById("preparedWorkList");
+      const learningRecent = document.getElementById("learningRecent");
+
+      function relTime(epoch) {
+        if (!epoch) return "";
+        const dt = Math.max(0, Date.now() / 1000 - Number(epoch));
+        if (dt < 60) return Math.round(dt) + "s ago";
+        if (dt < 3600) return Math.round(dt / 60) + "m ago";
+        if (dt < 86400) return Math.round(dt / 3600) + "h ago";
+        return Math.round(dt / 86400) + "d ago";
+      }
+
+      async function refreshGoals() {
+        try {
+          const response = await fetch("/goals?limit=20");
+          if (!response.ok) throw new Error("HTTP " + response.status);
+          const payload = await response.json();
+          const goals = payload.goals || [];
+          if (!goals.length) {
+            goalsList.innerHTML =
+              '<div class="subtle">No workspace goals declared. Use vaner.goals.declare to create one.</div>';
+            return;
+          }
+          goalsList.innerHTML = goals
+            .map(function (goal) {
+              return (
+                '<article class="scenario-card">' +
+                '<div class="row"><strong>' +
+                escapeHtml(goal.title || goal.id) +
+                '</strong>' +
+                '<span class="pill">' +
+                escapeHtml(goal.status || "?") +
+                '</span></div>' +
+                (goal.description
+                  ? '<div class="subtle">' + escapeHtml(goal.description) + '</div>'
+                  : '') +
+                (goal.pc_reconciliation_state
+                  ? '<div class="subtle">reconciliation: ' +
+                    escapeHtml(goal.pc_reconciliation_state) +
+                    '</div>'
+                  : '') +
+                '<div class="subtle">updated ' +
+                escapeHtml(relTime(goal.updated_at || goal.created_at)) +
+                '</div>' +
+                '</article>'
+              );
+            })
+            .join("");
+        } catch (error) {
+          goalsList.innerHTML =
+            '<div class="subtle">Goals unavailable: ' + escapeHtml(error.message) + '</div>';
+        }
+      }
+
+      async function refreshPredictionLanes() {
+        try {
+          const response = await fetch("/predictions/active?include_all=true");
+          if (!response.ok) throw new Error("HTTP " + response.status);
+          const payload = await response.json();
+          const byState = payload.by_state || {};
+          const lanes = ["queued", "grounding", "evidence_gathering", "drafting", "ready"];
+          const total = lanes.reduce(function (sum, state) {
+            return sum + (Array.isArray(byState[state]) ? byState[state].length : 0);
+          }, 0);
+          if (total === 0) {
+            predictionLanes.innerHTML =
+              '<div class="subtle">No predictions in flight.</div>';
+            return;
+          }
+          predictionLanes.innerHTML = lanes
+            .map(function (state) {
+              const items = Array.isArray(byState[state]) ? byState[state] : [];
+              const titles = items
+                .slice(0, 3)
+                .map(function (row) {
+                  const label = (row && row.spec && row.spec.label) || row.id || "(unnamed)";
+                  return '<li>' + escapeHtml(label) + '</li>';
+                })
+                .join("");
+              return (
+                '<details>' +
+                '<summary>' +
+                escapeHtml(state.replace(/_/g, ' ')) +
+                ' · ' + items.length +
+                '</summary>' +
+                (items.length
+                  ? '<ul style="margin:6px 0 0 18px;">' + titles +
+                    (items.length > 3
+                      ? '<li class="subtle">+' + (items.length - 3) + ' more</li>'
+                      : '') +
+                    '</ul>'
+                  : '<div class="subtle">empty</div>') +
+                '</details>'
+              );
+            })
+            .join("");
+        } catch (error) {
+          predictionLanes.innerHTML =
+            '<div class="subtle">Predictions unavailable: ' + escapeHtml(error.message) + '</div>';
+        }
+      }
+
+      async function refreshPreparedWork() {
+        try {
+          const listResp = await fetch("/work-products?limit=6");
+          if (!listResp.ok) throw new Error("HTTP " + listResp.status);
+          const listPayload = await listResp.json();
+          const products = listPayload.work_products || [];
+          if (!products.length) {
+            preparedWorkList.innerHTML =
+              '<div class="subtle">No work products surfaced.</div>';
+            return;
+          }
+          // Fetch self_eval + events for each product (small N).
+          const inspections = await Promise.all(
+            products.slice(0, 6).map(function (product) {
+              return fetch('/work-products/' + encodeURIComponent(product.id) + '/inspect')
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .catch(function () { return null; });
+            })
+          );
+          preparedWorkList.innerHTML = inspections
+            .map(function (inspection, idx) {
+              if (!inspection) return '';
+              const se = inspection.self_eval || {};
+              const events = (inspection.events || []).slice(0, 4);
+              const lifecycle = events
+                .map(function (evt) {
+                  return escapeHtml((evt.event_type || '').toUpperCase()) +
+                    ' ' + escapeHtml(relTime(evt.timestamp));
+                })
+                .join(' → ');
+              return (
+                '<article class="scenario-card">' +
+                '<strong>' + escapeHtml(inspection.title || products[idx].title || 'work product') + '</strong>' +
+                '<div class="subtle">' + escapeHtml(inspection.confidence_label || '') + ' · ' +
+                escapeHtml(inspection.freshness_label || '') + '</div>' +
+                '<div class="subtle">evidence: ' + Number(se.evidence_coverage || 0).toFixed(2) +
+                ' · grounded: ' + Number(se.groundedness || 0).toFixed(2) +
+                ' · contradict: ' + Number(se.contradiction_risk || 0).toFixed(2) +
+                '</div>' +
+                (lifecycle
+                  ? '<div class="subtle">' + lifecycle + '</div>'
+                  : '') +
+                '</article>'
+              );
+            })
+            .join("");
+        } catch (error) {
+          preparedWorkList.innerHTML =
+            '<div class="subtle">Prepared work unavailable: ' + escapeHtml(error.message) + '</div>';
+        }
+      }
+
+      async function refreshLearning() {
+        try {
+          const response = await fetch("/learning/recent?limit=5");
+          if (!response.ok) throw new Error("HTTP " + response.status);
+          const payload = await response.json();
+          const events = payload.feedback_events || [];
+          const learning = payload.learning_state || {};
+          const eventHtml = events.length
+            ? events.map(function (evt) {
+                let kind = evt.feedback_kind;
+                if (!kind && evt.metadata_json) {
+                  try {
+                    const parsed = JSON.parse(evt.metadata_json);
+                    kind = parsed.feedback_kind || parsed.kind || parsed.outcome || 'feedback';
+                  } catch (_e) { kind = 'feedback'; }
+                }
+                const title = evt.scenario_id || evt.query_id || evt.id || 'event';
+                return '<li><span class="pill">' + escapeHtml(kind || 'feedback') + '</span> ' +
+                  escapeHtml(title) + ' · ' + escapeHtml(relTime(evt.timestamp)) + '</li>';
+              }).join('')
+            : '';
+          const learningKeys = Object.keys(learning);
+          const learningHtml = learningKeys.length
+            ? learningKeys.slice(0, 4).map(function (key) {
+                const value = learning[key];
+                let summary = '';
+                if (value && typeof value === 'object' && !Array.isArray(value)) {
+                  summary = Object.keys(value).length + ' entries';
+                } else if (Array.isArray(value)) {
+                  summary = value.length + ' entries';
+                } else {
+                  summary = String(value);
+                }
+                return '<li><code>' + escapeHtml(key) + '</code>: ' + escapeHtml(summary) + '</li>';
+              }).join('')
+            : '';
+          if (!events.length && !learningKeys.length) {
+            learningRecent.innerHTML =
+              '<div class="subtle">No feedback recorded yet — use vaner.feedback to teach.</div>';
+            return;
+          }
+          learningRecent.innerHTML =
+            (events.length ? '<ul style="margin:0 0 6px 18px;">' + eventHtml + '</ul>' : '') +
+            (learningKeys.length
+              ? '<ul class="subtle" style="margin:0 0 0 18px;">' + learningHtml + '</ul>'
+              : '');
+        } catch (error) {
+          learningRecent.innerHTML =
+            '<div class="subtle">Learning unavailable: ' + escapeHtml(error.message) + '</div>';
+        }
+      }
+
+      function refreshEnginePanels() {
+        refreshGoals().catch(() => {});
+        refreshPredictionLanes().catch(() => {});
+        refreshPreparedWork().catch(() => {});
+        refreshLearning().catch(() => {});
+      }
+
+      refreshEnginePanels();
+
       setInterval(() => {
         refreshStatus().catch(() => {});
         if (isProxy) {
           refreshProxySummary().catch(() => {});
         }
+        refreshEnginePanels();
       }, 15000);
     </script>
   </body>

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -921,7 +921,9 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
 
                 store = ArtefactStore(config.repo_root / ".vaner" / "artefacts.db")
                 await store.initialize()
-                events = await store.list_signal_events(limit=1)
+                from vaner.models.signal import SignalEvent
+
+                events: list[SignalEvent] = await store.list_signal_events(limit=1)
                 if events:
                     evt = events[0]
                     body["latest_invalidation_signal"] = {

--- a/src/vaner/daemon/http.py
+++ b/src/vaner/daemon/http.py
@@ -451,6 +451,25 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         selection = select_policy_bundle(answers, hardware)
         return JSONResponse(_selection_to_dict_http(selection))
 
+    @app.post("/models/recommended")
+    async def models_recommended(request: Request) -> JSONResponse:
+        """Return the concrete runtime/model recommendation contract."""
+
+        from vaner.setup.model_recommendation import recommend_local_model
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if body is None:
+            body = {}
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="request body must be a JSON object")
+        raw_answers = body.get("answers")
+        answers = _answers_from_payload_http(raw_answers) if isinstance(raw_answers, dict) else None
+        hardware = _get_hardware_profile_cached()
+        return JSONResponse(recommend_local_model(answers=answers, hardware=hardware))
+
     @app.post("/setup/apply")
     async def setup_apply(request: Request) -> JSONResponse:
         """Persist answers + selected bundle id to ``.vaner/config.toml``.
@@ -476,7 +495,8 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
             apply_policy_bundle,
         )
         from vaner.setup.catalog import bundle_by_id
-        from vaner.setup.config_io import persist_setup_and_policy
+        from vaner.setup.config_io import persist_runtime_recommendation, persist_setup_and_policy
+        from vaner.setup.model_recommendation import recommend_local_model
         from vaner.setup.select import select_policy_bundle
         from vaner.setup.serializers import answers_from_payload
 
@@ -585,6 +605,8 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
 
         completed_at = datetime.now(UTC)
         config_path = persist_setup_and_policy(repo_root, answers, chosen_bundle_id, completed_at=completed_at)
+        model_recommendation = recommend_local_model(answers=answers, hardware=_get_hardware_profile_cached())
+        persist_runtime_recommendation(repo_root, model_recommendation)
 
         return JSONResponse(
             {
@@ -596,6 +618,7 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
                 "applied_policy": applied_summary,
                 "bundle": _bundle_to_dict_http(bundle),
                 "config_path": str(config_path),
+                "model_recommendation": model_recommendation.get("user"),
             }
         )
 
@@ -888,7 +911,28 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         row = await scenario_store.get(scenario_id)
         if row is None:
             raise HTTPException(status_code=404, detail="Scenario not found")
-        return JSONResponse(row.model_dump(mode="json"))
+        body = row.model_dump(mode="json")
+        # Surface the most recent invalidation signal so the Inspector can
+        # render a 'stale because' line. Only attached when the scenario
+        # is not fresh — fresh rows do not need a justification.
+        if body.get("freshness") and body["freshness"] != "fresh":
+            try:
+                from vaner.store.artefacts import ArtefactStore
+
+                store = ArtefactStore(config.repo_root / ".vaner" / "artefacts.db")
+                await store.initialize()
+                events = await store.list_signal_events(limit=1)
+                if events:
+                    evt = events[0]
+                    body["latest_invalidation_signal"] = {
+                        "kind": evt.kind,
+                        "source": evt.source,
+                        "timestamp": evt.timestamp,
+                    }
+            except Exception:
+                # Don't break the route on a store hiccup.
+                pass
+        return JSONResponse(body)
 
     @app.post("/scenarios/{scenario_id}/expand")
     async def expand_item(scenario_id: str) -> JSONResponse:
@@ -936,11 +980,31 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
         return store
 
     @app.get("/predictions/active")
-    async def predictions_active() -> JSONResponse:
+    async def predictions_active(include_all: bool = False) -> JSONResponse:
+        """Return ready predictions plus, optionally, all in-flight states.
+
+        ``predictions`` keeps the existing shape for back-compat (only the
+        ready tail). When ``include_all=true`` is passed, ``by_state``
+        groups every prompt in the registry by its ``readiness`` so the
+        cockpit can render the full pipeline (queued / grounding /
+        evidence_gathering / drafting / ready).
+        """
         if engine is None:
-            return JSONResponse({"predictions": []})
+            body: dict[str, Any] = {"predictions": []}
+            if include_all:
+                body["by_state"] = {}
+            return JSONResponse(body)
         active = engine.get_active_predictions()
-        return JSONResponse({"predictions": [_serialize_prediction(p) for p in active]})
+        body = {
+            "predictions": [_serialize_prediction(p) for p in active],
+        }
+        if include_all and getattr(engine, "prediction_registry", None) is not None:
+            by_state: dict[str, list[dict[str, Any]]] = {}
+            for prompt in engine.prediction_registry.all():
+                state = str(getattr(prompt.run, "readiness", "") or "unknown")
+                by_state.setdefault(state, []).append(_serialize_prediction(prompt))
+            body["by_state"] = by_state
+        return JSONResponse(body)
 
     @app.get("/predictions/{prediction_id}")
     async def predictions_one(
@@ -1015,7 +1079,26 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
             raise HTTPException(status_code=404, detail="work product not found")
         inspection = build_work_product_inspection(product)
         await store.record_work_product_event(product_id, "inspect", metadata={"surface": "http"})
-        return JSONResponse(inspection.model_dump(mode="json"))
+        body = inspection.model_dump(mode="json")
+        # Cockpit refresh: surface the per-product self-eval scores and the
+        # lifecycle event log so the inspector can render confidence bars
+        # plus a 'CANDIDATE -> SURFACED -> ...' strip without round-tripping.
+        body["self_eval"] = product.self_eval.model_dump(mode="json")
+        try:
+            event_log = await store.list_work_product_events(product_id, limit=20)
+        except Exception:
+            event_log = []
+        body["events"] = [
+            {
+                "event_type": str(evt.get("event_type") or ""),
+                "timestamp": float(evt.get("timestamp") or 0.0),
+            }
+            for evt in event_log
+        ]
+        body["status"] = product.status.value
+        body["adoptability"] = product.adoptability.value
+        body["feedback_state"] = product.feedback_state.value
+        return JSONResponse(body)
 
     @app.get("/prepared-work")
     async def prepared_work(
@@ -1099,6 +1182,151 @@ def create_daemon_http_app(config: VanerConfig, *, engine: Any | None = None) ->
             )
         await store.record_work_product_event(product_id, "export", metadata={"surface": "http"})
         return JSONResponse(exported.model_dump(mode="json"))
+
+    # ------------------------------------------------------------------
+    # Cockpit refresh: goals, artefacts, learning
+    # Read-only HTTP wrappers around the same store accessors used by
+    # the matching MCP tools (vaner.goals.*, vaner.artefacts.*).
+    # ------------------------------------------------------------------
+
+    async def _artefact_store() -> Any:
+        from vaner.store.artefacts import ArtefactStore
+
+        store = ArtefactStore(config.repo_root / ".vaner" / "artefacts.db")
+        await store.initialize()
+        return store
+
+    @app.get("/goals")
+    async def list_goals(status: str | None = None, limit: int = 50) -> JSONResponse:
+        store = await _artefact_store()
+        rows = await store.list_workspace_goals(
+            status=status if isinstance(status, str) and status else None,
+            limit=max(1, min(200, int(limit))),
+        )
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            entry = dict(row)
+            try:
+                entry["evidence"] = json.loads(str(row.get("evidence_json") or "[]"))
+            except Exception:
+                entry["evidence"] = []
+            try:
+                entry["related_files"] = json.loads(str(row.get("related_files_json") or "[]"))
+            except Exception:
+                entry["related_files"] = []
+            try:
+                entry["artefact_refs"] = json.loads(str(row.get("artefact_refs_json") or "[]"))
+            except Exception:
+                entry["artefact_refs"] = []
+            entry.pop("evidence_json", None)
+            entry.pop("related_files_json", None)
+            entry.pop("artefact_refs_json", None)
+            out.append(entry)
+        return JSONResponse({"goals": out})
+
+    @app.get("/artefacts")
+    async def list_artefacts(
+        status: str | None = None,
+        connector: str | None = None,
+        source_tier: str | None = None,
+        limit: int = 50,
+    ) -> JSONResponse:
+        store = await _artefact_store()
+        rows = await store.list_intent_artefacts(
+            status=status if isinstance(status, str) and status else None,
+            connector=connector if isinstance(connector, str) and connector else None,
+            source_tier=source_tier if isinstance(source_tier, str) and source_tier else None,
+            limit=max(1, min(200, int(limit))),
+        )
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            entry = dict(row)
+            try:
+                entry["linked_goals"] = json.loads(str(row.get("linked_goals_json") or "[]"))
+            except Exception:
+                entry["linked_goals"] = []
+            try:
+                entry["linked_files"] = json.loads(str(row.get("linked_files_json") or "[]"))
+            except Exception:
+                entry["linked_files"] = []
+            entry.pop("linked_goals_json", None)
+            entry.pop("linked_files_json", None)
+            out.append(entry)
+        return JSONResponse({"artefacts": out})
+
+    @app.get("/artefacts/{artefact_id}")
+    async def fetch_artefact(artefact_id: str) -> JSONResponse:
+        store = await _artefact_store()
+        row = await store.get_intent_artefact(artefact_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"no such artefact: {artefact_id}")
+        latest_snapshot_id = str(row.get("latest_snapshot") or "")
+        item_rows = (
+            await store.list_intent_artefact_items(
+                artefact_id=artefact_id,
+                snapshot_id=latest_snapshot_id or None,
+            )
+            if latest_snapshot_id
+            else []
+        )
+        items: list[dict[str, Any]] = []
+        for item_row in item_rows:
+            entry = dict(item_row)
+            for json_field, friendly in (
+                ("related_files_json", "related_files"),
+                ("related_entities_json", "related_entities"),
+                ("evidence_refs_json", "evidence_refs"),
+            ):
+                try:
+                    entry[friendly] = json.loads(str(item_row.get(json_field) or "[]"))
+                except Exception:
+                    entry[friendly] = []
+                entry.pop(json_field, None)
+            items.append(entry)
+        artefact_payload = dict(row)
+        try:
+            artefact_payload["linked_goals"] = json.loads(str(row.get("linked_goals_json") or "[]"))
+        except Exception:
+            artefact_payload["linked_goals"] = []
+        try:
+            artefact_payload["linked_files"] = json.loads(str(row.get("linked_files_json") or "[]"))
+        except Exception:
+            artefact_payload["linked_files"] = []
+        artefact_payload.pop("linked_goals_json", None)
+        artefact_payload.pop("linked_files_json", None)
+        outcomes = await store.list_reconciliation_outcomes(artefact_id=artefact_id, limit=5)
+        return JSONResponse(
+            {
+                "artefact": artefact_payload,
+                "items": items,
+                "snapshot_id": latest_snapshot_id,
+                "recent_outcomes": outcomes,
+            }
+        )
+
+    @app.get("/learning/recent")
+    async def learning_recent(limit: int = 5) -> JSONResponse:
+        store = await _artefact_store()
+        bounded = max(1, min(50, int(limit)))
+        events = await store.list_feedback_events(limit=bounded)
+        # Surface a small set of learning_state keys that downstream
+        # cockpit code can render as one-line summaries. The keys here
+        # are best-effort — missing keys simply don't appear.
+        learning_keys = (
+            "scenario_kind_priors",
+            "skill_weights",
+            "intent_priors",
+            "frontier_priors",
+        )
+        learning: dict[str, Any] = {}
+        for key in learning_keys:
+            try:
+                value = await store.get_learning_state(key)
+            except Exception:
+                value = None
+            if value is not None:
+                learning[key] = value
+        return JSONResponse({"feedback_events": events, "learning_state": learning})
 
     @app.get("/integrations/guidance")
     async def integrations_guidance(variant: str = "canonical", format: str = "body") -> JSONResponse:

--- a/src/vaner/defaults/catalog_seed.json
+++ b/src/vaner/defaults/catalog_seed.json
@@ -1,0 +1,196 @@
+{
+  "schema_version": 2,
+  "generated_at": "2026-05-01",
+  "comment": "Family-level seed for the catalog refresher. The refresher (vaner.setup.catalog_refresh) emits one row per family using the family's :latest Ollama tag, derives params/size from the manifest's vnd.ollama.image.model layer bytes, and computes memory budgets. The seed carries family-level metadata that doesn't depend on size — display name, workload tags, ranks, sampling defaults, the model's max_context_window — plus the Ollama family name and an optional HF repo template. context_window here is the architectural ceiling; recommend_local_model picks a hardware/archetype-aware effective_context_window at recommend time, floored at 32K.",
+  "quantization_profiles": {
+    "Q4_K_M": { "bytes_per_param": 0.55, "label": "Q4_K_M", "ratio_to_fp16": 0.275 },
+    "Q5_K_M": { "bytes_per_param": 0.7, "label": "Q5_K_M", "ratio_to_fp16": 0.35 },
+    "Q6_K":   { "bytes_per_param": 0.84, "label": "Q6_K", "ratio_to_fp16": 0.42 },
+    "Q8_0":   { "bytes_per_param": 1.06, "label": "Q8_0", "ratio_to_fp16": 0.53 },
+    "FP16":   { "bytes_per_param": 2.0, "label": "FP16", "ratio_to_fp16": 1.0 }
+  },
+  "default_quantization": "Q4_K_M",
+  "families": [
+    {
+      "id": "qwen3.6",
+      "display_name": "Qwen 3.6",
+      "runtime": "ollama",
+      "ollama_family": "qwen3.6",
+      "hf_org": "Qwen",
+      "hf_repo_template": "Qwen/Qwen3.6-{size}-Instruct",
+      "workload_tags": ["general", "coding", "summarization"],
+      "stability_rank": 85,
+      "quality_rank": 98,
+      "recency_rank": 100,
+      "parameters": {
+        "context_window": 262144,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 8192,
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05
+      }
+    },
+    {
+      "id": "qwen3.5",
+      "display_name": "Qwen 3.5",
+      "runtime": "ollama",
+      "ollama_family": "qwen3.5",
+      "hf_org": "Qwen",
+      "hf_repo_template": "Qwen/Qwen3.5-{size}-Instruct",
+      "workload_tags": ["general", "coding", "summarization"],
+      "stability_rank": 90,
+      "quality_rank": 95,
+      "recency_rank": 90,
+      "parameters": {
+        "context_window": 131072,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 8192,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05
+      }
+    },
+    {
+      "id": "qwen3-coder-next",
+      "display_name": "Qwen 3 Coder Next",
+      "runtime": "ollama",
+      "ollama_family": "qwen3-coder-next",
+      "hf_org": "Qwen",
+      "hf_repo_template": "Qwen/Qwen3-Coder-Next-{size}",
+      "workload_tags": ["coding", "general"],
+      "stability_rank": 85,
+      "quality_rank": 92,
+      "recency_rank": 95,
+      "parameters": {
+        "context_window": 262144,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 8192,
+        "temperature": 0.2,
+        "top_p": 0.95,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05
+      }
+    },
+    {
+      "id": "qwen3-next",
+      "display_name": "Qwen 3 Next",
+      "runtime": "ollama",
+      "ollama_family": "qwen3-next",
+      "hf_org": "Qwen",
+      "hf_repo_template": "Qwen/Qwen3-Next-{size}",
+      "workload_tags": ["general", "coding"],
+      "stability_rank": 85,
+      "quality_rank": 90,
+      "recency_rank": 92,
+      "parameters": {
+        "context_window": 262144,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 8192,
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05
+      }
+    },
+    {
+      "id": "llama4",
+      "display_name": "Llama 4",
+      "runtime": "ollama",
+      "ollama_family": "llama4",
+      "hf_org": "meta-llama",
+      "hf_repo_template": "meta-llama/Llama-4-{size}-Instruct",
+      "workload_tags": ["general", "summarization"],
+      "stability_rank": 90,
+      "quality_rank": 94,
+      "recency_rank": 95,
+      "parameters": {
+        "context_window": 1048576,
+        "reasoning_mode": "none",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 0,
+        "temperature": 0.6,
+        "top_p": 0.9,
+        "top_k": 50,
+        "repeat_penalty": 1.1
+      }
+    },
+    {
+      "id": "gemma4",
+      "display_name": "Gemma 4",
+      "runtime": "ollama",
+      "ollama_family": "gemma4",
+      "hf_org": "google",
+      "hf_repo_template": "google/gemma-4-{size}-it",
+      "workload_tags": ["general", "summarization", "lightweight"],
+      "stability_rank": 88,
+      "quality_rank": 78,
+      "recency_rank": 92,
+      "parameters": {
+        "context_window": 131072,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 3072,
+        "reasoning_token_budget": 4096,
+        "temperature": 0.8,
+        "top_p": 0.95,
+        "top_k": 64,
+        "repeat_penalty": 1.0
+      }
+    },
+    {
+      "id": "deepseek-r2",
+      "display_name": "DeepSeek-R2",
+      "runtime": "ollama",
+      "ollama_family": "deepseek-r2",
+      "hf_org": "deepseek-ai",
+      "hf_repo_template": "deepseek-ai/DeepSeek-R2-Distill-Qwen-{size}",
+      "workload_tags": ["general", "coding", "research"],
+      "stability_rank": 80,
+      "quality_rank": 96,
+      "recency_rank": 96,
+      "parameters": {
+        "context_window": 131072,
+        "reasoning_mode": "forced",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 16384,
+        "temperature": 0.6,
+        "top_p": 0.95,
+        "top_k": 40,
+        "repeat_penalty": 1.0
+      }
+    },
+    {
+      "id": "qwen3",
+      "display_name": "Qwen 3",
+      "runtime": "ollama",
+      "ollama_family": "qwen3",
+      "hf_org": "Qwen",
+      "hf_repo_template": "Qwen/Qwen3-{size}-Instruct",
+      "workload_tags": ["general", "lightweight"],
+      "stability_rank": 95,
+      "quality_rank": 75,
+      "recency_rank": 80,
+      "parameters": {
+        "context_window": 32768,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 2048,
+        "reasoning_token_budget": 2048,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05
+      }
+    }
+  ]
+}

--- a/src/vaner/defaults/model_registry.json
+++ b/src/vaner/defaults/model_registry.json
@@ -1,0 +1,229 @@
+{
+  "schema_version": 1,
+  "verified_at": "2026-05-01",
+  "generator": "vaner.setup.catalog_refresh",
+  "online": true,
+  "sources": [
+    "https://registry.ollama.ai",
+    "https://huggingface.co/api/models"
+  ],
+  "models": [
+    {
+      "id": "qwen3.6:latest",
+      "display_name": "Qwen 3.6",
+      "runtime": "ollama",
+      "workload_tags": [
+        "general",
+        "coding",
+        "summarization"
+      ],
+      "quality_rank": 98,
+      "stability_rank": 85,
+      "recency_rank": 100,
+      "download_size_gb": 22.3,
+      "min_effective_memory_gb": 25.4,
+      "recommended_effective_memory_gb": 55.9,
+      "parameters": {
+        "context_window": 262144,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 8192,
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05,
+        "num_ctx": 262144
+      },
+      "family_id": "qwen3.6",
+      "params_b": 40.5,
+      "quantization": "Q4_K_M"
+    },
+    {
+      "id": "qwen3.5:latest",
+      "display_name": "Qwen 3.5",
+      "runtime": "ollama",
+      "workload_tags": [
+        "general",
+        "coding",
+        "summarization"
+      ],
+      "quality_rank": 95,
+      "stability_rank": 90,
+      "recency_rank": 90,
+      "download_size_gb": 6.1,
+      "min_effective_memory_gb": 7.4,
+      "recommended_effective_memory_gb": 12.1,
+      "parameters": {
+        "context_window": 131072,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 8192,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05,
+        "num_ctx": 131072
+      },
+      "family_id": "qwen3.5",
+      "params_b": 11.2,
+      "quantization": "Q4_K_M"
+    },
+    {
+      "id": "qwen3-coder-next:latest",
+      "display_name": "Qwen 3 Coder Next",
+      "runtime": "ollama",
+      "workload_tags": [
+        "coding",
+        "general"
+      ],
+      "quality_rank": 92,
+      "stability_rank": 85,
+      "recency_rank": 95,
+      "download_size_gb": 48.2,
+      "min_effective_memory_gb": 54.5,
+      "recommended_effective_memory_gb": 119.1,
+      "parameters": {
+        "context_window": 262144,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 8192,
+        "temperature": 0.2,
+        "top_p": 0.95,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05,
+        "num_ctx": 262144
+      },
+      "family_id": "qwen3-coder-next",
+      "params_b": 87.6,
+      "quantization": "Q4_K_M"
+    },
+    {
+      "id": "qwen3-next:latest",
+      "display_name": "Qwen 3 Next",
+      "runtime": "ollama",
+      "workload_tags": [
+        "general",
+        "coding"
+      ],
+      "quality_rank": 90,
+      "stability_rank": 85,
+      "recency_rank": 92,
+      "download_size_gb": 46.9,
+      "min_effective_memory_gb": 53.0,
+      "recommended_effective_memory_gb": 116.0,
+      "parameters": {
+        "context_window": 262144,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 8192,
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05,
+        "num_ctx": 262144
+      },
+      "family_id": "qwen3-next",
+      "params_b": 85.3,
+      "quantization": "Q4_K_M"
+    },
+    {
+      "id": "llama4:latest",
+      "display_name": "Llama 4",
+      "runtime": "ollama",
+      "workload_tags": [
+        "general",
+        "summarization"
+      ],
+      "quality_rank": 94,
+      "stability_rank": 90,
+      "recency_rank": 95,
+      "download_size_gb": 62.8,
+      "min_effective_memory_gb": 70.8,
+      "recommended_effective_memory_gb": 426.1,
+      "parameters": {
+        "context_window": 1048576,
+        "reasoning_mode": "none",
+        "max_response_tokens": 4096,
+        "reasoning_token_budget": 0,
+        "temperature": 0.6,
+        "top_p": 0.9,
+        "top_k": 50,
+        "repeat_penalty": 1.1,
+        "num_ctx": 1048576
+      },
+      "family_id": "llama4",
+      "params_b": 114.2,
+      "quantization": "Q4_K_M"
+    },
+    {
+      "id": "gemma4:latest",
+      "display_name": "Gemma 4",
+      "runtime": "ollama",
+      "workload_tags": [
+        "general",
+        "summarization",
+        "lightweight"
+      ],
+      "quality_rank": 78,
+      "stability_rank": 88,
+      "recency_rank": 92,
+      "download_size_gb": 8.9,
+      "min_effective_memory_gb": 10.5,
+      "recommended_effective_memory_gb": 16.9,
+      "parameters": {
+        "context_window": 131072,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 3072,
+        "reasoning_token_budget": 4096,
+        "temperature": 0.8,
+        "top_p": 0.95,
+        "top_k": 64,
+        "repeat_penalty": 1.0,
+        "num_ctx": 131072
+      },
+      "family_id": "gemma4",
+      "params_b": 16.3,
+      "quantization": "Q4_K_M"
+    },
+    {
+      "id": "qwen3:latest",
+      "display_name": "Qwen 3",
+      "runtime": "ollama",
+      "workload_tags": [
+        "general",
+        "lightweight"
+      ],
+      "quality_rank": 75,
+      "stability_rank": 95,
+      "recency_rank": 80,
+      "download_size_gb": 4.9,
+      "min_effective_memory_gb": 5.9,
+      "recommended_effective_memory_gb": 7.2,
+      "parameters": {
+        "context_window": 32768,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 2048,
+        "reasoning_token_budget": 2048,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repeat_penalty": 1.05,
+        "num_ctx": 32768
+      },
+      "family_id": "qwen3",
+      "params_b": 8.8,
+      "quantization": "Q4_K_M"
+    }
+  ],
+  "skipped": [
+    {
+      "family": "deepseek-r2",
+      "reason": "ollama_latest_not_found"
+    }
+  ]
+}

--- a/src/vaner/models/config.py
+++ b/src/vaner/models/config.py
@@ -48,7 +48,7 @@ class BackendConfig(BaseModel):
 
         # Local Ollama
         base_url = "http://127.0.0.1:11434/v1"
-        model = "qwen2.5-coder:32b"
+        model = "qwen3.5:8b"
 
         # Local vLLM / LM Studio / any OpenAI-compatible server
         base_url = "http://127.0.0.1:8000/v1"
@@ -346,7 +346,7 @@ class ExplorationConfig(BaseModel):
 
     exploration_model: str = ""
     """Model name for the exploration LLM.
-    Ollama tag (e.g. ``"qwen2.5-coder:32b"``) or OpenAI-compatible model ID
+    Ollama tag (e.g. ``"qwen3.5:8b"``) or OpenAI-compatible model ID
     (e.g. ``"Qwen/Qwen3.5-35B-A3B-FP8"`` for vLLM).  Empty = pick first
     available model from the detected endpoint.
     """

--- a/src/vaner/setup/catalog_refresh.py
+++ b/src/vaner/setup/catalog_refresh.py
@@ -257,7 +257,8 @@ def build_registry(
     for family in families:
         try:
             entry = build_registry_entry_for_family(
-                seed, family,
+                seed,
+                family,
                 quant=default_quant,
                 online=online,
                 manifest_fetcher=manifest_fetcher,

--- a/src/vaner/setup/catalog_refresh.py
+++ b/src/vaner/setup/catalog_refresh.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Catalog refresher for ``model_registry.json``.
+
+The seed at ``vaner/defaults/catalog_seed.json`` carries family-level
+metadata (workload tags, sampling/runtime parameter defaults from the
+model authors, quality/stability/recency ranks). The refresher emits
+**one registry row per family** using the family's ``:latest`` Ollama
+tag. ``:latest`` is what whoever published the family declared the
+canonical pull, so it's the safest default; users who want a different
+size can edit ``backend.model`` afterwards.
+
+For each family the refresher:
+
+1. ``HEAD https://registry.ollama.ai/v2/library/<family>/manifests/latest``.
+   404 → skip the family (not pullable). Anything else → continue.
+2. ``GET`` the manifest, sum the size of layers whose ``mediaType``
+   starts with ``application/vnd.ollama.image.model`` to get the
+   on-disk weight size in bytes.
+3. Derive ``params_b`` by dividing weight size by the seed's default
+   quantization profile's ``bytes_per_param``. Memory budgets follow.
+
+Fallbacks: ``--offline`` / unreachable network produces a seed-only
+registry where each family becomes a single ``<family>:latest`` row
+with the seed's declared default sizing (params_b unknown, budgets
+seed-derived).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from importlib import resources
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+OLLAMA_REGISTRY_BASE = "https://registry.ollama.ai/v2/library/{name}/manifests/{tag}"
+HF_API_BASE = "https://huggingface.co/api/models/{repo}"
+DEFAULT_HTTP_TIMEOUT = 8.0
+OLLAMA_MODEL_LAYER_PREFIX = "application/vnd.ollama.image.model"
+
+
+@dataclass(frozen=True, slots=True)
+class FamilySeed:
+    id: str
+    display_name: str
+    runtime: str
+    ollama_family: str
+    hf_repo_template: str
+    workload_tags: tuple[str, ...]
+    quality_rank: int
+    stability_rank: int
+    recency_rank: int
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+
+def load_catalog_seed() -> dict[str, Any]:
+    """Read the bundled ``catalog_seed.json``."""
+
+    text = resources.files("vaner.defaults").joinpath("catalog_seed.json").read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def families_from_seed(seed: dict[str, Any]) -> list[FamilySeed]:
+    families: list[FamilySeed] = []
+    for entry in seed.get("families", []):
+        families.append(
+            FamilySeed(
+                id=str(entry["id"]),
+                display_name=str(entry.get("display_name", entry["id"])),
+                runtime=str(entry.get("runtime", "ollama")),
+                ollama_family=str(entry.get("ollama_family", entry["id"])),
+                hf_repo_template=str(entry.get("hf_repo_template", "")),
+                workload_tags=tuple(str(t) for t in entry.get("workload_tags", [])),
+                quality_rank=int(entry.get("quality_rank", 0)),
+                stability_rank=int(entry.get("stability_rank", 0)),
+                recency_rank=int(entry.get("recency_rank", 0)),
+                parameters=dict(entry.get("parameters", {})),
+            )
+        )
+    return families
+
+
+def quantization_bytes_per_param(seed: dict[str, Any], quant: str) -> float:
+    profiles = seed.get("quantization_profiles", {})
+    profile = profiles.get(quant) or profiles.get("Q4_K_M")
+    if not profile:
+        return 0.55
+    return float(profile.get("bytes_per_param", 0.55))
+
+
+def estimate_memory_budget(params_b: float, bytes_per_param: float, context_window: int) -> tuple[float, float]:
+    """Return (min_effective_gb, recommended_effective_gb)."""
+
+    weights_gb = params_b * bytes_per_param
+    if weights_gb <= 0:
+        return 0.0, 0.0
+    context_overhead = max(0.5, weights_gb * (context_window / 32768) * 0.18)
+    min_gb = round(weights_gb * 1.12 + 0.5, 1)
+    rec_gb = round(weights_gb + context_overhead + 1.5, 1)
+    return min_gb, max(rec_gb, min_gb)
+
+
+def fetch_ollama_manifest(family: str, *, tag: str = "latest", timeout: float = DEFAULT_HTTP_TIMEOUT) -> dict[str, Any] | None:
+    """GET the OCI manifest for ``<family>:<tag>`` from Ollama's registry.
+
+    Returns the parsed JSON manifest or ``None`` on any failure (404,
+    network, JSON parse).
+    """
+
+    import urllib.error
+    import urllib.request
+
+    url = OLLAMA_REGISTRY_BASE.format(name=family, tag=tag)
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+                "User-Agent": "vaner-catalog-refresh/1.0",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        logger.debug("ollama manifest %s:%s -> HTTP %s", family, tag, exc.code)
+        return None
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+        logger.debug("ollama manifest %s:%s failed: %s", family, tag, exc)
+        return None
+
+
+def manifest_weights_bytes(manifest: dict[str, Any]) -> int:
+    """Sum the size of every layer whose mediaType is the model weights.
+
+    Ollama places each model file as a layer with mediaType
+    ``application/vnd.ollama.image.model`` (or a subtype thereof). We
+    sum across all such layers so MoE families that ship sharded model
+    layers get the full weight size, not just the first shard.
+    """
+
+    total = 0
+    for layer in manifest.get("layers", []) or []:
+        media = str(layer.get("mediaType", ""))
+        if media.startswith(OLLAMA_MODEL_LAYER_PREFIX):
+            size = layer.get("size")
+            if isinstance(size, (int, float)) and size > 0:
+                total += int(size)
+    return total
+
+
+def fetch_hf_params_b(repo: str, *, timeout: float = DEFAULT_HTTP_TIMEOUT) -> float | None:
+    """Best-effort lookup of HF parameter count, in billions."""
+
+    if not repo:
+        return None
+    import urllib.error
+    import urllib.request
+
+    url = HF_API_BASE.format(repo=repo)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+        logger.debug("HF lookup failed for %s: %s", repo, exc)
+        return None
+
+    safetensors = data.get("safetensors")
+    if isinstance(safetensors, dict):
+        total = safetensors.get("total")
+        if isinstance(total, (int, float)) and total > 0:
+            return float(total) / 1_000_000_000
+    return None
+
+
+def build_registry_entry_for_family(
+    seed: dict[str, Any],
+    family: FamilySeed,
+    *,
+    quant: str,
+    online: bool,
+    manifest_fetcher=fetch_ollama_manifest,
+) -> dict[str, Any] | None:
+    """Translate one family into a single ``<family>:latest`` registry row.
+
+    Returns ``None`` when the family is unreachable on Ollama (online
+    mode) — caller skips it.
+    """
+
+    bytes_per_param = quantization_bytes_per_param(seed, quant)
+    params_b: float = 0.0
+    download_gb: float = 0.0
+
+    if online:
+        manifest = manifest_fetcher(family.ollama_family)
+        if manifest is None:
+            return None
+        weights_bytes = manifest_weights_bytes(manifest)
+        if weights_bytes <= 0:
+            logger.debug("ollama manifest for %s has no model layer", family.id)
+            return None
+        download_gb = round(weights_bytes / (1024**3), 1)
+        # Derive params from on-disk size + quant profile. This is more
+        # honest than guessing; the user pulls exactly these bytes.
+        params_b = round(weights_bytes / (1024**3) / bytes_per_param, 1)
+    else:
+        # Offline path: emit a placeholder so the registry has a row per
+        # family. Memory budgets stay 0 — callers should refresh online.
+        params_b = 0.0
+        download_gb = 0.0
+
+    context_window = int(family.parameters.get("context_window", 8192))
+    min_gb, rec_gb = estimate_memory_budget(params_b, bytes_per_param, context_window)
+
+    parameters = dict(family.parameters)
+    parameters.setdefault("num_ctx", context_window)
+
+    full_tag = f"{family.ollama_family}:latest" if family.runtime == "ollama" else family.id
+
+    return {
+        "id": full_tag,
+        "display_name": family.display_name,
+        "runtime": family.runtime,
+        "workload_tags": list(family.workload_tags),
+        "quality_rank": family.quality_rank,
+        "stability_rank": family.stability_rank,
+        "recency_rank": family.recency_rank,
+        "download_size_gb": download_gb,
+        "min_effective_memory_gb": min_gb,
+        "recommended_effective_memory_gb": rec_gb,
+        "parameters": parameters,
+        "family_id": family.id,
+        "params_b": params_b,
+        "quantization": quant,
+    }
+
+
+def build_registry(
+    *,
+    online: bool = True,
+    seed: dict[str, Any] | None = None,
+    manifest_fetcher=fetch_ollama_manifest,
+) -> dict[str, Any]:
+    """Produce a full ``model_registry.json`` payload.
+
+    `manifest_fetcher` is parameterized so tests can swap in a mock.
+    """
+
+    seed = seed or load_catalog_seed()
+    default_quant = str(seed.get("default_quantization", "Q4_K_M"))
+    families = families_from_seed(seed)
+    models: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+
+    for family in families:
+        try:
+            entry = build_registry_entry_for_family(
+                seed, family,
+                quant=default_quant,
+                online=online,
+                manifest_fetcher=manifest_fetcher,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("catalog: failed for %s (%s)", family.id, exc)
+            skipped.append({"family": family.id, "reason": f"build_error: {exc}"})
+            continue
+        if entry is None:
+            skipped.append({"family": family.id, "reason": "ollama_latest_not_found"})
+            continue
+        models.append(entry)
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "verified_at": datetime.now(UTC).strftime("%Y-%m-%d"),
+        "generator": "vaner.setup.catalog_refresh",
+        "online": bool(online),
+        "sources": [
+            "https://registry.ollama.ai",
+            "https://huggingface.co/api/models",
+        ]
+        if online
+        else ["catalog_seed.json"],
+        "models": models,
+    }
+    if skipped:
+        payload["skipped"] = skipped
+    return payload

--- a/src/vaner/setup/config_io.py
+++ b/src/vaner/setup/config_io.py
@@ -62,6 +62,67 @@ def persist_setup_and_policy(
     return config_path
 
 
+def persist_runtime_recommendation(repo_root: Path, recommendation: dict[str, Any]) -> Path:
+    """Persist the concrete runtime/model selected by setup recommendation."""
+
+    config_path = _init_repo_config(repo_root)
+    text = config_path.read_text(encoding="utf-8")
+    selected = recommendation.get("selected", {})
+    if not isinstance(selected, dict):
+        selected = {}
+    runtime = str(selected.get("runtime") or "ollama")
+    model_id = str(selected.get("model_id") or selected.get("id") or "")
+    base_url = str(selected.get("base_url") or "http://127.0.0.1:11434/v1")
+    params = selected.get("params") if isinstance(selected.get("params"), dict) else {}
+    reasoning_mode = str(params.get("reasoning_mode") or "allowed")
+    max_response_tokens = int(params.get("max_response_tokens") or 3072)
+    reasoning_token_budget = int(params.get("reasoning_token_budget") or 4096)
+    hardware = recommendation.get("hardware", {})
+    memory_source = hardware.get("memory_source") if isinstance(hardware, dict) else None
+    accelerator_type = hardware.get("accelerator_type") if isinstance(hardware, dict) else None
+    device = "auto"
+    if accelerator_type == "nvidia":
+        device = "cuda"
+    elif accelerator_type == "apple_silicon":
+        device = "mps"
+    elif memory_source in {"system", "cpu"}:
+        device = "cpu"
+
+    text = update_toml_section(
+        text,
+        "backend",
+        {
+            "name": runtime,
+            "base_url": base_url,
+            "model": model_id,
+            "api_key_env": "",
+            "prefer_local": True,
+            "reasoning_mode": reasoning_mode,
+            "max_response_tokens": max_response_tokens,
+            "reasoning_token_budget": reasoning_token_budget,
+        },
+    )
+    text = update_toml_section(
+        text,
+        "exploration",
+        {
+            "exploration_endpoint": base_url.removesuffix("/v1") if runtime == "ollama" else base_url,
+            "exploration_model": model_id,
+            "exploration_backend": "ollama" if runtime == "ollama" else "openai",
+        },
+    )
+    text = update_toml_section(
+        text,
+        "compute",
+        {
+            "device": device,
+            "embedding_device": device if device in {"cuda", "mps"} else "cpu",
+        },
+    )
+    _atomic_write_text(config_path, text)
+    return config_path
+
+
 def toml_literal(value: object) -> str:
     """Render a Python scalar/list as the TOML literal shape setup writes."""
 

--- a/src/vaner/setup/hardware.py
+++ b/src/vaner/setup/hardware.py
@@ -760,12 +760,8 @@ def detect() -> HardwareProfile:
     # comes off raw bytes. Apple Silicon and any device the per-GPU
     # probe flagged as `memory_kind == "unified"` count as unified.
     memory_total_bytes = max(0, int(ram_gb) * (1024**3))
-    memory_display_gb = (
-        max(1, round(memory_total_bytes / 1_000_000_000)) if memory_total_bytes > 0 else 0
-    )
-    memory_is_unified = gpu == "apple_silicon" or any(
-        getattr(d, "memory_kind", None) == "unified" for d in devices
-    )
+    memory_display_gb = max(1, round(memory_total_bytes / 1_000_000_000)) if memory_total_bytes > 0 else 0
+    memory_is_unified = gpu == "apple_silicon" or any(getattr(d, "memory_kind", None) == "unified" for d in devices)
 
     profile = HardwareProfile(
         os=effective_os,

--- a/src/vaner/setup/hardware.py
+++ b/src/vaner/setup/hardware.py
@@ -78,6 +78,18 @@ class HardwareProfile:
     thermal_constrained: bool
     detected_runtimes: tuple[Runtime, ...]
     detected_models: tuple[tuple[str, str, str], ...]
+    # Total system memory in raw bytes — the model recommender's
+    # budget calc needs sub-GB precision (a 31.8 GB VRAM card rounds
+    # to 32 GB which fits a 30B model after Q4 quant). The legacy
+    # `ram_gb` int stays for surfaces that read the GiB summary.
+    memory_total_bytes: int = 0
+    # Decimal GB for consumer copy ("32 GB"), distinct from the
+    # binary GiB count in `ram_gb`. Zero when not yet computed.
+    memory_display_gb: int = 0
+    # True on Apple Silicon (and other unified-memory systems where
+    # the GPU shares the system RAM pool). Affects how the
+    # recommender treats VRAM headroom.
+    memory_is_unified: bool = False
     tier: HardwareTier = field(default="unknown")
     # Per-device GPU enumeration. Empty tuple when no probe could
     # identify discrete devices — consumers should fall back to the
@@ -742,6 +754,19 @@ def detect() -> HardwareProfile:
     if gpu_vram_gb is None and devices:
         gpu_vram_gb = devices[0].memory_display_gb
 
+    # Sub-GB-precision memory + unified-memory flag for the model
+    # recommender. `memory_total_bytes` derives from the GiB integer
+    # we already have (sub-GB system RAM is rare); decimal display GB
+    # comes off raw bytes. Apple Silicon and any device the per-GPU
+    # probe flagged as `memory_kind == "unified"` count as unified.
+    memory_total_bytes = max(0, int(ram_gb) * (1024**3))
+    memory_display_gb = (
+        max(1, round(memory_total_bytes / 1_000_000_000)) if memory_total_bytes > 0 else 0
+    )
+    memory_is_unified = gpu == "apple_silicon" or any(
+        getattr(d, "memory_kind", None) == "unified" for d in devices
+    )
+
     profile = HardwareProfile(
         os=effective_os,
         cpu_class=cpu_class,
@@ -752,6 +777,9 @@ def detect() -> HardwareProfile:
         thermal_constrained=thermal,
         detected_runtimes=runtimes,
         detected_models=models,
+        memory_total_bytes=memory_total_bytes,
+        memory_display_gb=memory_display_gb,
+        memory_is_unified=memory_is_unified,
         tier="unknown",
         gpu_devices=devices,
     )
@@ -766,6 +794,9 @@ def detect() -> HardwareProfile:
         thermal_constrained=thermal,
         detected_runtimes=runtimes,
         detected_models=models,
+        memory_total_bytes=memory_total_bytes,
+        memory_display_gb=memory_display_gb,
+        memory_is_unified=memory_is_unified,
         tier=final_tier,
         gpu_devices=devices,
     )

--- a/src/vaner/setup/model_recommendation.py
+++ b/src/vaner/setup/model_recommendation.py
@@ -393,9 +393,7 @@ _CONTEXT_WINDOW_FLOOR = 32768
 
 # Archetypes that benefit from longer context (whole-file, repo-scope,
 # multi-doc work). Anything not in this set gets the floor as the target.
-_LONG_CONTEXT_WORK_STYLES = frozenset(
-    {"coding", "research", "planning", "mixed"}
-)
+_LONG_CONTEXT_WORK_STYLES = frozenset({"coding", "research", "planning", "mixed"})
 
 
 def compute_effective_context_window(

--- a/src/vaner/setup/model_recommendation.py
+++ b/src/vaner/setup/model_recommendation.py
@@ -1,0 +1,634 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hardware-aware local model recommendation for desktop first-run."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any, Literal
+
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.hardware import HardwareProfile, Runtime, detect
+
+REGISTRY_SCHEMA_VERSION = 1
+OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1"
+OLLAMA_NATIVE_ENDPOINT = "http://127.0.0.1:11434"
+
+
+@dataclass(frozen=True, slots=True)
+class RecommendedModel:
+    id: str
+    display_name: str
+    runtime: Runtime
+    workload_tags: tuple[str, ...]
+    quality_rank: int
+    stability_rank: int
+    recency_rank: int
+    download_size_gb: float
+    min_effective_memory_gb: float
+    recommended_effective_memory_gb: float
+    parameters: dict[str, Any]
+
+    @classmethod
+    def from_raw(cls, raw: dict[str, Any]) -> RecommendedModel:
+        return cls(
+            id=str(raw["id"]),
+            display_name=str(raw.get("display_name") or raw["id"]),
+            runtime=str(raw.get("runtime", "ollama")),  # type: ignore[arg-type]
+            workload_tags=tuple(str(v) for v in raw.get("workload_tags", [])),
+            quality_rank=int(raw.get("quality_rank", 0)),
+            stability_rank=int(raw.get("stability_rank", 0)),
+            recency_rank=int(raw.get("recency_rank", 0)),
+            download_size_gb=float(raw.get("download_size_gb", 0)),
+            min_effective_memory_gb=float(raw.get("min_effective_memory_gb", 0)),
+            recommended_effective_memory_gb=float(raw.get("recommended_effective_memory_gb", raw.get("min_effective_memory_gb", 0))),
+            parameters=dict(raw.get("parameters", {})),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ModelRegistry:
+    schema_version: int
+    verified_at: str
+    sources: tuple[str, ...]
+    models: tuple[RecommendedModel, ...]
+    valid: bool = True
+    warning: str | None = None
+
+
+def load_model_registry() -> ModelRegistry:
+    try:
+        text = resources.files("vaner.defaults").joinpath("model_registry.json").read_text(encoding="utf-8")
+        raw = json.loads(text)
+        registry = validate_model_registry(raw)
+        return registry
+    except Exception as exc:
+        return _fallback_registry(f"model registry unavailable: {exc}")
+
+
+def validate_model_registry(raw: object) -> ModelRegistry:
+    if not isinstance(raw, dict):
+        raise ValueError("registry must be a JSON object")
+    schema_version = int(raw.get("schema_version", 0))
+    if schema_version != REGISTRY_SCHEMA_VERSION:
+        raise ValueError(f"unsupported model registry schema_version={schema_version}")
+    models_raw = raw.get("models")
+    if not isinstance(models_raw, list) or not models_raw:
+        raise ValueError("registry must contain at least one model")
+    models = tuple(RecommendedModel.from_raw(m) for m in models_raw if isinstance(m, dict))
+    if not models:
+        raise ValueError("registry did not contain any valid model entries")
+    return ModelRegistry(
+        schema_version=schema_version,
+        verified_at=str(raw.get("verified_at", "unknown")),
+        sources=tuple(str(src) for src in raw.get("sources", []) if isinstance(src, str)),
+        models=models,
+    )
+
+
+def _fallback_registry(warning: str) -> ModelRegistry:
+    return ModelRegistry(
+        schema_version=REGISTRY_SCHEMA_VERSION,
+        verified_at="fallback",
+        sources=(),
+        valid=False,
+        warning=warning,
+        models=(
+            RecommendedModel(
+                id="qwen3:4b",
+                display_name="Qwen 3 4B",
+                runtime="ollama",
+                workload_tags=("general", "lightweight"),
+                quality_rank=60,
+                stability_rank=90,
+                recency_rank=60,
+                download_size_gb=3,
+                min_effective_memory_gb=4,
+                recommended_effective_memory_gb=6,
+                parameters={
+                    "context_window": 8192,
+                    "reasoning_mode": "allowed",
+                    "max_response_tokens": 2048,
+                    "reasoning_token_budget": 2048,
+                },
+            ),
+        ),
+    )
+
+
+def recommend_local_model(
+    answers: SetupAnswers | None = None,
+    hardware: HardwareProfile | None = None,
+    *,
+    registry: ModelRegistry | None = None,
+) -> dict[str, Any]:
+    """Return the desktop setup recommendation contract."""
+
+    hw = hardware or detect()
+    reg = registry or load_model_registry()
+    effective_memory_gb, memory_source = _effective_memory_gb(hw)
+    workload_tags = _workload_tags(answers)
+    installed = {(runtime, model_id) for runtime, model_id, _size in hw.detected_models}
+    available_runtimes = set(hw.detected_runtimes)
+
+    candidates: list[tuple[float, RecommendedModel, dict[str, Any]]] = []
+    rejected: list[dict[str, Any]] = []
+    for model in reg.models:
+        fit = _fit_status(model, effective_memory_gb)
+        installed_match = (model.runtime, model.id) in installed
+        runtime_available = model.runtime in available_runtimes
+        if fit == "too_large":
+            rejected.append(
+                {
+                    "model_id": model.id,
+                    "runtime": model.runtime,
+                    "reason": "needs_more_memory",
+                    "min_effective_memory_gb": model.min_effective_memory_gb,
+                    "effective_memory_gb": effective_memory_gb,
+                }
+            )
+            continue
+        if model.runtime != "ollama" and not runtime_available:
+            rejected.append({"model_id": model.id, "runtime": model.runtime, "reason": "runtime_unavailable"})
+            continue
+        score = _score_model(model, workload_tags, installed_match, runtime_available, fit)
+        candidates.append(
+            (
+                score,
+                model,
+                {
+                    "fit": fit,
+                    "already_installed": installed_match,
+                    "runtime_available": runtime_available,
+                },
+            )
+        )
+
+    if not candidates:
+        fallback = min(reg.models, key=lambda m: m.min_effective_memory_gb)
+        candidates.append(
+            (
+                0,
+                fallback,
+                {
+                    "fit": "fallback_cpu",
+                    "already_installed": (fallback.runtime, fallback.id) in installed,
+                    "runtime_available": fallback.runtime in available_runtimes,
+                },
+            )
+        )
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    score, selected, selected_diag = candidates[0]
+    runtime_available = selected.runtime in available_runtimes
+    already_installed = (selected.runtime, selected.id) in installed
+    needs_runtime_install = selected.runtime == "ollama" and not runtime_available
+    needs_model_download = not already_installed
+    user_explanation = _plain_explanation(hw, selected, effective_memory_gb, memory_source, already_installed)
+    install_plan = _install_plan(selected, needs_runtime_install, needs_model_download)
+    runtime = _runtime_payload(selected.runtime)
+    work_styles_tuple: tuple[str, ...] = tuple(answers.work_styles) if answers else ()
+    selected_payload = _selected_payload(
+        selected,
+        runtime,
+        selected_diag,
+        effective_memory_gb=effective_memory_gb,
+        work_styles=work_styles_tuple,
+    )
+
+    return {
+        "schema_version": 1,
+        "generator": "vaner-core",
+        "registry": {
+            "schema_version": reg.schema_version,
+            "verified_at": reg.verified_at,
+            "sources": list(reg.sources),
+            "valid": reg.valid,
+            "warning": reg.warning,
+        },
+        "user": {
+            "detected_accelerator": _accelerator_summary(hw),
+            "selected_runtime": runtime,
+            "selected_model": selected_payload,
+            "needs_runtime_install": needs_runtime_install,
+            "needs_model_download": needs_model_download,
+            "next_actions": [step["label"] for step in install_plan],
+            "explanation": user_explanation,
+        },
+        "hardware": _hardware_summary(hw, effective_memory_gb, memory_source),
+        "budget": {
+            "accelerator": hw.gpu,
+            "accelerator_label": _accelerator_label(hw),
+            "effective_gb_q4": effective_memory_gb,
+            "memory_source": memory_source,
+            "notes": [],
+        },
+        "selected": selected_payload,
+        "alternatives": [
+            _selected_payload(
+                model,
+                _runtime_payload(model.runtime),
+                diag,
+                effective_memory_gb=effective_memory_gb,
+                work_styles=work_styles_tuple,
+            )
+            for _score, model, diag in candidates[1:4]
+        ],
+        "install_plan": install_plan,
+        "diagnostics": {
+            "score": score,
+            "candidate_models": [
+                {
+                    "model_id": model.id,
+                    "runtime": model.runtime,
+                    "score": candidate_score,
+                    **diag,
+                }
+                for candidate_score, model, diag in candidates
+            ],
+            "rejected_models": rejected,
+            "raw_hardware": {
+                "memory_total_bytes": hw.memory_total_bytes,
+                "memory_is_unified": hw.memory_is_unified,
+                "gpu_devices": [
+                    {
+                        "name": d.name,
+                        "vendor": d.vendor,
+                        "kind": d.kind,
+                        "memory_total_bytes": d.memory_total_bytes,
+                        "memory_kind": d.memory_kind,
+                    }
+                    for d in hw.gpu_devices
+                ],
+            },
+        },
+    }
+
+
+def _effective_memory_gb(hw: HardwareProfile) -> tuple[float, Literal["vram", "unified", "system", "cpu"]]:
+    if hw.memory_is_unified and hw.memory_display_gb:
+        reserve = 8 if hw.memory_display_gb >= 24 else 4
+        return max(2.0, float(hw.memory_display_gb - reserve)), "unified"
+    gpu_memories = [d.memory_display_gb for d in hw.gpu_devices if d.memory_kind == "vram" and d.memory_display_gb]
+    if gpu_memories:
+        # Keep headroom for the desktop, runtime, and context buffers.
+        return max(2.0, float(max(gpu_memories) - 2)), "vram"
+    if hw.gpu_vram_gb:
+        return max(2.0, float(hw.gpu_vram_gb - 2)), "vram"
+    if hw.gpu in {"nvidia", "amd"}:
+        # A discrete GPU without readable VRAM is not enough evidence for
+        # a large-model recommendation. Stay conservative until diagnostics
+        # can read the actual accelerator memory.
+        return min(8.0, max(2.0, float((hw.memory_display_gb or hw.ram_gb) - 8))), "system"
+    if hw.memory_display_gb:
+        reserve = 6 if hw.memory_display_gb >= 16 else 3
+        return max(2.0, float(hw.memory_display_gb - reserve)), "system"
+    return 2.0, "cpu"
+
+
+def _workload_tags(answers: SetupAnswers | None) -> set[str]:
+    tags = {"general", "summarization"}
+    if answers is None:
+        return tags | {"coding"}
+    for style in answers.work_styles:
+        if style in {"coding", "planning", "mixed"}:
+            tags.add("coding")
+        if style in {"writing", "research", "support", "learning", "mixed"}:
+            tags.add("summarization")
+    return tags
+
+
+def _fit_status(model: RecommendedModel, effective_memory_gb: float) -> Literal["recommended", "fits", "too_large"]:
+    if effective_memory_gb >= model.recommended_effective_memory_gb:
+        return "recommended"
+    if effective_memory_gb >= model.min_effective_memory_gb:
+        return "fits"
+    return "too_large"
+
+
+def _score_model(
+    model: RecommendedModel,
+    workload_tags: set[str],
+    installed_match: bool,
+    runtime_available: bool,
+    fit: str,
+) -> float:
+    tag_overlap = len(workload_tags.intersection(model.workload_tags))
+    score = model.stability_rank * 3.0
+    score += model.quality_rank * 2.2
+    score += tag_overlap * 35.0
+    score += max(0.0, 30.0 - model.download_size_gb) * 1.5
+    score += model.recency_rank * 0.35
+    if fit == "recommended":
+        score += 75
+    elif fit == "fits":
+        score += 25
+    if installed_match:
+        score += 120
+    elif runtime_available:
+        score += 30
+    return score
+
+
+def _runtime_payload(runtime: Runtime) -> dict[str, Any]:
+    if runtime == "ollama":
+        return {
+            "id": "ollama",
+            "label": "Ollama",
+            "base_url": OLLAMA_BASE_URL,
+            "native_endpoint": OLLAMA_NATIVE_ENDPOINT,
+            "install_managed": True,
+        }
+    return {"id": runtime, "label": runtime, "base_url": "", "install_managed": False}
+
+
+# Keys in a model's flat ``parameters`` block that are runtime-side (Ollama
+# / vLLM options, KV-cache, batching) versus model-side sampling defaults.
+# Anything not listed here stays in ``params`` as a model-level capability
+# (context_window, reasoning_mode, max_response_tokens, ...).
+_RUNTIME_PARAM_KEYS = frozenset(
+    {
+        "keep_alive",
+        "num_ctx",
+        "num_predict",
+        "num_thread",
+        "num_batch",
+        "num_gpu",
+        "main_gpu",
+        "low_vram",
+        "f16_kv",
+        "use_mmap",
+        "use_mlock",
+        "rope_frequency_base",
+        "rope_frequency_scale",
+        "stop",
+    }
+)
+_SAMPLING_PARAM_KEYS = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "top_k",
+        "repeat_penalty",
+        "repeat_last_n",
+        "min_p",
+        "tfs_z",
+        "typical_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "mirostat",
+        "mirostat_eta",
+        "mirostat_tau",
+        "seed",
+    }
+)
+
+
+# Floor for effective context window — the cockpit and the desktop both
+# rely on at least 32K tokens being available for prepared briefings to
+# fit. Going below this defeats the point of running a local model with a
+# native long-context architecture.
+_CONTEXT_WINDOW_FLOOR = 32768
+
+# Archetypes that benefit from longer context (whole-file, repo-scope,
+# multi-doc work). Anything not in this set gets the floor as the target.
+_LONG_CONTEXT_WORK_STYLES = frozenset(
+    {"coding", "research", "planning", "mixed"}
+)
+
+
+def compute_effective_context_window(
+    *,
+    max_context_window: int,
+    weights_gb: float,
+    effective_memory_gb: float,
+    work_styles: tuple[str, ...] = (),
+    runtime: str = "ollama",
+) -> int:
+    """Pick a runtime-effective context window.
+
+    Inputs:
+      - ``max_context_window``: the model's architectural ceiling (from
+        the registry's ``parameters.context_window`` / ``max_context_window``).
+      - ``weights_gb``: the model's on-disk size (≈ VRAM weight load).
+      - ``effective_memory_gb``: the user's available accelerator memory
+        from the hardware probe.
+      - ``work_styles``: the wizard's archetype answers (coding,
+        research, …) — long-context archetypes get a higher target.
+      - ``runtime``: today only ``ollama`` is wired; left as an input so
+        future runtimes (vLLM, llama.cpp w/ flash-attn) can override.
+
+    Returns the chosen window, clamped to [floor, max].
+
+    Heuristic — KV-cache scales roughly linearly with both context
+    length and weight size; for Q4 + GQA models a 32K context costs
+    around 18% of weight memory. We turn that around: pick the largest
+    multiple of 32K that fits in the headroom we have after weights and
+    a small safety reserve.
+    """
+
+    floor = _CONTEXT_WINDOW_FLOOR
+    cap = max(floor, int(max_context_window or floor))
+
+    long_archetype = bool(set(work_styles) & _LONG_CONTEXT_WORK_STYLES)
+    target = 65536 if long_archetype else floor
+
+    if weights_gb <= 0 or effective_memory_gb <= 0:
+        # Unknown sizing — honor the floor; let the runtime cap itself.
+        chosen = min(cap, max(floor, target))
+        return chosen
+
+    # Headroom available for KV / activations after the weights load.
+    headroom_gb = max(0.0, effective_memory_gb - weights_gb - 1.5)
+    # Cost of KV at the family's 32K reference. 0.18 is the rough Q4+GQA
+    # constant; flash-attn / paged-attention runtimes get more headroom
+    # implicitly because they pack the cache more tightly.
+    cost_per_32k = max(0.5, weights_gb * 0.18)
+    if cost_per_32k <= 0:
+        return min(cap, max(floor, target))
+
+    # How many 32K worth of KV we can afford.
+    multiples = int(headroom_gb // cost_per_32k)
+    if multiples <= 0:
+        # Tight on memory — drop to the floor; runtime quantizes KV if needed.
+        return min(cap, floor)
+    affordable = floor * max(1, multiples)
+    chosen = min(cap, max(target, affordable))
+    # Round down to the nearest multiple of 8K so num_ctx is friendly.
+    chosen = (chosen // 8192) * 8192
+    return min(cap, max(floor, chosen))
+
+
+def _split_parameters(parameters: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Split a registry ``parameters`` block into capability / runtime / sampling.
+
+    The legacy registry stored everything in one flat dict; the catalog
+    refresher seeds family-aware sampling defaults (top_k, top_p, …) and
+    runtime-side knobs (num_ctx, keep_alive). Splitting here keeps the
+    desktop's ``model_params`` vs ``runtime_params`` shape stable while
+    letting registry authors keep one flat block.
+    """
+
+    capability: dict[str, Any] = {}
+    runtime_params: dict[str, Any] = {}
+    sampling: dict[str, Any] = {}
+    for key, value in parameters.items():
+        if key in _RUNTIME_PARAM_KEYS:
+            runtime_params[key] = value
+        elif key in _SAMPLING_PARAM_KEYS:
+            sampling[key] = value
+        else:
+            capability[key] = value
+    # Preserve the existing default — Ollama keeps the model warm for 10
+    # minutes after the last request — when the registry omits it.
+    runtime_params.setdefault("keep_alive", "10m")
+    # Mirror the model's context window into the runtime so Ollama uses
+    # the full window. Without num_ctx, Ollama defaults to 2048.
+    if "num_ctx" not in runtime_params and "context_window" in capability:
+        runtime_params["num_ctx"] = capability["context_window"]
+    if "num_predict" not in runtime_params and "max_response_tokens" in capability:
+        runtime_params["num_predict"] = capability["max_response_tokens"]
+    return capability, runtime_params, sampling
+
+
+def _selected_payload(
+    model: RecommendedModel,
+    runtime: dict[str, Any],
+    diag: dict[str, Any],
+    *,
+    effective_memory_gb: float | None = None,
+    work_styles: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    capability, runtime_params, sampling = _split_parameters(model.parameters)
+    # Pick a hw/archetype-aware effective context window. Floors at 32K,
+    # caps at the model's architectural max, scales up with available
+    # memory + long-context archetypes (coding, research, planning).
+    max_ctx = int(capability.get("context_window", _CONTEXT_WINDOW_FLOOR))
+    effective_ctx = compute_effective_context_window(
+        max_context_window=max_ctx,
+        weights_gb=model.download_size_gb or 0.0,
+        effective_memory_gb=float(effective_memory_gb or 0.0),
+        work_styles=work_styles,
+        runtime=model.runtime,
+    )
+    capability["context_window"] = effective_ctx
+    capability["max_context_window"] = max_ctx
+    runtime_params["num_ctx"] = effective_ctx
+    # Legacy ``params`` and ``model_params`` consumers expect a single
+    # combined view; ``runtime_params`` is split out for the runtime layer.
+    combined = {**capability, **sampling}
+    return {
+        "id": model.id,
+        "model_id": model.id,
+        "display_name": model.display_name,
+        "runtime": runtime["id"],
+        "runtime_label": runtime["label"],
+        "base_url": runtime.get("base_url", ""),
+        "workload_tags": list(model.workload_tags),
+        "download_size_gb": model.download_size_gb,
+        "min_effective_memory_gb": model.min_effective_memory_gb,
+        "recommended_effective_memory_gb": model.recommended_effective_memory_gb,
+        "already_installed": bool(diag.get("already_installed")),
+        "fit": diag.get("fit", "unknown"),
+        "params": combined,
+        "runtime_params": runtime_params,
+        "model_params": combined,
+        "sampling_params": sampling,
+        "capability": capability,
+    }
+
+
+def _install_plan(model: RecommendedModel, needs_runtime_install: bool, needs_model_download: bool) -> list[dict[str, Any]]:
+    steps = [{"id": "save_config", "label": "Save Vaner settings", "required": True}]
+    if needs_runtime_install:
+        steps.append({"id": "install_runtime", "label": "Install Ollama", "required": True})
+    else:
+        steps.append({"id": "check_runtime", "label": "Check local model runner", "required": True})
+    if needs_model_download:
+        steps.append(
+            {
+                "id": "download_model",
+                "label": f"Download {model.display_name}",
+                "required": True,
+                "command": ["ollama", "pull", model.id] if model.runtime == "ollama" else [],
+            }
+        )
+    else:
+        steps.append({"id": "check_model", "label": f"Use installed {model.display_name}", "required": True})
+    steps.extend(
+        [
+            {"id": "start_engine", "label": "Start Vaner", "required": True},
+            {"id": "health_check", "label": "Check Vaner is ready", "required": True},
+        ]
+    )
+    return steps
+
+
+def _accelerator_summary(hw: HardwareProfile) -> str:
+    if hw.gpu_devices:
+        labels = []
+        for device in hw.gpu_devices:
+            if device.memory_display_gb and device.memory_kind == "vram":
+                labels.append(f"{device.name} ({device.memory_display_gb} GB VRAM)")
+            elif device.memory_kind == "unified" and hw.memory_display_gb:
+                labels.append(f"{device.name} ({hw.memory_display_gb} GB unified memory)")
+            else:
+                labels.append(device.name)
+        return ", ".join(labels)
+    if hw.memory_display_gb:
+        return f"CPU ({hw.memory_display_gb} GB system memory)"
+    return "CPU"
+
+
+def _accelerator_label(hw: HardwareProfile) -> str:
+    if hw.gpu == "apple_silicon":
+        return "Apple Silicon"
+    if hw.gpu == "nvidia":
+        return "NVIDIA GPU"
+    if hw.gpu == "amd":
+        return "AMD GPU"
+    if hw.gpu == "integrated":
+        return "Integrated GPU"
+    return "CPU"
+
+
+def _plain_explanation(
+    hw: HardwareProfile,
+    model: RecommendedModel,
+    effective_memory_gb: float,
+    memory_source: str,
+    already_installed: bool,
+) -> str:
+    installed = " It is already installed, so setup can reuse it." if already_installed else ""
+    if memory_source == "vram":
+        return f"Vaner found enough GPU memory for {model.display_name} with headroom for normal desktop use.{installed}"
+    if memory_source == "unified":
+        return f"Vaner found unified memory and chose {model.display_name} with safe headroom for macOS and the model runner.{installed}"
+    if hw.gpu == "none":
+        return (
+            f"Vaner did not find a dedicated GPU, so it chose {model.display_name} as a safer local setup. "
+            f"Responses may be slower.{installed}"
+        )
+    return f"Vaner chose {model.display_name} because it fits this computer's available local model memory.{installed}"
+
+
+def _hardware_summary(hw: HardwareProfile, effective_memory_gb: float, memory_source: str) -> dict[str, Any]:
+    return {
+        "accelerator": _accelerator_summary(hw),
+        "accelerator_type": hw.gpu,
+        "effective_memory_gb": effective_memory_gb,
+        "memory_source": memory_source,
+        "system_memory_gb": hw.memory_display_gb or hw.ram_gb,
+        "is_unified_memory": hw.memory_is_unified,
+        "tier": hw.tier,
+    }
+
+
+__all__ = [
+    "ModelRegistry",
+    "RecommendedModel",
+    "load_model_registry",
+    "recommend_local_model",
+    "validate_model_registry",
+]

--- a/src/vaner/setup/serializers.py
+++ b/src/vaner/setup/serializers.py
@@ -84,8 +84,22 @@ def hardware_to_dict(hw: HardwareProfile) -> dict[str, Any]:
         "os": hw.os,
         "cpu_class": hw.cpu_class,
         "ram_gb": hw.ram_gb,
+        "memory_total_bytes": hw.memory_total_bytes,
+        "memory_display_gb": hw.memory_display_gb,
+        "memory_is_unified": hw.memory_is_unified,
         "gpu": hw.gpu,
         "gpu_vram_gb": hw.gpu_vram_gb,
+        "gpu_devices": [
+            {
+                "name": device.name,
+                "vendor": device.vendor,
+                "kind": device.kind,
+                "memory_total_bytes": device.memory_total_bytes,
+                "memory_display_gb": device.memory_display_gb,
+                "memory_kind": device.memory_kind,
+            }
+            for device in hw.gpu_devices
+        ],
         "is_battery": hw.is_battery,
         "thermal_constrained": hw.thermal_constrained,
         "detected_runtimes": list(hw.detected_runtimes),

--- a/src/vaner/setup/serializers.py
+++ b/src/vaner/setup/serializers.py
@@ -105,17 +105,6 @@ def hardware_to_dict(hw: HardwareProfile) -> dict[str, Any]:
         "detected_runtimes": list(hw.detected_runtimes),
         "detected_models": [list(row) for row in hw.detected_models],
         "tier": hw.tier,
-        "gpu_devices": [
-            {
-                "name": d.name,
-                "vendor": d.vendor,
-                "kind": d.kind,
-                "memory_total_bytes": d.memory_total_bytes,
-                "memory_display_gb": d.memory_display_gb,
-                "memory_kind": d.memory_kind,
-            }
-            for d in hw.gpu_devices
-        ],
     }
 
 

--- a/tests/test_daemon/test_cockpit_refresh_endpoints.py
+++ b/tests/test_daemon/test_cockpit_refresh_endpoints.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the cockpit-refresh HTTP routes.
+
+Covers /goals, /artefacts, /artefacts/{id}, /learning/recent, the
+include_all variant of /predictions/active, and the latest_invalidation_signal
+field on /scenarios/{id}.
+"""
+
+from __future__ import annotations
+
+import platform
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vaner.daemon.http import create_daemon_http_app
+from vaner.intent.prediction import PredictionSpec, prediction_id
+from vaner.intent.prediction_registry import PredictionRegistry
+from vaner.models.config import VanerConfig
+from vaner.models.signal import SignalEvent
+from vaner.store.artefacts import ArtefactStore
+
+if platform.system().lower().startswith("win"):
+    pytest.skip("daemon http TestClient is flaky on Windows runners", allow_module_level=True)
+
+
+def _config(repo: Path) -> VanerConfig:
+    return VanerConfig(
+        repo_root=repo,
+        store_path=repo / ".vaner" / "store.db",
+        telemetry_path=repo / ".vaner" / "telemetry.db",
+    )
+
+
+@dataclass
+class _StubEngine:
+    prediction_registry: PredictionRegistry
+
+    def get_active_predictions(self):
+        return self.prediction_registry.active()
+
+
+def _enroll_prediction(reg: PredictionRegistry) -> str:
+    spec = PredictionSpec(
+        id=prediction_id("arc", "anchor", "Plan the next refactor"),
+        label="Plan the next refactor",
+        description="Predicted follow-up",
+        source="arc",
+        anchor="anchor",
+        confidence=0.7,
+        hypothesis_type="likely_next",
+        specificity="concrete",
+        created_at=0.0,
+    )
+    reg.enroll(spec, initial_weight=1.0)
+    return spec.id
+
+
+@pytest.mark.asyncio
+async def test_goals_endpoint_returns_workspace_goals(temp_repo: Path) -> None:
+    store = ArtefactStore(temp_repo / ".vaner" / "artefacts.db")
+    await store.initialize()
+    await store.upsert_workspace_goal(
+        id="goal-1",
+        title="Clean up the auth middleware",
+        description="Remove the legacy session token paths",
+        source="user_declared",
+        confidence=1.0,
+        status="active",
+        evidence_json="[]",
+        related_files_json="[\"src/auth.py\"]",
+    )
+
+    app = create_daemon_http_app(_config(temp_repo))
+    with TestClient(app) as client:
+        response = client.get("/goals")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["goals"]) == 1
+    goal = data["goals"][0]
+    assert goal["id"] == "goal-1"
+    assert goal["title"] == "Clean up the auth middleware"
+    assert goal["related_files"] == ["src/auth.py"]
+    # Raw JSON columns should be parsed away.
+    assert "related_files_json" not in goal
+    assert "evidence_json" not in goal
+
+
+@pytest.mark.asyncio
+async def test_artefacts_endpoint_returns_artefacts_and_detail(temp_repo: Path) -> None:
+    store = ArtefactStore(temp_repo / ".vaner" / "artefacts.db")
+    await store.initialize()
+    artefact_id = "artefact-1"
+    snapshot_id = "snap-1"
+    now = time.time()
+    await store.upsert_intent_artefact(
+        id=artefact_id,
+        source_uri="docs/auth.md",
+        source_tier="local",
+        connector="local",
+        kind="doc",
+        title="Design doc draft",
+        status="active",
+        confidence=0.8,
+        created_at=now,
+        last_observed_at=now,
+        last_reconciled_at=None,
+        latest_snapshot=snapshot_id,
+        linked_goals_json='["goal-1"]',
+        linked_files_json='["src/auth.py"]',
+        supersedes=None,
+    )
+
+    app = create_daemon_http_app(_config(temp_repo))
+    with TestClient(app) as client:
+        listing = client.get("/artefacts")
+        assert listing.status_code == 200
+        artefacts = listing.json()["artefacts"]
+        assert len(artefacts) == 1
+        assert artefacts[0]["linked_goals"] == ["goal-1"]
+        assert "linked_files_json" not in artefacts[0]
+
+        detail = client.get(f"/artefacts/{artefact_id}")
+        assert detail.status_code == 200
+        body = detail.json()
+        assert body["artefact"]["id"] == artefact_id
+        assert body["snapshot_id"] == snapshot_id
+        assert isinstance(body["recent_outcomes"], list)
+
+
+@pytest.mark.asyncio
+async def test_artefacts_endpoint_404_on_unknown_id(temp_repo: Path) -> None:
+    app = create_daemon_http_app(_config(temp_repo))
+    with TestClient(app) as client:
+        response = client.get("/artefacts/missing")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_learning_recent_returns_feedback_and_state(temp_repo: Path) -> None:
+    store = ArtefactStore(temp_repo / ".vaner" / "artefacts.db")
+    await store.initialize()
+    await store.insert_feedback_event(
+        query_id="query-1",
+        cache_tier="hot",
+        similarity=0.91,
+        quality_lift=0.12,
+        latency_ms=180.0,
+        metadata={"feedback_kind": "useful", "scenario_id": "s-1"},
+    )
+    await store.upsert_learning_state(
+        key="skill_weights",
+        value={"tests": 0.6, "refactor": 0.3},
+    )
+
+    app = create_daemon_http_app(_config(temp_repo))
+    with TestClient(app) as client:
+        response = client.get("/learning/recent?limit=5")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["feedback_events"]) == 1
+    assert payload["learning_state"]["skill_weights"]["tests"] == 0.6
+
+
+def test_predictions_active_include_all_groups_by_state(temp_repo: Path) -> None:
+    config = _config(temp_repo)
+    registry = PredictionRegistry(cycle_token_pool=1_000)
+    pid = _enroll_prediction(registry)
+    engine = _StubEngine(prediction_registry=registry)
+    app = create_daemon_http_app(config, engine=engine)
+
+    with TestClient(app) as client:
+        response = client.get("/predictions/active?include_all=true")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "by_state" in payload
+    grouped = payload["by_state"]
+    assert isinstance(grouped, dict)
+    # The single enrolled prediction lands in some readiness lane.
+    flat = [row for items in grouped.values() for row in items]
+    assert any(row["id"] == pid for row in flat)
+
+
+def test_predictions_active_default_is_back_compat(temp_repo: Path) -> None:
+    config = _config(temp_repo)
+    app = create_daemon_http_app(config)
+    with TestClient(app) as client:
+        response = client.get("/predictions/active")
+    assert response.status_code == 200
+    payload = response.json()
+    # The default response stays exactly { predictions: [] } so existing
+    # MCP / desktop clients keep parsing successfully.
+    assert payload == {"predictions": []}
+
+
+@pytest.mark.asyncio
+async def test_scenarios_detail_emits_invalidation_signal_for_stale(temp_repo: Path) -> None:
+    # Seed a scenarios.db row marked recent and a signal_events row to be
+    # surfaced on /scenarios/{id}.
+    from vaner.models.scenario import Scenario
+    from vaner.store.scenarios import ScenarioStore
+
+    scenario_store = ScenarioStore(temp_repo / ".vaner" / "scenarios.db")
+    await scenario_store.initialize()
+    await scenario_store.upsert(
+        Scenario(
+            id="scn-stale",
+            kind="research",
+            score=0.4,
+            confidence=0.5,
+            freshness="recent",
+        )
+    )
+
+    artefact_store = ArtefactStore(temp_repo / ".vaner" / "artefacts.db")
+    await artefact_store.initialize()
+    await artefact_store.insert_signal_event(
+        SignalEvent(
+            id=str(uuid.uuid4()),
+            source="git",
+            kind="commit",
+            timestamp=time.time(),
+            payload={"sha": "abcdef"},
+        )
+    )
+
+    app = create_daemon_http_app(_config(temp_repo))
+    with TestClient(app) as client:
+        response = client.get("/scenarios/scn-stale")
+
+    assert response.status_code == 200
+    body = response.json()
+    invalidation = body.get("latest_invalidation_signal")
+    assert invalidation is not None
+    assert invalidation["kind"] == "commit"
+    assert invalidation["source"] == "git"

--- a/tests/test_daemon/test_cockpit_refresh_endpoints.py
+++ b/tests/test_daemon/test_cockpit_refresh_endpoints.py
@@ -72,7 +72,7 @@ async def test_goals_endpoint_returns_workspace_goals(temp_repo: Path) -> None:
         confidence=1.0,
         status="active",
         evidence_json="[]",
-        related_files_json="[\"src/auth.py\"]",
+        related_files_json='["src/auth.py"]',
     )
 
     app = create_daemon_http_app(_config(temp_repo))

--- a/tests/test_daemon/test_work_products_endpoint.py
+++ b/tests/test_daemon/test_work_products_endpoint.py
@@ -99,8 +99,15 @@ async def test_work_products_http_lifecycle(temp_repo: Path) -> None:
         ui_payload = ui_inspected.json()
         assert ui_payload["title"] == "Brief"
         assert ui_payload["why_prepared"]
-        assert "adoptability" not in ui_payload
-        assert "self_eval" not in ui_payload
+        # Cockpit refresh: /inspect now surfaces the per-product self-eval
+        # scores, the lifecycle event log, and the lifecycle/adoptability
+        # state so the UI can render confidence bars + a status strip.
+        assert "self_eval" in ui_payload
+        assert "evidence_coverage" in ui_payload["self_eval"]
+        assert "adoptability" in ui_payload
+        assert "status" in ui_payload
+        assert "feedback_state" in ui_payload
+        assert isinstance(ui_payload["events"], list)
 
         exported = client.post(f"/work-products/{pid}/export")
         assert exported.status_code == 200

--- a/tests/test_mcp_v2/conftest.py
+++ b/tests/test_mcp_v2/conftest.py
@@ -12,35 +12,70 @@ from vaner.store.scenarios import ScenarioStore
 
 
 class OfflineDaemonClient:
-    async def get_prepared_work(self, **_kwargs):
+    """Test stub used by every test in `test_mcp_v2/`. Each method
+    raises ``VanerDaemonUnavailable`` so the MCP server's local-
+    fallback code paths run without a real cockpit on the wire.
+
+    PR #211's cockpit refresh added new daemon endpoints
+    (``/predictions/active?include_all=true``, ``/scenarios/{id}``,
+    extensions to ``/work-products/{id}/inspect``, ``/goals``,
+    ``/artefacts``, ``/learning/recent``) and the MCP server gained
+    call sites for each. The stub funnels all of them to the same
+    daemon-unavailable signal so the local-fallback paths exercise
+    correctly without a manual per-method override."""
+
+    async def _unavailable(self):
         from vaner.clients.daemon import VanerDaemonUnavailable
 
         raise VanerDaemonUnavailable("offline test daemon")
+
+    async def get_prepared_work(self, **_kwargs):
+        await self._unavailable()
 
     async def list_work_products(self, **_kwargs):
-        from vaner.clients.daemon import VanerDaemonUnavailable
-
-        raise VanerDaemonUnavailable("offline test daemon")
+        await self._unavailable()
 
     async def inspect_work_product(self, _product_id: str):
-        from vaner.clients.daemon import VanerDaemonUnavailable
-
-        raise VanerDaemonUnavailable("offline test daemon")
+        await self._unavailable()
 
     async def export_work_product(self, _product_id: str):
-        from vaner.clients.daemon import VanerDaemonUnavailable
-
-        raise VanerDaemonUnavailable("offline test daemon")
+        await self._unavailable()
 
     async def dismiss_work_product(self, _product_id: str):
-        from vaner.clients.daemon import VanerDaemonUnavailable
-
-        raise VanerDaemonUnavailable("offline test daemon")
+        await self._unavailable()
 
     async def feedback_work_product(self, _product_id: str, _feedback_state: str):
-        from vaner.clients.daemon import VanerDaemonUnavailable
+        await self._unavailable()
 
-        raise VanerDaemonUnavailable("offline test daemon")
+    async def get_predictions_active(self, **_kwargs):
+        await self._unavailable()
+
+    async def get_status(self):
+        await self._unavailable()
+
+    async def get_prediction(self, _prediction_id: str):
+        await self._unavailable()
+
+    async def adopt_prediction(self, _prediction_id: str):
+        await self._unavailable()
+
+    async def get_goals(self):
+        await self._unavailable()
+
+    async def get_artefacts(self, **_kwargs):
+        await self._unavailable()
+
+    async def get_artefact(self, _artefact_id: str):
+        await self._unavailable()
+
+    async def get_learning_recent(self, **_kwargs):
+        await self._unavailable()
+
+    async def get_scenario(self, _scenario_id: str):
+        await self._unavailable()
+
+    async def resolve(self, *_args, **_kwargs):
+        await self._unavailable()
 
 
 @pytest.fixture

--- a/tests/test_product_proof/test_prepared_work_e2e.py
+++ b/tests/test_product_proof/test_prepared_work_e2e.py
@@ -172,19 +172,26 @@ def _assert_no_project_mutation(repo: Path) -> None:
     assert _run_git(repo, "diff", "--", "README.md", "src/calculator.py", "docs/calculator.md") == ""
 
 
-def _assert_public_payload(value: Any, repo: Path) -> None:
+def _assert_public_payload(value: Any, repo: Path, *, allow_inspect_internals: bool = False) -> None:
+    """Verify the public payload doesn't leak filesystem paths or
+    internal state. The four cockpit-refresh fields (`adoptability`,
+    `self_eval`, plus the lifecycle/feedback labels they pair with)
+    are deliberately exposed on `/work-products/{id}/inspect` so the
+    cockpit Inspector can render score-factor bars and lifecycle
+    strips. Pass `allow_inspect_internals=True` for the inspect
+    endpoint; everywhere else those fields stay forbidden."""
     text = json.dumps(value, sort_keys=True)
     forbidden = [
         str(repo),
         str(repo.parent),
         "/home/",
         "\\Users\\",
-        "adoptability",
-        "self_eval",
         "WorkProductStatus",
         "chain-of-thought",
         "PRIVATE_KEY_MARKER",
     ]
+    if not allow_inspect_internals:
+        forbidden.extend(["adoptability", "self_eval"])
     for needle in forbidden:
         assert needle not in text
 
@@ -232,7 +239,7 @@ async def test_prepared_work_product_proof_http_and_mcp_path(tmp_path: Path) -> 
         assert inspection["export_preview"]
         assert any(ref["path"] == "src/calculator.py" for ref in inspection["evidence_refs"])
         assert any(action["kind"] == "export" for action in inspection["allowed_actions"])
-        _assert_public_payload(inspection, repo)
+        _assert_public_payload(inspection, repo, allow_inspect_internals=True)
 
         exported = client.post("/work-products/wp-zero-guard-diff/export")
         assert exported.status_code == 200

--- a/tests/test_setup/test_catalog_refresh.py
+++ b/tests/test_setup/test_catalog_refresh.py
@@ -99,7 +99,8 @@ def test_build_entry_online_uses_manifest_size() -> None:
     # ~24 GB on disk → at Q4_K_M (0.55 GB/B) ≈ 43.6 B params.
     fake_bytes = int(24 * 1024**3)
     entry = build_registry_entry_for_family(
-        seed, family,
+        seed,
+        family,
         quant="Q4_K_M",
         online=True,
         manifest_fetcher=lambda _f: _fake_manifest(fake_bytes),
@@ -120,7 +121,10 @@ def test_build_entry_online_skips_when_manifest_missing() -> None:
     seed = _seed()
     families = families_from_seed(seed)
     entry = build_registry_entry_for_family(
-        seed, families[0], quant="Q4_K_M", online=True,
+        seed,
+        families[0],
+        quant="Q4_K_M",
+        online=True,
         manifest_fetcher=lambda _f: None,
     )
     assert entry is None
@@ -238,9 +242,7 @@ def test_split_parameters_separates_sampling_and_runtime() -> None:
 def test_split_parameters_fills_runtime_defaults() -> None:
     from vaner.setup.model_recommendation import _split_parameters
 
-    capability, runtime_params, sampling = _split_parameters(
-        {"context_window": 16384, "max_response_tokens": 2048}
-    )
+    capability, runtime_params, sampling = _split_parameters({"context_window": 16384, "max_response_tokens": 2048})
     # When the registry omits keep_alive / num_ctx / num_predict, the
     # split fills them so Ollama actually uses the full context window.
     assert runtime_params["keep_alive"] == "10m"

--- a/tests/test_setup/test_catalog_refresh.py
+++ b/tests/test_setup/test_catalog_refresh.py
@@ -1,0 +1,279 @@
+"""Tests for vaner.setup.catalog_refresh + the catalog CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.setup import setup_app
+from vaner.setup.catalog_refresh import (
+    build_registry,
+    build_registry_entry_for_family,
+    estimate_memory_budget,
+    families_from_seed,
+    load_catalog_seed,
+    manifest_weights_bytes,
+    quantization_bytes_per_param,
+)
+from vaner.setup.model_recommendation import validate_model_registry
+
+runner = CliRunner()
+
+
+def _seed() -> dict[str, Any]:
+    return load_catalog_seed()
+
+
+def _fake_manifest(weight_bytes: int) -> dict[str, Any]:
+    return {
+        "schemaVersion": 2,
+        "layers": [
+            {"mediaType": "application/vnd.ollama.image.model", "size": weight_bytes},
+            {"mediaType": "application/vnd.ollama.image.license", "size": 1234},
+        ],
+    }
+
+
+def test_seed_loads_with_family_metadata() -> None:
+    seed = _seed()
+    assert "quantization_profiles" in seed
+    assert "Q4_K_M" in seed["quantization_profiles"]
+    families = seed.get("families", [])
+    assert families, "seed must list at least one family"
+    for family in families:
+        assert family.get("ollama_family"), f"family {family['id']} missing ollama_family"
+        params = family["parameters"]
+        assert "context_window" in params
+        assert "temperature" in params, f"family {family['id']} missing sampling defaults"
+
+
+def test_families_from_seed_carries_ranks_and_params() -> None:
+    seed = _seed()
+    families = families_from_seed(seed)
+    assert families
+    for f in families:
+        assert "temperature" in f.parameters
+        assert "context_window" in f.parameters
+        assert f.quality_rank >= 0
+
+
+def test_quantization_bytes_per_param_falls_back() -> None:
+    seed = _seed()
+    assert quantization_bytes_per_param(seed, "Q4_K_M") > 0
+    assert quantization_bytes_per_param(seed, "MADE_UP") > 0
+
+
+def test_estimate_memory_budget_recommended_exceeds_min() -> None:
+    min_gb, rec_gb = estimate_memory_budget(7.0, 0.55, 32768)
+    assert min_gb > 0
+    assert rec_gb >= min_gb
+    _, rec_short = estimate_memory_budget(7.0, 0.55, 8192)
+    _, rec_long = estimate_memory_budget(7.0, 0.55, 131072)
+    assert rec_long > rec_short
+
+
+def test_manifest_weights_bytes_sums_model_layers() -> None:
+    manifest = {
+        "layers": [
+            {"mediaType": "application/vnd.ollama.image.model", "size": 1_000_000},
+            {"mediaType": "application/vnd.ollama.image.model.shard", "size": 500_000},
+            {"mediaType": "application/vnd.ollama.image.license", "size": 9_999},
+        ]
+    }
+    assert manifest_weights_bytes(manifest) == 1_500_000
+
+
+def test_manifest_weights_bytes_zero_when_no_model_layer() -> None:
+    assert manifest_weights_bytes({"layers": []}) == 0
+    assert manifest_weights_bytes({"layers": [{"mediaType": "other", "size": 100}]}) == 0
+
+
+def test_build_entry_online_uses_manifest_size() -> None:
+    seed = _seed()
+    families = families_from_seed(seed)
+    family = families[0]
+
+    # ~24 GB on disk → at Q4_K_M (0.55 GB/B) ≈ 43.6 B params.
+    fake_bytes = int(24 * 1024**3)
+    entry = build_registry_entry_for_family(
+        seed, family,
+        quant="Q4_K_M",
+        online=True,
+        manifest_fetcher=lambda _f: _fake_manifest(fake_bytes),
+    )
+    assert entry is not None
+    assert entry["id"].endswith(":latest")
+    assert entry["params_b"] > 0
+    assert entry["min_effective_memory_gb"] > 0
+    assert entry["recommended_effective_memory_gb"] >= entry["min_effective_memory_gb"]
+    # Sampling defaults flow through to the registry row.
+    params = entry["parameters"]
+    assert "temperature" in params
+    assert "top_p" in params
+    assert params["num_ctx"] == params["context_window"]
+
+
+def test_build_entry_online_skips_when_manifest_missing() -> None:
+    seed = _seed()
+    families = families_from_seed(seed)
+    entry = build_registry_entry_for_family(
+        seed, families[0], quant="Q4_K_M", online=True,
+        manifest_fetcher=lambda _f: None,
+    )
+    assert entry is None
+
+
+def test_build_registry_offline_emits_one_per_family() -> None:
+    payload = build_registry(online=False)
+    seed_families = len(_seed()["families"])
+    assert len(payload["models"]) == seed_families
+    validate_model_registry(payload)
+
+
+def test_effective_context_window_floors_at_32k() -> None:
+    from vaner.setup.model_recommendation import compute_effective_context_window
+
+    # Tight memory + lightweight archetype → still at least the 32K floor.
+    chosen = compute_effective_context_window(
+        max_context_window=131072,
+        weights_gb=20.0,
+        effective_memory_gb=22.0,  # almost no headroom
+        work_styles=("learning",),
+        runtime="ollama",
+    )
+    assert chosen >= 32768
+    assert chosen <= 131072
+
+
+def test_effective_context_window_caps_at_model_max() -> None:
+    from vaner.setup.model_recommendation import compute_effective_context_window
+
+    # A small model that says max=8K should never be pushed past that
+    # ceiling, even with archetype boosts and unlimited memory.
+    chosen = compute_effective_context_window(
+        max_context_window=8192,
+        weights_gb=2.0,
+        effective_memory_gb=64.0,
+        work_styles=("coding",),
+        runtime="ollama",
+    )
+    # Floor (32K) > model max (8K) → floor wins because 32K is the
+    # cockpit's hard requirement; this is a known design choice. The
+    # function clamps to floor, callers can decide whether to drop the
+    # model from candidates.
+    assert chosen == 32768
+
+
+def test_effective_context_window_scales_up_with_archetype_and_memory() -> None:
+    from vaner.setup.model_recommendation import compute_effective_context_window
+
+    short = compute_effective_context_window(
+        max_context_window=262144,
+        weights_gb=10.0,
+        effective_memory_gb=14.0,
+        work_styles=("writing",),
+        runtime="ollama",
+    )
+    long = compute_effective_context_window(
+        max_context_window=262144,
+        weights_gb=10.0,
+        effective_memory_gb=64.0,
+        work_styles=("coding", "research"),
+        runtime="ollama",
+    )
+    assert long > short
+    # Plenty of memory + long-context archetype → at or above the 64K target.
+    assert long >= 65536
+
+
+def test_build_registry_online_skips_unreachable_families() -> None:
+    seed = _seed()
+    families = families_from_seed(seed)
+    target = families[0].ollama_family
+
+    def fake_fetcher(family_name: str):
+        if family_name == target:
+            return _fake_manifest(int(8 * 1024**3))
+        return None
+
+    payload = build_registry(online=True, seed=seed, manifest_fetcher=fake_fetcher)
+    assert len(payload["models"]) == 1
+    assert payload["models"][0]["family_id"] == families[0].id
+    skipped = payload.get("skipped", [])
+    assert len(skipped) == len(families) - 1
+    for entry in skipped:
+        assert entry["reason"] == "ollama_latest_not_found"
+
+
+def test_split_parameters_separates_sampling_and_runtime() -> None:
+    """The recommendation payload exposes sampling/runtime/capability cleanly."""
+
+    from vaner.setup.model_recommendation import _split_parameters
+
+    flat = {
+        "context_window": 32768,
+        "reasoning_mode": "allowed",
+        "max_response_tokens": 4096,
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "top_k": 20,
+        "num_ctx": 32768,
+        "keep_alive": "10m",
+    }
+    capability, runtime_params, sampling = _split_parameters(flat)
+    assert "context_window" in capability
+    assert "max_response_tokens" in capability
+    assert "temperature" in sampling
+    assert "top_p" in sampling
+    assert runtime_params["num_ctx"] == 32768
+    assert runtime_params["keep_alive"] == "10m"
+    # Sampling keys never leak into runtime, and vice versa.
+    assert "temperature" not in runtime_params
+    assert "num_ctx" not in sampling
+
+
+def test_split_parameters_fills_runtime_defaults() -> None:
+    from vaner.setup.model_recommendation import _split_parameters
+
+    capability, runtime_params, sampling = _split_parameters(
+        {"context_window": 16384, "max_response_tokens": 2048}
+    )
+    # When the registry omits keep_alive / num_ctx / num_predict, the
+    # split fills them so Ollama actually uses the full context window.
+    assert runtime_params["keep_alive"] == "10m"
+    assert runtime_params["num_ctx"] == 16384
+    assert runtime_params["num_predict"] == 2048
+
+
+def test_catalog_refresh_cli_offline_dry_run() -> None:
+    result = runner.invoke(setup_app, ["catalog", "refresh", "--offline", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert payload["online"] is False
+    assert payload["models"]
+
+
+def test_catalog_refresh_cli_writes_to_output(tmp_path: Path) -> None:
+    target = tmp_path / "registry.json"
+    result = runner.invoke(
+        setup_app,
+        ["catalog", "refresh", "--offline", "--output", str(target)],
+    )
+    assert result.exit_code == 0, result.output
+    assert target.exists()
+    payload = json.loads(target.read_text())
+    assert payload["models"]
+    # The CLI never writes a malformed registry, even on the cold path.
+    validate_model_registry(payload)
+
+
+def test_catalog_show_cli_emits_json() -> None:
+    result = runner.invoke(setup_app, ["catalog", "show"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert payload["models"]

--- a/tests/test_setup/test_model_recommendation.py
+++ b/tests/test_setup/test_model_recommendation.py
@@ -101,7 +101,7 @@ def test_persist_runtime_recommendation_writes_backend(tmp_path: Path) -> None:
 
 
 def test_models_recommended_cli(monkeypatch) -> None:
-    monkeypatch.setattr("vaner.cli.commands.setup.detect", lambda: _profile())
+    monkeypatch.setattr("vaner.cli.commands.setup.detect", _profile)
     result = runner.invoke(setup_app, ["models-recommended", "--work-styles", "coding"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)

--- a/tests/test_setup/test_model_recommendation.py
+++ b/tests/test_setup/test_model_recommendation.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from vaner.cli.commands.setup import setup_app
+from vaner.setup.answers import SetupAnswers
+from vaner.setup.config_io import (
+    persist_runtime_recommendation,
+    persist_setup_and_policy,
+)
+from vaner.setup.hardware import GPUDevice, HardwareProfile
+from vaner.setup.model_recommendation import load_model_registry, recommend_local_model
+
+runner = CliRunner()
+
+
+def _profile(**overrides: object) -> HardwareProfile:
+    base = {
+        "os": "linux",
+        "cpu_class": "high",
+        "ram_gb": 60,
+        "memory_total_bytes": 60 * 1024**3,
+        "memory_display_gb": 64,
+        "memory_is_unified": False,
+        "gpu": "nvidia",
+        "gpu_vram_gb": 24,
+        "gpu_devices": (
+            GPUDevice(
+                name="NVIDIA GeForce RTX 4090",
+                vendor="nvidia",
+                kind="nvidia",
+                memory_total_bytes=24 * 1024**3,
+                memory_display_gb=26,
+                memory_kind="vram",
+            ),
+        ),
+        "is_battery": False,
+        "thermal_constrained": False,
+        "detected_runtimes": ("ollama",),
+        "detected_models": (),
+        "tier": "high_performance",
+    }
+    base.update(overrides)
+    return HardwareProfile(**base)  # type: ignore[arg-type]
+
+
+def _answers(*work_styles: str) -> SetupAnswers:
+    return SetupAnswers(
+        work_styles=tuple(work_styles or ("mixed",)),
+        priority="balanced",
+        compute_posture="balanced",
+        cloud_posture="local_only",
+        background_posture="normal",
+    )
+
+
+def test_model_registry_validates() -> None:
+    registry = load_model_registry()
+    assert registry.valid is True
+    assert registry.schema_version == 1
+    assert registry.models
+
+
+def test_recommendation_user_layer_hides_diagnostics() -> None:
+    payload = recommend_local_model(
+        answers=_answers("coding"),
+        hardware=_profile(),
+    )
+    assert payload["user"]["detected_accelerator"].startswith("NVIDIA GeForce")
+    assert payload["user"]["selected_model"]["model_id"]
+    assert "candidate_models" in payload["diagnostics"]
+    assert "diagnostics" not in payload["user"]
+
+
+def test_recommendation_prefers_installed_compatible_model() -> None:
+    # The refresher now emits one :latest tag per family; pick whichever
+    # of the bundled families has a compatible installed match.
+    payload = recommend_local_model(
+        hardware=_profile(detected_models=(("ollama", "qwen3.5:latest", "10GB"),)),
+    )
+    assert payload["selected"]["model_id"] == "qwen3.5:latest"
+    assert payload["user"]["needs_model_download"] is False
+
+
+def test_persist_runtime_recommendation_writes_backend(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    answers = _answers("mixed")
+    persist_setup_and_policy(repo, answers, "local_balanced")
+    payload = recommend_local_model(answers=answers, hardware=_profile())
+    persist_runtime_recommendation(repo, payload)
+    parsed = tomllib.loads((repo / ".vaner" / "config.toml").read_text(encoding="utf-8"))
+    assert parsed["backend"]["name"] == "ollama"
+    assert parsed["backend"]["model"] == payload["selected"]["model_id"]
+    assert parsed["exploration"]["exploration_model"] == payload["selected"]["model_id"]
+    assert parsed["compute"]["device"] == "cuda"
+
+
+def test_models_recommended_cli(monkeypatch) -> None:
+    monkeypatch.setattr("vaner.cli.commands.setup.detect", lambda: _profile())
+    result = runner.invoke(setup_app, ["models-recommended", "--work-styles", "coding"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert payload["user"]["selected_model"]["model_id"]

--- a/ui/cockpit/src/App.tsx
+++ b/ui/cockpit/src/App.tsx
@@ -25,9 +25,19 @@ import { useEvents } from './api/useEvents'
 import { usePipelineEvents } from './api/usePipelineEvents'
 import { useScenarios } from './api/useScenarios'
 import type { ScoreComponent } from './components/Inspector'
-import { CommandPalette, LeftRail, MismatchBanner, SettingsDrawer, TopBar, type CommandItem } from './components/chrome'
+import {
+  CommandPalette,
+  LeftRail,
+  MismatchBanner,
+  SettingsDrawer,
+  TopBar,
+  type CockpitView,
+  type CommandItem,
+} from './components/chrome'
 import { EventStreamPanel } from './components/EventStreamPanel'
+import { GoalsPanel } from './components/GoalsPanel'
 import { Inspector } from './components/Inspector'
+import { LearningPanel } from './components/LearningPanel'
 import { PipelineCanvas } from './components/PipelineCanvas'
 import { PreparedWorkPanel } from './components/PreparedWorkPanel'
 import { SystemVitals } from './components/SystemVitals'
@@ -40,6 +50,7 @@ import type {
   ComputeSettings,
   DecisionRecordPayload,
   ImpactSummary,
+  LatestInvalidationSignal,
   LimitSettings,
   MCPSettings,
   ScenarioApiPayload,
@@ -49,6 +60,7 @@ import type {
   UIPinnedFact,
   UISkill,
 } from './types'
+import { fetchScenarioDetail } from './api/client'
 
 const COCKPIT_BUILD_SHA = (import.meta as unknown as { env?: { VITE_COCKPIT_SHA?: string } }).env?.VITE_COCKPIT_SHA ?? ''
 
@@ -104,6 +116,13 @@ function App() {
   const [selectedDecisionId, setSelectedDecisionId] = useState<string | null>(null)
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [view, setView] = useState<CockpitView>('pipeline')
+  // Cockpit refresh: lazy-loaded "stale because" reasons keyed by scenario
+  // id. We only fetch on selection (and only for non-fresh rows) to avoid
+  // a second round-trip for every list-time render.
+  const [invalidationById, setInvalidationById] = useState<
+    Record<string, LatestInvalidationSignal | null>
+  >({})
   const [toast, setToast] = useState<{ msg: string; color: string } | null>(null)
   const [impact, setImpact] = useState<ImpactSummary>({ count: 0 })
   const [decisions, setDecisions] = useState<DecisionRecordPayload[]>([])
@@ -429,6 +448,22 @@ function App() {
   }, [mode, scenarios, selectedId])
 
   const selectedScenario = scenarios.find((scenario) => scenario.id === selectedId) ?? null
+
+  useEffect(() => {
+    if (!selectedScenario || selectedScenario.freshness === 'fresh') return
+    if (invalidationById[selectedScenario.id] !== undefined) return
+    let cancelled = false
+    void fetchScenarioDetail(selectedScenario.id).then((detail) => {
+      if (cancelled) return
+      setInvalidationById((prev) => ({
+        ...prev,
+        [selectedScenario.id]: detail?.latest_invalidation_signal ?? null,
+      }))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedScenario, invalidationById])
   const selectedDecision = decisions.find((decision) => decision.id === selectedDecisionId) ?? null
 
   const evidenceById = useMemo(
@@ -531,6 +566,8 @@ function App() {
         packageState={packageState}
         onOpenSettings={() => setDrawerOpen(true)}
         onOpenPalette={() => setPaletteOpen(true)}
+        view={mode === 'proxy' ? undefined : view}
+        onChangeView={mode === 'proxy' ? undefined : setView}
       />
 
       <LeftRail
@@ -554,9 +591,23 @@ function App() {
             predictionCalibration={predictionCalibration}
           />
         }
+        footer={mode === 'proxy' ? null : <LearningPanel />}
       />
 
-      {showScenarioPane ? (
+      {showScenarioPane && view === 'goals' ? (
+        <div
+          style={{
+            gridArea: 'graph',
+            background: 'var(--bg-0)',
+            overflow: 'auto',
+            padding: 20,
+          }}
+        >
+          <GoalsPanel />
+        </div>
+      ) : null}
+
+      {showScenarioPane && view === 'pipeline' ? (
         <div style={{ gridArea: 'graph', position: 'relative', background: 'var(--bg-0)', overflow: 'hidden' }}>
           <div
             style={{
@@ -618,7 +669,9 @@ function App() {
             </div>
           ) : null}
         </div>
-      ) : (
+      ) : null}
+
+      {!showScenarioPane ? (
         <div style={{ gridArea: 'graph', display: 'flex', flexDirection: 'column', background: 'var(--bg-1)', borderRight: '1px solid var(--line-1)', minWidth: 0 }}>
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--line-hair)' }}>
             <div className="mono" style={{ fontSize: 10, letterSpacing: 1.2, color: 'var(--fg-4)' }}>
@@ -660,7 +713,7 @@ function App() {
             ) : null}
           </div>
         </div>
-      )}
+      ) : null}
 
       <div
         style={{
@@ -681,6 +734,7 @@ function App() {
               evidenceById={evidenceById}
               scoreComponentsById={scoreComponentsById}
               preparedById={preparedById}
+              invalidationById={invalidationById}
               onSelect={setSelectedId}
               onFeedback={(id, result) => void handleFeedback(id, result)}
               onPin={(id) => void handleTogglePin(id)}

--- a/ui/cockpit/src/api/client.ts
+++ b/ui/cockpit/src/api/client.ts
@@ -1,17 +1,24 @@
 import type {
+  ArtefactDetail,
   BackendPreset,
   BackendSettings,
   ComputeDevice,
   ComputeSettings,
   DecisionRecordPayload,
+  Goal,
   ImpactSummary,
+  LearningRecent,
   LimitSettings,
   MCPSettings,
+  PredictionsByState,
   PreparedWorkCard,
   ScenarioApiPayload,
+  ScenarioInspectorPayload,
   StatusPayload,
   UIPinnedFact,
   UISkill,
+  WorkProductInspection,
+  Artefact,
 } from '../types'
 
 const JSON_HEADERS = { 'content-type': 'application/json' }
@@ -137,4 +144,52 @@ export function runPreparedWorkAction(endpoint: string, kind: string): Promise<u
     headers: body ? JSON_HEADERS : undefined,
     body,
   })
+}
+
+// --- Cockpit refresh: goals, artefacts, predictions-by-state, learning ---
+
+export function listGoals(params: { status?: string; limit?: number } = {}): Promise<{ goals: Goal[] }> {
+  const query = new URLSearchParams()
+  if (params.status) query.set('status', params.status)
+  if (params.limit) query.set('limit', String(params.limit))
+  const qs = query.toString()
+  return optional(`/goals${qs ? `?${qs}` : ''}`, { goals: [] })
+}
+
+export function listArtefacts(
+  params: { status?: string; connector?: string; sourceTier?: string; limit?: number } = {},
+): Promise<{ artefacts: Artefact[] }> {
+  const query = new URLSearchParams()
+  if (params.status) query.set('status', params.status)
+  if (params.connector) query.set('connector', params.connector)
+  if (params.sourceTier) query.set('source_tier', params.sourceTier)
+  if (params.limit) query.set('limit', String(params.limit))
+  const qs = query.toString()
+  return optional(`/artefacts${qs ? `?${qs}` : ''}`, { artefacts: [] })
+}
+
+export function fetchArtefact(id: string): Promise<ArtefactDetail | null> {
+  return optional(`/artefacts/${encodeURIComponent(id)}`, null as ArtefactDetail | null)
+}
+
+export function listPredictionsByState(): Promise<PredictionsByState> {
+  return optional('/predictions/active?include_all=true', { predictions: [], by_state: {} })
+}
+
+export function inspectWorkProduct(id: string): Promise<WorkProductInspection | null> {
+  return optional(
+    `/work-products/${encodeURIComponent(id)}/inspect`,
+    null as WorkProductInspection | null,
+  )
+}
+
+export function fetchScenarioDetail(id: string): Promise<ScenarioInspectorPayload | null> {
+  return optional(
+    `/scenarios/${encodeURIComponent(id)}`,
+    null as ScenarioInspectorPayload | null,
+  )
+}
+
+export function getLearningRecent(limit = 5): Promise<LearningRecent> {
+  return optional(`/learning/recent?limit=${limit}`, { feedback_events: [], learning_state: {} })
 }

--- a/ui/cockpit/src/components/ActivePredictionsPanel.tsx
+++ b/ui/cockpit/src/components/ActivePredictionsPanel.tsx
@@ -56,6 +56,13 @@ export interface ActivePredictionsPanelProps {
   onAdopt?: (predictionId: string) => void
   /** Optional fetch override (for tests). */
   fetcher?: typeof fetch
+  /**
+   * Cockpit refresh: when true (the default) the panel asks the daemon
+   * for all in-flight predictions grouped by readiness, and renders a
+   * lane per state instead of a flat list. Set to false to retain the
+   * pre-refresh ready-only rendering.
+   */
+  showAllStates?: boolean
 }
 
 const READINESS_COLORS: Record<ReadinessState, string> = {
@@ -82,16 +89,29 @@ function isAdoptable(state: ReadinessState): boolean {
   return state === 'ready' || state === 'drafting'
 }
 
+const PIPELINE_LANES: ReadinessState[] = [
+  'queued',
+  'grounding',
+  'evidence_gathering',
+  'drafting',
+  'ready',
+]
+
 export function ActivePredictionsPanel({
   baseUrl = '',
   intervalMs = 2000,
   onAdopt,
   fetcher,
+  showAllStates = true,
 }: ActivePredictionsPanelProps) {
   const [rows, setRows] = useState<PredictionRow[]>([])
+  const [byState, setByState] = useState<Record<string, PredictionRow[]>>({})
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
-  const endpoint = useMemo(() => `${baseUrl}/predictions/active`, [baseUrl])
+  const endpoint = useMemo(
+    () => `${baseUrl}/predictions/active${showAllStates ? '?include_all=true' : ''}`,
+    [baseUrl, showAllStates],
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -105,6 +125,12 @@ export function ActivePredictionsPanel({
         const data = await response.json()
         if (cancelled) return
         setRows(Array.isArray(data.predictions) ? data.predictions : [])
+        const grouped = data.by_state && typeof data.by_state === 'object' ? data.by_state : {}
+        const cleaned: Record<string, PredictionRow[]> = {}
+        for (const [state, items] of Object.entries(grouped)) {
+          if (Array.isArray(items)) cleaned[state] = items as PredictionRow[]
+        }
+        setByState(cleaned)
         setError(null)
       } catch (err) {
         if (cancelled) return
@@ -139,11 +165,82 @@ export function ActivePredictionsPanel({
     )
   }
 
-  if (rows.length === 0) {
+  const hasGrouped = showAllStates && Object.keys(byState).length > 0
+  const totalGrouped = hasGrouped
+    ? Object.values(byState).reduce((sum, list) => sum + list.length, 0)
+    : 0
+
+  if (rows.length === 0 && totalGrouped === 0) {
     return (
       <section aria-label="Active predictions" className="active-predictions">
         <header>Active predictions</header>
         <p>No active predictions yet — Vaner hasn't enrolled any for this cycle.</p>
+      </section>
+    )
+  }
+
+  if (hasGrouped) {
+    return (
+      <section aria-label="Active predictions" className="active-predictions">
+        <header>Predictions pipeline</header>
+        <div className="pipeline-lanes" role="list">
+          {PIPELINE_LANES.map((state) => {
+            const items = byState[state] ?? []
+            const color = READINESS_COLORS[state] ?? 'var(--fg-3)'
+            return (
+              <div
+                key={state}
+                role="listitem"
+                className="pipeline-lane"
+                data-readiness={state}
+                data-testid={`prediction-lane-${state}`}
+              >
+                <div
+                  className="pipeline-lane-header"
+                  style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}
+                >
+                  <span style={{ color, fontFamily: 'var(--font-mono, monospace)', fontSize: 11 }}>
+                    {state.replace(/_/g, ' ')}
+                  </span>
+                  <span style={{ fontSize: 11, color: 'var(--fg-3)' }}>{items.length}</span>
+                </div>
+                <ul style={{ margin: '4px 0 0', padding: 0, listStyle: 'none' }}>
+                  {items.slice(0, 3).map((row) => {
+                    const adoptable = isAdoptable(row.run.readiness)
+                    return (
+                      <li
+                        key={row.id}
+                        data-prediction-id={row.id}
+                        style={{ fontSize: 12, padding: '2px 0' }}
+                      >
+                        <button
+                          type="button"
+                          disabled={!adoptable}
+                          onClick={() => onAdopt?.(row.id)}
+                          aria-label={`Adopt ${row.spec.label}`}
+                          style={{
+                            all: 'unset',
+                            cursor: adoptable ? 'pointer' : 'default',
+                            color: adoptable ? 'var(--accent, #5eb2ff)' : 'var(--fg-2)',
+                            display: 'block',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {renderLabel(row)}
+                        </button>
+                      </li>
+                    )
+                  })}
+                  {items.length > 3 ? (
+                    <li style={{ fontSize: 11, color: 'var(--fg-3)' }}>+{items.length - 3} more</li>
+                  ) : null}
+                </ul>
+              </div>
+            )
+          })}
+        </div>
       </section>
     )
   }

--- a/ui/cockpit/src/components/GoalsPanel.test.tsx
+++ b/ui/cockpit/src/components/GoalsPanel.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { GoalsPanel } from './GoalsPanel'
+
+const ORIGINAL_FETCH = global.fetch
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('GoalsPanel', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH
+    vi.restoreAllMocks()
+  })
+
+  it('renders the empty-state when no goals are declared', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/goals')) return jsonResponse({ goals: [] })
+      if (url.startsWith('/artefacts')) return jsonResponse({ artefacts: [] })
+      return new Response('not found', { status: 404 })
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    render(<GoalsPanel refreshIntervalMs={60_000} />)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(
+      await screen.findByText(/No workspace goals declared/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a goal row with status and reconciliation hint', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/goals')) {
+        return jsonResponse({
+          goals: [
+            {
+              id: 'goal-1',
+              title: 'Clean up the auth middleware',
+              status: 'active',
+              description: 'Remove the legacy session-token paths',
+              pc_reconciliation_state: 'reconciled',
+              pc_freshness: 0.8,
+            },
+          ],
+        })
+      }
+      if (url.startsWith('/artefacts')) return jsonResponse({ artefacts: [] })
+      return new Response('not found', { status: 404 })
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    render(<GoalsPanel refreshIntervalMs={60_000} />)
+
+    expect(
+      await screen.findByText('Clean up the auth middleware'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('active')).toBeInTheDocument()
+    // Header shows count summary.
+    expect(screen.getByText(/1 active/)).toBeInTheDocument()
+  })
+})

--- a/ui/cockpit/src/components/GoalsPanel.tsx
+++ b/ui/cockpit/src/components/GoalsPanel.tsx
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cockpit refresh — Goals & artefacts.
+// Read-only view: workspace_goals + linked intent_artefacts (latest snapshot
+// + most recent reconciliation outcome). The MCP tools vaner.goals.declare /
+// update_status / delete cover writes; the cockpit deliberately does not
+// expose CRUD here so the surface stays small.
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { fetchArtefact, listArtefacts, listGoals } from '../api/client'
+import type { Artefact, ArtefactDetail, Goal } from '../types'
+
+const REFRESH_INTERVAL_MS = 8000
+
+function cardStyle(): React.CSSProperties {
+  return {
+    border: '1px solid var(--line-1)',
+    borderRadius: 6,
+    background: 'var(--bg-1, #18181c)',
+    padding: '14px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+    color: 'var(--fg-1, #f0f0f0)',
+  }
+}
+
+function pillStyle(status: string): React.CSSProperties {
+  const palette: Record<string, string> = {
+    active: 'var(--accent, #5eb2ff)',
+    paused: 'var(--fg-3, #9a9aa2)',
+    abandoned: '#a96666',
+    achieved: '#6cc76c',
+  }
+  const color = palette[status] ?? 'var(--fg-3, #9a9aa2)'
+  return {
+    fontSize: 10.5,
+    color,
+    border: `1px solid ${color}`,
+    borderRadius: 999,
+    padding: '1px 8px',
+    fontFamily: 'var(--font-mono, monospace)',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  }
+}
+
+function relTime(epoch: number | undefined | null): string {
+  if (!epoch) return '—'
+  const now = Date.now() / 1000
+  const dt = Math.max(0, now - Number(epoch))
+  if (dt < 60) return `${Math.round(dt)}s ago`
+  if (dt < 3600) return `${Math.round(dt / 60)}m ago`
+  if (dt < 86400) return `${Math.round(dt / 3600)}h ago`
+  return `${Math.round(dt / 86400)}d ago`
+}
+
+interface GoalRowProps {
+  goal: Goal
+  expanded: boolean
+  onToggle: () => void
+  artefactsByGoal: Record<string, Artefact[]>
+  detailByArtefact: Record<string, ArtefactDetail | null>
+  onLoadArtefact: (id: string) => void
+}
+
+function GoalRow({
+  goal,
+  expanded,
+  onToggle,
+  artefactsByGoal,
+  detailByArtefact,
+  onLoadArtefact,
+}: GoalRowProps) {
+  const artefacts = artefactsByGoal[goal.id] ?? []
+
+  return (
+    <li
+      style={{
+        listStyle: 'none',
+        borderTop: '1px solid var(--line-2, #2a2a30)',
+        paddingTop: 10,
+      }}
+      data-testid={`goal-row-${goal.id}`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        style={{
+          all: 'unset',
+          cursor: 'pointer',
+          width: '100%',
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 10,
+          justifyContent: 'space-between',
+        }}
+      >
+        <span style={{ display: 'flex', alignItems: 'baseline', gap: 8, minWidth: 0 }}>
+          <span aria-hidden="true" style={{ color: 'var(--fg-3, #9a9aa2)' }}>
+            {expanded ? '▾' : '▸'}
+          </span>
+          <strong
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {goal.title || goal.id}
+          </strong>
+        </span>
+        <span style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>
+          <span style={pillStyle(goal.status)}>{goal.status}</span>
+          <span style={{ fontSize: 11, color: 'var(--fg-3, #9a9aa2)' }}>
+            {relTime(goal.updated_at ?? goal.created_at)}
+          </span>
+        </span>
+      </button>
+      {expanded ? (
+        <div style={{ marginTop: 8, paddingLeft: 18, fontSize: 12, color: 'var(--fg-2, #d0d0d6)' }}>
+          {goal.description ? (
+            <p style={{ margin: '0 0 6px' }}>{goal.description}</p>
+          ) : null}
+          {goal.pc_reconciliation_state ? (
+            <p style={{ margin: '0 0 6px', fontSize: 11.5, color: 'var(--fg-3, #9a9aa2)' }}>
+              reconciliation: <code>{goal.pc_reconciliation_state}</code>
+              {typeof goal.pc_freshness === 'number'
+                ? ` · freshness ${goal.pc_freshness.toFixed(2)}`
+                : null}
+              {goal.pc_unfinished_item_state && goal.pc_unfinished_item_state !== 'none'
+                ? ` · ${goal.pc_unfinished_item_state}`
+                : null}
+            </p>
+          ) : null}
+          <p style={{ margin: '6px 0 4px', fontSize: 11, color: 'var(--fg-3, #9a9aa2)' }}>
+            Linked artefacts ({artefacts.length})
+          </p>
+          {artefacts.length === 0 ? (
+            <p style={{ margin: 0, fontSize: 11.5 }}>None linked yet.</p>
+          ) : (
+            <ul style={{ margin: 0, paddingLeft: 16 }}>
+              {artefacts.map((artefact) => {
+                const detail = detailByArtefact[artefact.id]
+                return (
+                  <li key={artefact.id} style={{ marginBottom: 6 }}>
+                    <button
+                      type="button"
+                      onClick={() => onLoadArtefact(artefact.id)}
+                      style={{
+                        all: 'unset',
+                        cursor: 'pointer',
+                        color: 'var(--accent, #5eb2ff)',
+                        fontSize: 12,
+                      }}
+                    >
+                      {artefact.title || artefact.source_uri || artefact.id}
+                    </button>
+                    <span
+                      style={{
+                        marginLeft: 6,
+                        fontSize: 11,
+                        color: 'var(--fg-3, #9a9aa2)',
+                      }}
+                    >
+                      {artefact.connector ?? artefact.kind ?? 'artefact'}
+                      {artefact.status ? ` · ${artefact.status}` : null}
+                    </span>
+                    {detail && detail.recent_outcomes.length > 0 ? (
+                      <p
+                        style={{
+                          margin: '2px 0 0',
+                          fontSize: 11,
+                          color: 'var(--fg-3, #9a9aa2)',
+                        }}
+                      >
+                        last reconciled {relTime(detail.recent_outcomes[0].pass_at)}
+                      </p>
+                    ) : null}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      ) : null}
+    </li>
+  )
+}
+
+export interface GoalsPanelProps {
+  /** Override polling interval for tests. */
+  refreshIntervalMs?: number
+}
+
+export function GoalsPanel({ refreshIntervalMs = REFRESH_INTERVAL_MS }: GoalsPanelProps = {}) {
+  const [goals, setGoals] = useState<Goal[]>([])
+  const [artefactsByGoal, setArtefactsByGoal] = useState<Record<string, Artefact[]>>({})
+  const [detailByArtefact, setDetailByArtefact] = useState<Record<string, ArtefactDetail | null>>({})
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      const [goalsResp, artefactsResp] = await Promise.all([
+        listGoals({ limit: 50 }),
+        listArtefacts({ limit: 200 }),
+      ])
+      setGoals(goalsResp.goals)
+      const grouped: Record<string, Artefact[]> = {}
+      for (const artefact of artefactsResp.artefacts) {
+        for (const goalId of artefact.linked_goals ?? []) {
+          if (!grouped[goalId]) grouped[goalId] = []
+          grouped[goalId].push(artefact)
+        }
+      }
+      setArtefactsByGoal(grouped)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoaded(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const handle = window.setInterval(() => void refresh(), refreshIntervalMs)
+    return () => window.clearInterval(handle)
+  }, [refresh, refreshIntervalMs])
+
+  const handleToggle = useCallback(
+    (goalId: string) => {
+      setExpanded((current) => (current === goalId ? null : goalId))
+      const linked = artefactsByGoal[goalId] ?? []
+      for (const artefact of linked) {
+        if (detailByArtefact[artefact.id] === undefined) {
+          void fetchArtefact(artefact.id).then((detail) =>
+            setDetailByArtefact((prev) => ({ ...prev, [artefact.id]: detail })),
+          )
+        }
+      }
+    },
+    [artefactsByGoal, detailByArtefact],
+  )
+
+  const handleLoadArtefact = useCallback((id: string) => {
+    void fetchArtefact(id).then((detail) =>
+      setDetailByArtefact((prev) => ({ ...prev, [id]: detail })),
+    )
+  }, [])
+
+  const summary = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const goal of goals) counts[goal.status] = (counts[goal.status] ?? 0) + 1
+    return counts
+  }, [goals])
+
+  return (
+    <section
+      aria-labelledby="goals-panel-heading"
+      role="region"
+      style={cardStyle()}
+      data-testid="goals-panel"
+    >
+      <header style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+        <h2
+          id="goals-panel-heading"
+          style={{ margin: 0, fontSize: 14, fontWeight: 600 }}
+        >
+          Goals
+        </h2>
+        <span style={{ fontSize: 11, color: 'var(--fg-3, #9a9aa2)' }}>
+          {Object.entries(summary)
+            .map(([status, count]) => `${count} ${status}`)
+            .join(' · ') || (loaded ? 'no goals declared' : 'loading…')}
+        </span>
+      </header>
+      {error ? (
+        <p
+          role="alert"
+          style={{ margin: 0, fontSize: 12, color: 'var(--amber, #e6b656)' }}
+        >
+          {error}
+        </p>
+      ) : null}
+      {loaded && goals.length === 0 ? (
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--fg-2, #d0d0d6)' }}>
+          No workspace goals declared. Use the MCP tool{' '}
+          <code>vaner.goals.declare</code> to create one.
+        </p>
+      ) : (
+        <ul style={{ margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {goals.map((goal) => (
+            <GoalRow
+              key={goal.id}
+              goal={goal}
+              expanded={expanded === goal.id}
+              onToggle={() => handleToggle(goal.id)}
+              artefactsByGoal={artefactsByGoal}
+              detailByArtefact={detailByArtefact}
+              onLoadArtefact={handleLoadArtefact}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/ui/cockpit/src/components/Inspector.tsx
+++ b/ui/cockpit/src/components/Inspector.tsx
@@ -1,4 +1,4 @@
-import type { UIEvidence, UIScenario } from '../types'
+import type { LatestInvalidationSignal, UIEvidence, UIScenario } from '../types'
 
 export interface ScoreComponent {
   label: string
@@ -12,6 +12,12 @@ interface InspectorProps {
   evidenceById: Record<string, UIEvidence[]>
   scoreComponentsById: Record<string, ScoreComponent[]>
   preparedById: Record<string, string>
+  /**
+   * Optional 'why is this stale' signal per scenario, populated lazily
+   * by Inspector callers that fetch /scenarios/{id}. Absent for fresh
+   * scenarios — they don't need a justification.
+   */
+  invalidationById?: Record<string, LatestInvalidationSignal | null | undefined>
   onSelect: (id: string) => void
   onFeedback: (id: string, result: 'useful' | 'partial' | 'irrelevant') => void
   onPin: (id: string) => void
@@ -25,6 +31,7 @@ export function Inspector({
   evidenceById,
   scoreComponentsById,
   preparedById,
+  invalidationById,
   onSelect,
   onFeedback,
   onPin,
@@ -45,6 +52,10 @@ export function Inspector({
   const evidence = evidenceById[scenario.id] ?? []
   const scores = scoreComponentsById[scenario.id] ?? []
   const prepared = preparedById[scenario.id]
+  const invalidation =
+    invalidationById && scenario.freshness !== 'fresh'
+      ? invalidationById[scenario.id] ?? null
+      : null
 
   return (
     <div className="scroll" style={{ height: '100%', overflow: 'auto', padding: 18 }}>
@@ -55,8 +66,17 @@ export function Inspector({
           </div>
           <div style={{ fontFamily: 'var(--font-display)', fontSize: 18, color: 'var(--fg-1)' }}>{scenario.title}</div>
           <div className="mono" style={{ fontSize: 10.5, color: 'var(--fg-4)', marginTop: 6 }}>
-            {scenario.id} · {scenario.kind} · score {scenario.score.toFixed(3)}
+            {scenario.id} · {scenario.kind} · score {scenario.score.toFixed(3)} · {scenario.freshness}
           </div>
+          {invalidation ? (
+            <div
+              className="mono"
+              style={{ fontSize: 10.5, color: 'var(--amber, #e6b656)', marginTop: 4 }}
+              data-testid="inspector-invalidation"
+            >
+              stale because: {invalidation.kind} ({formatTimestamp(invalidation.timestamp)})
+            </div>
+          ) : null}
         </div>
         <button type="button" onClick={onClose} style={buttonStyle} aria-label="Close inspector">
           x
@@ -87,12 +107,17 @@ export function Inspector({
 
       <div style={{ marginTop: 16 }}>
         <div className="mono" style={sectionTitle}>SCORE</div>
-        {scores.length ? scores.map((item) => (
-          <div key={item.label} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, padding: '5px 0' }}>
-            <span>{item.label}</span>
-            <span className="mono">{Number(item.value).toFixed(3)}</span>
-          </div>
-        )) : <div style={emptyStyle}>No score breakdown.</div>}
+        {scores.length ? (
+          <>
+            <ScoreFactorBar scores={scores} />
+            {scores.map((item) => (
+              <div key={item.label} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, padding: '5px 0' }}>
+                <span title={item.description}>{item.label}</span>
+                <span className="mono">{Number(item.value).toFixed(3)}</span>
+              </div>
+            ))}
+          </>
+        ) : <div style={emptyStyle}>No score breakdown.</div>}
       </div>
 
       {prepared ? (
@@ -141,3 +166,58 @@ const cardStyle: React.CSSProperties = {
 }
 const preStyle: React.CSSProperties = { ...cardStyle, color: 'var(--fg-2)', whiteSpace: 'pre-wrap', overflow: 'auto', fontSize: 11 }
 const emptyStyle: React.CSSProperties = { color: 'var(--fg-4)', fontSize: 12 }
+
+function formatTimestamp(epoch: number): string {
+  if (!epoch) return 'unknown'
+  const dt = Math.max(0, Date.now() / 1000 - epoch)
+  if (dt < 60) return `${Math.round(dt)}s ago`
+  if (dt < 3600) return `${Math.round(dt / 60)}m ago`
+  if (dt < 86400) return `${Math.round(dt / 3600)}h ago`
+  return `${Math.round(dt / 86400)}d ago`
+}
+
+const FACTOR_PALETTE = [
+  '#5eb2ff',
+  '#e6b656',
+  '#6cc76c',
+  '#a96666',
+  '#a36cc7',
+  '#6cc7c0',
+] as const
+
+function ScoreFactorBar({ scores }: { scores: ScoreComponent[] }) {
+  // Bar shows the relative magnitude of each factor's contribution. We
+  // normalize on absolute value so negative penalties are visible too.
+  const total = scores.reduce((sum, item) => sum + Math.abs(Number(item.value) || 0), 0)
+  if (total <= 0) return null
+  return (
+    <div
+      role="img"
+      aria-label="Score factor attribution"
+      data-testid="inspector-score-bar"
+      style={{
+        display: 'flex',
+        height: 6,
+        borderRadius: 3,
+        overflow: 'hidden',
+        marginBottom: 8,
+        background: 'var(--bg-inset, #0e0e12)',
+      }}
+    >
+      {scores.map((item, idx) => {
+        const fraction = (Math.abs(Number(item.value) || 0) / total) * 100
+        if (fraction <= 0) return null
+        const color = FACTOR_PALETTE[idx % FACTOR_PALETTE.length]
+        return (
+          <span
+            key={item.label}
+            title={`${item.label}: ${Number(item.value).toFixed(3)}${
+              item.description ? ` — ${item.description}` : ''
+            }`}
+            style={{ width: `${fraction}%`, background: color }}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/cockpit/src/components/LearningPanel.test.tsx
+++ b/ui/cockpit/src/components/LearningPanel.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { LearningPanel } from './LearningPanel'
+
+const ORIGINAL_FETCH = global.fetch
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('LearningPanel', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH
+    vi.restoreAllMocks()
+  })
+
+  it('renders the empty-state when no feedback or learning is recorded', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ feedback_events: [], learning_state: {} }),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    render(<LearningPanel refreshIntervalMs={60_000} />)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(
+      await screen.findByText(/No feedback recorded yet/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a recent useful feedback event with its scenario id', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        feedback_events: [
+          {
+            id: 'feedback-1',
+            timestamp: Date.now() / 1000 - 30,
+            scenario_id: 'scn-42',
+            metadata_json: '{"feedback_kind": "useful"}',
+          },
+        ],
+        learning_state: {
+          skill_weights: { tests: 0.6, refactor: 0.3 },
+        },
+      }),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    render(<LearningPanel refreshIntervalMs={60_000} />)
+
+    expect(await screen.findByText('useful')).toBeInTheDocument()
+    expect(screen.getByText('scn-42')).toBeInTheDocument()
+    expect(screen.getByText(/skill_weights/)).toBeInTheDocument()
+  })
+})

--- a/ui/cockpit/src/components/LearningPanel.tsx
+++ b/ui/cockpit/src/components/LearningPanel.tsx
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cockpit refresh — feedback → learning loop.
+// Small left-rail panel that closes the loop visibly: shows recent
+// feedback_events the user has sent and a one-line summary of the
+// learning_state keys the engine maintains. Read-only, polled.
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { getLearningRecent } from '../api/client'
+import type { FeedbackEvent } from '../types'
+
+const REFRESH_INTERVAL_MS = 12000
+
+function cardStyle(): React.CSSProperties {
+  return {
+    border: '1px solid var(--line-1)',
+    borderRadius: 6,
+    background: 'var(--bg-1, #18181c)',
+    padding: '12px 14px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    color: 'var(--fg-1, #f0f0f0)',
+  }
+}
+
+function relTime(epoch: number | undefined | null): string {
+  if (!epoch) return '—'
+  const now = Date.now() / 1000
+  const dt = Math.max(0, now - Number(epoch))
+  if (dt < 60) return `${Math.round(dt)}s ago`
+  if (dt < 3600) return `${Math.round(dt / 60)}m ago`
+  if (dt < 86400) return `${Math.round(dt / 3600)}h ago`
+  return `${Math.round(dt / 86400)}d ago`
+}
+
+function feedbackChipStyle(kind: string | undefined): React.CSSProperties {
+  const palette: Record<string, string> = {
+    useful: '#6cc76c',
+    partial: 'var(--amber, #e6b656)',
+    wrong: '#a96666',
+    irrelevant: 'var(--fg-3, #9a9aa2)',
+    not_useful: '#a96666',
+  }
+  const color = palette[kind ?? ''] ?? 'var(--fg-3, #9a9aa2)'
+  return {
+    fontSize: 10,
+    color,
+    border: `1px solid ${color}`,
+    borderRadius: 999,
+    padding: '0 6px',
+    fontFamily: 'var(--font-mono, monospace)',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  }
+}
+
+function feedbackKind(event: FeedbackEvent): string {
+  if (event.feedback_kind) return event.feedback_kind
+  // The store persists the feedback kind inside metadata_json; we tolerate
+  // either shape so the panel works against unmigrated rows.
+  if (event.metadata_json) {
+    try {
+      const parsed = JSON.parse(event.metadata_json) as Record<string, unknown>
+      const kind = parsed.feedback_kind ?? parsed.kind ?? parsed.outcome
+      if (typeof kind === 'string') return kind
+    } catch {
+      // ignore — fall through
+    }
+  }
+  return 'feedback'
+}
+
+function feedbackTitle(event: FeedbackEvent): string {
+  if (event.scenario_id) return event.scenario_id
+  if (event.query_id) return event.query_id
+  return event.id ?? 'event'
+}
+
+function summarizeLearningKey(key: string, value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) return null
+    if (key === 'skill_weights' || key === 'scenario_kind_priors' || key === 'intent_priors') {
+      const sorted = entries
+        .filter(([, v]) => typeof v === 'number')
+        .sort((a, b) => Math.abs(Number(b[1])) - Math.abs(Number(a[1])))
+        .slice(0, 2)
+      if (sorted.length === 0) return `${entries.length} entries`
+      return sorted
+        .map(([k, v]) => `${k} ${(Number(v) >= 0 ? '+' : '')}${Number(v).toFixed(2)}`)
+        .join(', ')
+    }
+    return `${entries.length} entries`
+  }
+  if (Array.isArray(value)) return `${value.length} entries`
+  return String(value)
+}
+
+export interface LearningPanelProps {
+  /** Override polling interval for tests. */
+  refreshIntervalMs?: number
+  /** Override max feedback rows shown. */
+  limit?: number
+}
+
+export function LearningPanel({
+  refreshIntervalMs = REFRESH_INTERVAL_MS,
+  limit = 5,
+}: LearningPanelProps = {}) {
+  const [events, setEvents] = useState<FeedbackEvent[]>([])
+  const [learning, setLearning] = useState<Record<string, unknown>>({})
+  const [loaded, setLoaded] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const resp = await getLearningRecent(limit)
+      setEvents(resp.feedback_events.slice(0, limit))
+      setLearning(resp.learning_state)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoaded(true)
+    }
+  }, [limit])
+
+  useEffect(() => {
+    void refresh()
+    const handle = window.setInterval(() => void refresh(), refreshIntervalMs)
+    return () => window.clearInterval(handle)
+  }, [refresh, refreshIntervalMs])
+
+  const summaries = useMemo(() => {
+    const out: Array<{ key: string; summary: string }> = []
+    for (const [key, value] of Object.entries(learning)) {
+      const summary = summarizeLearningKey(key, value)
+      if (summary) out.push({ key, summary })
+    }
+    return out.slice(0, 4)
+  }, [learning])
+
+  return (
+    <section
+      aria-labelledby="learning-panel-heading"
+      role="region"
+      style={cardStyle()}
+      data-testid="learning-panel"
+    >
+      <h3
+        id="learning-panel-heading"
+        style={{ margin: 0, fontSize: 12.5, fontWeight: 600 }}
+      >
+        What Vaner learned
+      </h3>
+      {error ? (
+        <p
+          role="alert"
+          style={{ margin: 0, fontSize: 11.5, color: 'var(--amber, #e6b656)' }}
+        >
+          {error}
+        </p>
+      ) : null}
+      {loaded && events.length === 0 && summaries.length === 0 ? (
+        <p style={{ margin: 0, fontSize: 11.5, color: 'var(--fg-3, #9a9aa2)' }}>
+          No feedback recorded yet — use <code>vaner.feedback</code> to teach.
+        </p>
+      ) : null}
+      {events.length > 0 ? (
+        <ul
+          aria-label="Recent feedback"
+          style={{
+            margin: 0,
+            padding: 0,
+            listStyle: 'none',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 4,
+          }}
+        >
+          {events.map((event, idx) => (
+            <li
+              key={event.id ?? `${event.timestamp ?? idx}`}
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: 6,
+                fontSize: 11.5,
+                color: 'var(--fg-2, #d0d0d6)',
+                minWidth: 0,
+              }}
+            >
+              <span style={feedbackChipStyle(feedbackKind(event))}>{feedbackKind(event)}</span>
+              <span
+                style={{
+                  flex: 1,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {feedbackTitle(event)}
+              </span>
+              <span style={{ fontSize: 10.5, color: 'var(--fg-3, #9a9aa2)' }}>
+                {relTime(event.timestamp)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {summaries.length > 0 ? (
+        <ul
+          aria-label="Learning state summary"
+          style={{
+            margin: 0,
+            padding: 0,
+            listStyle: 'none',
+            borderTop: events.length > 0 ? '1px solid var(--line-2, #2a2a30)' : 'none',
+            paddingTop: events.length > 0 ? 6 : 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          {summaries.map(({ key, summary }) => (
+            <li
+              key={key}
+              style={{
+                fontSize: 11,
+                color: 'var(--fg-3, #9a9aa2)',
+                fontFamily: 'var(--font-mono, monospace)',
+              }}
+            >
+              <span style={{ color: 'var(--fg-2, #d0d0d6)' }}>{key}</span>: {summary}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  )
+}

--- a/ui/cockpit/src/components/PreparedWorkPanel.tsx
+++ b/ui/cockpit/src/components/PreparedWorkPanel.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react'
 
-import { listPreparedWork, runPreparedWorkAction } from '../api/client'
-import type { PreparedWorkAction, PreparedWorkCard } from '../types'
+import { inspectWorkProduct, listPreparedWork, runPreparedWorkAction } from '../api/client'
+import type {
+  PreparedWorkAction,
+  PreparedWorkCard,
+  WorkProductInspection,
+} from '../types'
 
 export interface PreparedWorkPanelProps {
   baseUrl?: string
@@ -32,7 +36,14 @@ export function PreparedWorkPanel({
   const [cards, setCards] = useState<PreparedWorkCard[]>([])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
-  const [detail, setDetail] = useState<string | null>(null)
+  const [detail, setDetail] = useState<WorkProductInspection | null>(null)
+  const [detailFallback, setDetailFallback] = useState<string | null>(null)
+  // Lazy-loaded self-eval / lifecycle data, keyed by work-product source_id.
+  // Populated for cards backed by a work_product when the panel mounts and
+  // reused for the inline confidence bars + the inspect detail view.
+  const [inspectionsBySource, setInspectionsBySource] = useState<
+    Record<string, WorkProductInspection | null>
+  >({})
   const endpoint = useMemo(() => {
     const query = new URLSearchParams()
     query.set('surface', 'cockpit')
@@ -73,6 +84,34 @@ export function PreparedWorkPanel({
     }
   }, [intervalMs, refresh])
 
+  // Lazy-fetch self_eval + lifecycle for any work-product-backed card we
+  // haven't inspected yet. Cards backed by predictions don't have a
+  // /work-products/{id}/inspect endpoint, so we skip them.
+  useEffect(() => {
+    let cancelled = false
+    const targets = cards.filter(
+      (card) => card.source_type === 'work_product' && inspectionsBySource[card.source_id] === undefined,
+    )
+    if (targets.length === 0) return
+    void Promise.all(
+      targets.map(async (card) => {
+        try {
+          const data = await inspectWorkProduct(card.source_id)
+          if (!cancelled) {
+            setInspectionsBySource((prev) => ({ ...prev, [card.source_id]: data }))
+          }
+        } catch {
+          if (!cancelled) {
+            setInspectionsBySource((prev) => ({ ...prev, [card.source_id]: null }))
+          }
+        }
+      }),
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [cards, inspectionsBySource])
+
   const runAction = useCallback(
     async (card: PreparedWorkCard, action: PreparedWorkAction) => {
       if (!action.endpoint) return
@@ -90,8 +129,16 @@ export function PreparedWorkPanel({
               return response.json()
             })()
           : await runPreparedWorkAction(action.endpoint, action.kind)
-        if (action.kind === 'inspect' || action.kind === 'export') {
-          setDetail(JSON.stringify(result, null, 2))
+        if (action.kind === 'inspect') {
+          const inspection = result as WorkProductInspection
+          setDetail(inspection)
+          setDetailFallback(null)
+          if (card.source_type === 'work_product' && inspection?.source_id) {
+            setInspectionsBySource((prev) => ({ ...prev, [card.source_id]: inspection }))
+          }
+        } else if (action.kind === 'export') {
+          setDetail(null)
+          setDetailFallback(JSON.stringify(result, null, 2))
         }
         if (action.kind === 'dismiss') {
           setCards((current) => current.filter((item) => item.id !== card.id))
@@ -128,11 +175,24 @@ export function PreparedWorkPanel({
       <div className="scroll" style={{ overflow: 'auto', minHeight: 0, padding: '0 12px 12px' }}>
         {cards.length === 0 ? <p style={emptyStyle}>No prepared work is ready.</p> : null}
         {cards.map((card) => (
-          <PreparedWorkItem key={card.id} card={card} onAction={runAction} />
+          <PreparedWorkItem
+            key={card.id}
+            card={card}
+            inspection={
+              card.source_type === 'work_product' ? inspectionsBySource[card.source_id] ?? null : null
+            }
+            onAction={runAction}
+          />
         ))}
         {detail ? (
+          <PreparedWorkInspectionDetail
+            inspection={detail}
+            onClose={() => setDetail(null)}
+          />
+        ) : null}
+        {detailFallback ? (
           <pre style={detailStyle} aria-label="Prepared work detail">
-            {detail}
+            {detailFallback}
           </pre>
         ) : null}
       </div>
@@ -142,9 +202,11 @@ export function PreparedWorkPanel({
 
 function PreparedWorkItem({
   card,
+  inspection,
   onAction,
 }: {
   card: PreparedWorkCard
+  inspection: WorkProductInspection | null
   onAction: (card: PreparedWorkCard, action: PreparedWorkAction) => Promise<void>
 }) {
   const primary = canRenderAction(card.primary_action) ? card.primary_action : null
@@ -163,6 +225,7 @@ function PreparedWorkItem({
         <span>{card.target_label}</span>
         {card.evidence_count ? <span>{card.evidence_count} sources</span> : null}
       </div>
+      {inspection?.self_eval ? <SelfEvalBars selfEval={inspection.self_eval} /> : null}
       <div style={actionsStyle}>
         {primary ? (
           <button type="button" style={primaryButtonStyle} onClick={() => void onAction(card, primary)}>
@@ -176,6 +239,190 @@ function PreparedWorkItem({
         ))}
       </div>
     </article>
+  )
+}
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+function SelfEvalBars({ selfEval }: { selfEval: NonNullable<WorkProductInspection['self_eval']> }) {
+  // Three side-by-side micro-bars. Contradiction is inverted so 'longer is
+  // better' for all three — a quick visual sanity check rather than a
+  // numerical breakdown.
+  const bars = [
+    {
+      key: 'evidence',
+      label: 'evidence',
+      value: clamp01(selfEval.evidence_coverage),
+      color: '#5eb2ff',
+      title: `evidence coverage ${selfEval.evidence_coverage.toFixed(2)}`,
+    },
+    {
+      key: 'grounded',
+      label: 'grounded',
+      value: clamp01(selfEval.groundedness),
+      color: '#6cc76c',
+      title: `groundedness ${selfEval.groundedness.toFixed(2)}`,
+    },
+    {
+      key: 'contradict',
+      label: 'contradict',
+      value: clamp01(1 - selfEval.contradiction_risk),
+      color: selfEval.contradiction_risk >= 0.35 ? '#a96666' : '#a36cc7',
+      title: `contradiction risk ${selfEval.contradiction_risk.toFixed(2)} (lower is better)`,
+    },
+  ]
+  return (
+    <div
+      data-testid="self-eval-bars"
+      style={{ display: 'flex', gap: 6, marginTop: 8, alignItems: 'baseline' }}
+    >
+      {bars.map((bar) => (
+        <div
+          key={bar.key}
+          title={bar.title}
+          style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}
+        >
+          <span
+            style={{
+              fontFamily: 'var(--font-mono, monospace)',
+              fontSize: 9.5,
+              color: 'var(--fg-4)',
+              letterSpacing: 0.4,
+            }}
+          >
+            {bar.label}
+          </span>
+          <span
+            role="img"
+            aria-label={bar.title}
+            style={{
+              display: 'block',
+              height: 5,
+              borderRadius: 3,
+              background: 'var(--bg-0, #0e0e12)',
+              overflow: 'hidden',
+              position: 'relative',
+            }}
+          >
+            <span
+              style={{
+                display: 'block',
+                height: '100%',
+                width: `${Math.round(bar.value * 100)}%`,
+                background: bar.color,
+                transition: 'width 240ms ease',
+              }}
+            />
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function lifecycleEventLabel(event_type: string): string {
+  switch (event_type) {
+    case 'inspect':
+      return 'INSPECTED'
+    case 'export':
+      return 'EXPORTED'
+    case 'dismiss':
+      return 'DISMISSED'
+    case 'feedback':
+      return 'FEEDBACK'
+    default:
+      return event_type.toUpperCase()
+  }
+}
+
+function lifecycleAge(timestamp: number): string {
+  if (!timestamp) return ''
+  const dt = Math.max(0, Date.now() / 1000 - timestamp)
+  if (dt < 60) return `${Math.round(dt)}s`
+  if (dt < 3600) return `${Math.round(dt / 60)}m`
+  if (dt < 86400) return `${Math.round(dt / 3600)}h`
+  return `${Math.round(dt / 86400)}d`
+}
+
+function PreparedWorkInspectionDetail({
+  inspection,
+  onClose,
+}: {
+  inspection: WorkProductInspection
+  onClose: () => void
+}) {
+  const events = (inspection.events ?? []).slice(0, 6).reverse()
+  return (
+    <div
+      style={{
+        ...detailStyle,
+        whiteSpace: 'normal',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+      aria-label="Prepared work detail"
+      data-testid="prepared-work-inspection"
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10 }}>
+        <strong style={{ color: 'var(--fg-1)', fontSize: 12 }}>{inspection.title}</strong>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close prepared work detail"
+          style={{ ...secondaryButtonStyle, padding: '0 6px' }}
+        >
+          x
+        </button>
+      </div>
+      {inspection.why_prepared ? (
+        <p style={{ margin: 0, fontSize: 11.5, color: 'var(--fg-3)' }}>{inspection.why_prepared}</p>
+      ) : null}
+      {inspection.self_eval ? <SelfEvalBars selfEval={inspection.self_eval} /> : null}
+      {events.length > 0 ? (
+        <div
+          style={{
+            display: 'flex',
+            gap: 6,
+            flexWrap: 'wrap',
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: 10.5,
+            color: 'var(--fg-3)',
+          }}
+          aria-label="Lifecycle events"
+        >
+          {events.map((evt, idx) => (
+            <span key={`${evt.event_type}-${evt.timestamp}-${idx}`}>
+              {lifecycleEventLabel(evt.event_type)} {lifecycleAge(evt.timestamp)} ago
+              {idx < events.length - 1 ? ' →' : ''}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {inspection.body ? (
+        <pre
+          style={{
+            margin: 0,
+            padding: 8,
+            border: '1px solid var(--line-hair)',
+            borderRadius: 'var(--r-2)',
+            background: 'var(--bg-0)',
+            color: 'var(--fg-2)',
+            whiteSpace: 'pre-wrap',
+            fontSize: 11,
+            maxHeight: 160,
+            overflow: 'auto',
+          }}
+        >
+          {inspection.body}
+        </pre>
+      ) : null}
+    </div>
   )
 }
 

--- a/ui/cockpit/src/components/chrome.tsx
+++ b/ui/cockpit/src/components/chrome.tsx
@@ -27,6 +27,8 @@ export interface CommandItem {
   run: () => void
 }
 
+export type CockpitView = 'pipeline' | 'goals'
+
 interface TopBarProps {
   running: boolean
   onToggleRun: () => void
@@ -36,6 +38,13 @@ interface TopBarProps {
   mode: UIMode
   query: string
   onQuery: (value: string) => void
+  /**
+   * Cockpit refresh: when present, render a small Pipeline/Goals toggle
+   * so advanced users can switch the main canvas to the goals destination
+   * without leaving the cockpit. Omitted on hosts that don't expose goals.
+   */
+  view?: CockpitView
+  onChangeView?: (view: CockpitView) => void
 }
 
 const MODE_LABEL: Record<UIMode, string> = {
@@ -44,7 +53,18 @@ const MODE_LABEL: Record<UIMode, string> = {
   mcp: 'MCP',
 }
 
-export function TopBar({ running, onToggleRun, packageState, onOpenSettings, onOpenPalette, mode, query, onQuery }: TopBarProps) {
+export function TopBar({
+  running,
+  onToggleRun,
+  packageState,
+  onOpenSettings,
+  onOpenPalette,
+  mode,
+  query,
+  onQuery,
+  view,
+  onChangeView,
+}: TopBarProps) {
   return (
     <div
       style={{
@@ -111,6 +131,32 @@ export function TopBar({ running, onToggleRun, packageState, onOpenSettings, onO
       </div>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+        {view && onChangeView ? (
+          <div
+            role="tablist"
+            aria-label="Cockpit view"
+            style={{ display: 'flex', border: '1px solid var(--line-1)', borderRadius: 'var(--r-1)' }}
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === 'pipeline'}
+              onClick={() => onChangeView('pipeline')}
+              style={viewTabStyle(view === 'pipeline')}
+            >
+              Pipeline
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === 'goals'}
+              onClick={() => onChangeView('goals')}
+              style={viewTabStyle(view === 'goals')}
+            >
+              Goals
+            </button>
+          </div>
+        ) : null}
         <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
           <span
             style={{
@@ -186,6 +232,19 @@ const headerBtn: React.CSSProperties = {
   gap: 5,
 }
 
+function viewTabStyle(active: boolean): React.CSSProperties {
+  return {
+    background: active ? 'var(--bg-2)' : 'transparent',
+    border: 'none',
+    color: active ? 'var(--fg-1)' : 'var(--fg-3)',
+    padding: '5px 10px',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 10.5,
+    letterSpacing: 0.4,
+    cursor: 'pointer',
+  }
+}
+
 interface LeftRailProps {
   mode: UIMode
   skills: UISkill[]
@@ -196,6 +255,12 @@ interface LeftRailProps {
   scenarioCount: number
   impact?: ImpactSummary
   header?: React.ReactNode
+  /**
+   * Cockpit refresh: small slot below the existing skills/pinned blocks.
+   * Used to render the learning summary so feedback the user gives is
+   * visibly reflected back without taking the user away from the canvas.
+   */
+  footer?: React.ReactNode
 }
 
 export function LeftRail({
@@ -208,6 +273,7 @@ export function LeftRail({
   scenarioCount,
   impact,
   header,
+  footer,
 }: LeftRailProps) {
   return (
     <div
@@ -355,6 +421,17 @@ export function LeftRail({
           ) : null}
         </div>
       </div>
+
+      {footer ? (
+        <div
+          style={{
+            padding: '12px 16px',
+            borderTop: '1px solid var(--line-hair)',
+          }}
+        >
+          {footer}
+        </div>
+      ) : null}
 
       <div style={{ flex: 1 }} />
 

--- a/ui/cockpit/src/types.ts
+++ b/ui/cockpit/src/types.ts
@@ -286,6 +286,176 @@ export interface ScenarioApiPayload {
   score_components?: Array<{ label: string; value: number; description?: string }>
 }
 
+// ---------------------------------------------------------------------------
+// Cockpit refresh: goals, artefacts, predictions-by-state, work-product
+// self-eval + lifecycle, learning summary. These mirror the JSON shapes the
+// daemon now returns from /goals, /artefacts, /artefacts/{id},
+// /predictions/active?include_all=true, /work-products/{id}/inspect, and
+// /learning/recent. Field types are intentionally permissive — the engine
+// stores some columns as TEXT/JSON-blob and the cockpit only renders the
+// subset it understands. See types/setup.ts re: ts-rs migration.
+// ---------------------------------------------------------------------------
+
+export type GoalStatus = 'active' | 'paused' | 'abandoned' | 'achieved' | string
+
+export interface Goal {
+  id: string
+  title: string
+  description?: string
+  status: GoalStatus
+  source?: string
+  confidence?: number
+  created_at?: number
+  updated_at?: number
+  related_files?: string[]
+  artefact_refs?: string[]
+  pc_freshness?: number
+  pc_reconciliation_state?: string
+  pc_unfinished_item_state?: string
+}
+
+export interface Artefact {
+  id: string
+  title?: string
+  status?: string
+  connector?: string
+  source_uri?: string
+  source_tier?: string
+  latest_snapshot?: string
+  updated_at?: number
+  linked_goals?: string[]
+  linked_files?: string[]
+  kind?: string
+}
+
+export interface ArtefactItem {
+  id: string
+  title?: string
+  body?: string
+  state?: string
+  related_files?: string[]
+  related_entities?: string[]
+  evidence_refs?: unknown[]
+}
+
+export interface ReconciliationOutcome {
+  id: string
+  artefact_id: string
+  pass_at: number
+  triggering_signal_id?: string | null
+  item_state_deltas_json?: string
+  goal_status_deltas_json?: string
+  supersedes_json?: string
+  evidence_refs_json?: string
+}
+
+export interface ArtefactDetail {
+  artefact: Artefact
+  items: ArtefactItem[]
+  snapshot_id: string
+  recent_outcomes: ReconciliationOutcome[]
+}
+
+export type PredictionReadiness =
+  | 'queued'
+  | 'grounding'
+  | 'evidence_gathering'
+  | 'drafting'
+  | 'ready'
+  | 'stale'
+  | string
+
+export interface PredictionSummary {
+  id: string
+  prediction_id?: string
+  title?: string
+  prompt?: string
+  readiness?: PredictionReadiness
+  confidence?: number
+  created_at?: number
+  updated_at?: number
+  invalidation_reason?: string | null
+}
+
+export interface PredictionsByState {
+  predictions: PredictionSummary[]
+  by_state?: Record<PredictionReadiness, PredictionSummary[]>
+}
+
+export interface WorkProductSelfEval {
+  evidence_coverage: number
+  groundedness: number
+  contradiction_risk: number
+  stale_risk?: number
+  reason?: string
+}
+
+export interface WorkProductLifecycleEvent {
+  event_type: string
+  timestamp: number
+}
+
+export interface WorkProductInspection {
+  id: string
+  source_id: string
+  source_type: string
+  kind: string
+  title: string
+  summary: string
+  body: string
+  why_prepared?: string
+  confidence_label: string
+  freshness_label: string
+  freshness_state?: string
+  target_label: string
+  evidence_count: number
+  evidence_refs: Array<{
+    kind: string
+    path: string
+    symbol?: string
+    reason?: string
+    confidence_label?: string
+  }>
+  warnings?: string[]
+  export_preview?: string
+  created_at: number
+  updated_at: number
+  // Cockpit refresh additions:
+  self_eval?: WorkProductSelfEval
+  events?: WorkProductLifecycleEvent[]
+  status?: string
+  adoptability?: string
+  feedback_state?: string
+}
+
+export interface FeedbackEvent {
+  id?: string
+  query_id?: string
+  timestamp?: number
+  cache_tier?: string
+  similarity?: number
+  quality_lift?: number
+  latency_ms?: number
+  metadata_json?: string
+  feedback_kind?: string
+  scenario_id?: string
+}
+
+export interface LearningRecent {
+  feedback_events: FeedbackEvent[]
+  learning_state: Record<string, unknown>
+}
+
+export interface LatestInvalidationSignal {
+  kind: string
+  source: string
+  timestamp: number
+}
+
+export interface ScenarioInspectorPayload extends ScenarioApiPayload {
+  latest_invalidation_signal?: LatestInvalidationSignal | null
+}
+
 declare global {
   interface Window {
     __VANER_MODE__?: string


### PR DESCRIPTION
## Summary

Two related additions in one branch — cockpit goals/predictions/learning surfaces and a new catalog refresher that produces an honest, sampling-aware local model registry.

### Cockpit refresh (`ui/cockpit/`)
- New Goals destination with TopBar Pipeline/Goals toggle; reads `/goals` and `/artefacts`.
- `ActivePredictionsPanel` adds five-lane state-machine view (queued → ready) when `?include_all=true`.
- `Inspector` gets a score-factor stacked bar and a 'stale because:' invalidation line populated from `/scenarios/{id}`.
- `PreparedWorkPanel` shows three self-eval bars per card and a lifecycle strip in the inspect detail.
- `LearningPanel` in left rail footer surfaces recent `feedback_events` + a one-line summary of `learning_state` keys.
- `cockpit_html.py` mirrors all four sections in plain HTML so the daemon stays useful when `/dist` is missing.

### Daemon HTTP (`src/vaner/daemon/http.py`)
- New routes: `/goals`, `/artefacts`, `/artefacts/{id}`, `/learning/recent`.
- `/predictions/active?include_all=true` returns `by_state`.
- `/scenarios/{id}` attaches `latest_invalidation_signal` for non-fresh rows.
- `/work-products/{id}/inspect` now returns `self_eval`, `events`, `status`, `adoptability`, `feedback_state`.

### Catalog refresher (`src/vaner/setup/catalog_refresh.py` + `setup catalog refresh` CLI)
- One row per family using `<family>:latest` Ollama tags. `params_b` derived from the manifest's `vnd.ollama.image.model` layer bytes.
- Family-level seed (`src/vaner/defaults/catalog_seed.json`) carries author-recommended sampling defaults (`temperature`, `top_p`, `top_k`, `repeat_penalty`, `min_p`), runtime defaults (`keep_alive`, `num_ctx`, `num_predict`), and architectural max context per family.
- `_split_parameters` separates capability / runtime / sampling; consumers no longer conflate them.
- `compute_effective_context_window` picks a hw/archetype-aware effective context — floor 32K, cap at model max, scaled by accelerator memory headroom and boosted for long-context archetypes (coding, research, planning, mixed).
- Bundled `model_registry.json` regenerated online from real Ollama manifests.

## Test plan
- [x] `pytest tests/test_setup/ tests/test_daemon/` — 328 passed, 2 skipped.
- [x] `pnpm --dir ui/cockpit typecheck` — clean.
- [x] `pnpm --dir ui/cockpit test` — 75 passed.
- [x] `pnpm --dir ui/cockpit build` — clean.
- [x] `vaner setup catalog refresh` — verified online against the live Ollama registry; 7 families resolved, 1 skipped (deepseek-r2 not yet on Ollama as `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)