### PR TITLE
chore(readme): simplify to ~100 lines, single front-door, link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/Borgels/vaner/actions/workflows/ci.yml/badge.svg)](https://github.com/Borgels/vaner/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/Borgels/vaner/actions/workflows/codeql.yml/badge.svg)](https://github.com/Borgels/vaner/actions/workflows/codeql.yml)
 [![Release](https://img.shields.io/github/v/release/Borgels/vaner)](https://github.com/Borgels/vaner/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/Borgels/vaner/total?label=Downloads)](https://github.com/Borgels/vaner/releases)
 [![License](https://img.shields.io/github/license/Borgels/vaner)](LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Borgels/vaner/badge)](https://scorecard.dev/viewer/?uri=github.com/Borgels/vaner)
 
@@ -12,268 +11,89 @@
 ## What is Vaner?
 
 Vaner is a local-first preparation engine for AI coding agents. It turns idle
-compute into evidence-backed Prepared Work: review notes, bug hypotheses, docs
-drift, virtual diffs, research briefs, and ready prediction-backed drafts.
+compute into evidence-backed Prepared Work — review notes, bug hypotheses, docs
+drift, virtual diffs, research briefs, ready prediction-backed drafts — and
+serves the best fit when the real question arrives.
 
-Instead of waiting for a prompt and starting retrieval from cold, Vaner
-continuously prepares likely useful work, scores it, and serves the best fit
-quickly when the real question arrives. Prepared Work is non-mutating by
-default: virtual diffs and exports require explicit user action, and Vaner does
-not silently edit your files.
-
-It is built around evidence-backed scenario memory, not chat-log accumulation:
-
-- context is compiled from repo evidence and stored as reusable scenarios
-- memory has explicit lifecycle states (`candidate`, `trusted`, `stale`, `demoted`)
-- fingerprints tie memory to concrete sources so drift is detected automatically
-- conflict handling can abstain instead of blending contradictory evidence
+Prepared Work is non-mutating by default: virtual diffs and exports require
+explicit user action. Vaner does not silently edit your files.
 
 ## Install
 
-### One-line installer (Linux/macOS)
+**Most users:** download the desktop app at **[vaner.ai](https://vaner.ai)**.
+The desktop app starts the engine, picks a local model for your hardware, and
+wires Vaner into the MCP clients it detects on your machine (Claude Code,
+Cursor, Zed, VS Code, Claude Desktop, …).
+
+**Power users / CI:** install the CLI directly.
 
 ```bash
+# Linux/macOS — one-line installer
 curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+
+# Or via your package manager of choice
+pipx install 'vaner[mcp]'
+uv tool install 'vaner[mcp]'
 ```
 
-Common installer flags:
+Full install matrix (flags, non-interactive CI, package upgrade, source build,
+retention/expiry): **[docs.vaner.ai/getting-started](https://docs.vaner.ai/getting-started)**.
 
-- `--yes` (non-interactive), `--dry-run`, `--verify`
-- `--backend uv|pipx`
-- `--version <tag>`
-- `--with-ollama`
-- `--minimal` (legacy minimal extras; pairs with `--no-mcp` when needed)
-- `--backend-preset ollama|lmstudio|vllm|openai|anthropic|openrouter|skip`
-- `--backend-url <url>`, `--backend-model <model>`, `--backend-api-key-env <env>`
-- `--compute-preset background|balanced|dedicated`
-- `--max-session-minutes <n>`
-- `--no-mcp` (skip MCP extras)
-
-### Manual install (advanced)
+## First run
 
 ```bash
-pipx install 'vaner[all]'
-# or
-uv tool install 'vaner[all]'
+vaner init --path .   # detect hardware, pick a model, wire detected MCP clients
+vaner up --path .     # start the daemon + cockpit
 ```
 
-### Upgrade
+The cockpit opens at `http://127.0.0.1:8473/` and shows live pipeline state,
+prepared work, predictions, goals, and feedback.
 
-```bash
-vaner upgrade
-vaner version
-```
+## Connect your AI client
 
-### What Vaner stores and when it expires
+Vaner exposes context to your agent over [MCP](https://modelcontextprotocol.io/).
+`vaner init` wires the clients it detects automatically. Manual setup:
 
-Vaner stores local runtime state in your repository under `.vaner/` (for example `store.db`, `scenarios.db`,
-`metrics.db`, and `telemetry.db`). Retention is controlled by `limits.max_age_seconds` in `.vaner/config.toml`.
-Old signal/replay/query and stale cache entries are purged during engine/precompute activity. There is not yet a
-separate `prune` or `compact` command.
+| Client                                                      | One command                                                                                |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Claude Code (plugin, recommended)                           | `/plugin marketplace add Borgels/vaner` then `/plugin install vaner@vaner`                 |
+| Claude Code (manual MCP)                                    | `claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .`                |
+| Codex CLI                                                   | `codex mcp add vaner -- vaner mcp --path .`                                                |
+| Cursor, VS Code, Zed, Windsurf, Continue, Claude Desktop, Cline, Roo | see **[docs.vaner.ai/integrations](https://docs.vaner.ai/integrations)**          |
 
-Useful commands:
+## Documentation
 
-- `vaner config set limits.max_age_seconds 3600 --path .`
-- `vaner forget --path .` (remove local Vaner state for this repo)
-- `vaner uninstall --path . --keep-state` (remove client wiring while keeping state)
+Full docs at **[docs.vaner.ai](https://docs.vaner.ai)**:
 
-## Configure
+- [Getting started](https://docs.vaner.ai/getting-started) — install + first run
+- [Integrations](https://docs.vaner.ai/integrations) — every supported MCP client
+- [Cockpit](https://docs.vaner.ai/cockpit) — live pipeline view + diagnostics
+- [Configuration](https://docs.vaner.ai/configuration) — backends, compute, retention
+- [CLI reference](https://docs.vaner.ai/cli) — every command
+- [MCP tools](https://docs.vaner.ai/mcp) — `vaner.*` namespace
+- [Architecture](https://docs.vaner.ai/architecture) — how the engine works
+- [Security](https://docs.vaner.ai/security) — local-first guarantees, threat model
 
-Run the setup wizard per repo:
+## Contributing
 
-```bash
-vaner init --path .
-```
-
-Key non-interactive flags:
-
-- `--backend-preset`
-- `--backend-model` and `--backend-api-key-env`
-- `--compute-preset background|balanced|dedicated`
-- `--max-session-minutes <n>`
-- `--force`
-- `--interactive/--no-interactive`
-- `--no-mcp`
-
-What `vaner init` does by default:
-
-- writes repo-local config to `.vaner/config.toml`
-- writes repo-local Cursor MCP wiring to `.cursor/mcp.json`
-- writes managed feedback skills to `.cursor/skills/vaner/vaner-feedback/SKILL.md` and `~/.claude/skills/vaner/vaner-feedback/SKILL.md`
-- installs per-client usage primers (short guidance about when and how to use Vaner) into each detected client's rules surface: `.claude/CLAUDE.md` (Claude Code), `.cursor/rules/vaner.mdc` (Cursor), `.github/copilot-instructions.md` (Copilot), `AGENTS.md` (Codex CLI), `.clinerules` (Cline), `.continue/rules/vaner.md` (Continue). Primers are non-destructive: existing files get a delimited `<!-- vaner-primer:start v=… -->…<!-- vaner-primer:end -->` block that re-runs replace in place without touching content outside it.
-
-Use `vaner init --no-mcp --path .` if you want config only and do not want Vaner to wire MCP clients or managed
-skills. Use `--no-primer` to skip the client-level guidance. Use `--user-primer` to also install the Claude Code
-primer at `~/.claude/CLAUDE.md` (always-on across every session) in addition to the repo-level `.claude/CLAUDE.md`.
-If Cursor is already open, reload the window after `vaner init` so the new MCP server is picked up.
-
-Start / verify runtime:
-
-```bash
-vaner up --path .
-vaner status
-vaner logs --path .
-vaner down
-```
-
-### Supported MCP clients
-
-From the client registry IDs:
-
-`cursor`, `claude-desktop`, `claude-code`, `vscode-copilot`, `codex-cli`, `windsurf`, `zed`, `continue`, `cline`, `roo`
-
-## Quickstart
-
-```bash
-vaner init --path .
-vaner up --path .
-```
-
-The installer:
-
-- Detects `uv` or `pipx` and installs `vaner[mcp]` (MCP client support included by default; pass `--no-mcp` to skip).
-- Falls back to `git+https://github.com/Borgels/vaner.git` if the PyPI package isn't available yet.
-- Asks you to pick a model backend (Ollama, LM Studio, vLLM, OpenAI, Anthropic, OpenRouter, or skip).
-- Offers a compute budget (`background` / `balanced` / `dedicated`) and an optional wall-clock cap on ponder time (`--max-session-minutes`).
-
-Non-interactive example (CI, Dockerfile):
-
-```bash
-VANER_YES=1 \
-VANER_BACKEND_PRESET=openai \
-VANER_BACKEND_API_KEY_ENV=OPENAI_API_KEY \
-VANER_BACKEND_MODEL=gpt-4o \
-VANER_COMPUTE_PRESET=background \
-VANER_MAX_SESSION_MINUTES=30 \
-curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
-```
-
-From source (no installer):
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for dev setup, testing, CI, the
+Claude Code plugin parity rules, and DCO sign-off. Quick start:
 
 ```bash
 git clone https://github.com/Borgels/vaner.git
 cd vaner
-pip install '.[mcp]'
-```
-
-Installer source for review: [`scripts/install.sh`](scripts/install.sh).
-
-### 2. Connect your AI client
-
-Vaner exposes context to your agent over [MCP](https://modelcontextprotocol.io/). Pick your client and paste the one-liner:
-
-| Client | One command |
-| --- | --- |
-| Claude Code (plugin, recommended) | `/plugin marketplace add Borgels/vaner` then `/plugin install vaner@vaner` |
-| Claude Code (manual MCP) | `claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .` |
-| Codex CLI   | `codex mcp add vaner -- vaner mcp --path .` |
-| Cursor / VS Code / Zed / Windsurf / Continue / Claude Desktop / Cline / Roo | see [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp) |
-
-The Claude Code plugin bundles the MCP server, the `vaner-feedback` skill (namespaced as `/vaner:vaner-feedback`), and a SessionStart hook that detects whether the `vaner` CLI is installed. See [docs/claude-plugin.md](docs/claude-plugin.md) for details.
-
-Or let Vaner write the config file for you:
-
-```bash
-vaner init --path .                 # initialize this repo + pick backend interactively
-vaner mcp --path .                  # smoke-test the MCP server in stdio mode
-```
-
-### 3. Run it
-
-```bash
-vaner up --path .
-vaner query "where is auth enforced?" --explain --path .
-vaner inspect --last --path .
-```
-
-Asciinema demo: coming soon.
-
-## Cockpit live pipeline view
-
-Vaner ships a cockpit UI that doubles as a real-time control surface for the
-daemon. Open it at `http://127.0.0.1:8473/` after `vaner up --path .`, or
-co-mounted at `/cockpit/` when serving MCP over SSE.
-
-The cockpit view is organised around the actual daemon control flow:
-
-```
-Signals → Targets → Model → Artefacts → Scenarios → Decisions
-```
-
-- **Pipeline ribbon** at the top shows per-stage activity with animated
-  particles flowing left-to-right as the daemon processes each cycle. Model
-  lane surfaces a spinner while LLM requests are in flight, plus the last
-  latency.
-- **Scenario cluster** is the main canvas. Scenarios are laid out by
-  kind-bucketed force-directed layout and connected by **shared-path Jaccard
-  edges** — so even scenarios without an explicit parent/child form a visible
-  constellation when they touch the same files. Drag nodes, scroll to zoom.
-- **System vitals** (left rail) tracks mode, current cycle duration, model
-  busy state, recent LLM latency EMA, total cycles, artefacts written, and
-  error count. All values are derived from the event bus — no polling.
-- **Event stream** (right rail) is colour-coded by stage with per-stage
-  filter chips, heartbeat collapsing, and an in-flight LLM counter.
-
-Everything is driven by the unified event bus in `src/vaner/events/bus.py`,
-which the daemon runner, LLM helpers, proxy, and scenario store publish to.
-The SSE endpoint `/events/stream` accepts a `?stages=model,artefacts` filter
-for scripted consumers.
-
-## Documentation
-
-Most documentation lives at [docs.vaner.ai](https://docs.vaner.ai):
-
-- Getting started: [docs.vaner.ai/getting-started](https://docs.vaner.ai/getting-started)
-- Integrations: [docs.vaner.ai/integrations](https://docs.vaner.ai/integrations)
-- Configuration: [docs.vaner.ai/configuration](https://docs.vaner.ai/configuration)
-- Architecture: [docs.vaner.ai/architecture](https://docs.vaner.ai/architecture)
-- Security: [docs.vaner.ai/security](https://docs.vaner.ai/security)
-- CLI reference: [docs.vaner.ai/cli](https://docs.vaner.ai/cli)
-- MCP tools: [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp)
-- Examples: [docs.vaner.ai/examples](https://docs.vaner.ai/examples)
-
-## MCP
-
-Vaner exposes namespaced MCP tools. Normal clients should start with Prepared
-Work:
-
-- `vaner.prepared_work.dashboard` — UI-safe cards for prepared artifacts and
-  ready prediction-backed opportunities.
-- `vaner.work_products.list` / `inspect` / `export` / `dismiss` / `feedback` —
-  diagnostic artifact flows. Export returns content and never applies patches.
-- `vaner.resolve`, `vaner.suggest`, `vaner.search`, `vaner.expand`,
-  `vaner.inspect`, `vaner.explain`, `vaner.feedback`, `vaner.warm` — query
-  resolution and scenario navigation.
-- `vaner.debug.trace` — diagnostic trace output for debugging integrations.
-- `vaner.predictions.*`, `vaner.goals.*`, `vaner.artefacts.*`,
-  `vaner.sources.status`, `vaner.setup.*`, `vaner.policy.show`, and
-  `vaner.deep_run.*` — advanced/diagnostic surfaces for predictions, goals,
-  artifacts, setup, policy, and Deep-Run.
-
-Memory behavior details: `docs/memory-semantics.md`.
-
-### Minimal agent loop (MCP pseudo)
-
-```python
-state = client.call("vaner.status", {})
-resolution = client.call("vaner.resolve", {"query": prompt, "budget": {"tokens": 6000}})
-reply = llm.respond(resolution["summary"], prompt)
-client.call("vaner.feedback", {"resolution_id": resolution["resolution_id"], "rating": "useful"})
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+pre-commit install
+pytest tests -m "not slow and not integration"
 ```
 
 ## Community
 
-- Contributing guide: `CONTRIBUTING.md`
-- Security policy: `SECURITY.md`
-- Governance model: `GOVERNANCE.md`
-- Maintainer roles and sensitive-resource ownership: `MAINTAINERS.md`
-- Code of conduct: `CODE_OF_CONDUCT.md`
-- Support channels: `SUPPORT.md`
-- Examples: `examples/`
-
-## OpenSSF Best Practices
-
-Vaner is preparing an OpenSSF Best Practices submission.
+- Security policy: [`SECURITY.md`](SECURITY.md)
+- Governance: [`GOVERNANCE.md`](GOVERNANCE.md) · maintainers: [`MAINTAINERS.md`](MAINTAINERS.md)
+- Code of conduct: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) · support: [`SUPPORT.md`](SUPPORT.md)
+- Examples: [`examples/`](examples/)
 
 ## License
 

--- a/docs/mcp-migration.md
+++ b/docs/mcp-migration.md
@@ -54,3 +54,20 @@ Vaner actually assembles internally, pass one or both of these flags:
 `include_metrics` is additive. Briefing and predicted-response fields are now
 included by default for parity with the daemon HTTP `/resolve` surface; callers
 that need the lean legacy shape can pass either include flag as `false`.
+
+## Full v1 tool surface
+
+The complete `vaner.*` MCP tool family at v1.0 (see [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp) for full schemas):
+
+- `vaner.status` — engine health, model, compute config, prediction metrics.
+- `vaner.suggest` — intent-priming suggestions for a draft prompt.
+- `vaner.resolve` — unified context resolution; returns evidence + briefing + predicted response.
+- `vaner.expand` — explore adjacent scenarios from an existing resolution.
+- `vaner.search` — retrieval-style fallback when `vaner.resolve` confidence is weak.
+- `vaner.explain` — rationale for a scenario's score and selection.
+- `vaner.feedback` — record `useful` / `partial` / `wrong` / `irrelevant` against a `resolution_id`.
+- `vaner.warm` — explicit precompute trigger for a scoped path or anchor.
+- `vaner.inspect` — full scenario detail (evidence, score components, prepared context).
+- `vaner.debug.trace` — diagnostic trace for integration debugging.
+
+The advanced families (`vaner.predictions.*`, `vaner.goals.*`, `vaner.artefacts.*`, `vaner.work_products.*`, `vaner.prepared_work.dashboard`, `vaner.deep_run.*`, `vaner.setup.*`, `vaner.policy.show`, `vaner.sources.status`) are documented per-page on docs.vaner.ai.

--- a/tests/test_docs/test_mcp_tool_matrix.py
+++ b/tests/test_docs/test_mcp_tool_matrix.py
@@ -48,9 +48,18 @@ def test_docs_do_not_reference_removed_mcp_tools() -> None:
 
 
 def test_mcp_v2_tools_documented() -> None:
+    """Every NEW_TOOL_NAME must be documented somewhere authoritative.
+
+    docs.vaner.ai is the canonical reference; the README is a front-door
+    only and intentionally does not enumerate the full tool surface
+    (see PR #212). We check the in-repo migration doc plus the
+    vaner-docs sibling checkout when present. CI environments that
+    don't clone vaner-docs alongside this repo can satisfy the matrix
+    via ``docs/mcp-migration.md`` alone.
+    """
+
     root = Path(__file__).resolve().parents[2]
     targets: list[Path] = [
-        root / "README.md",
         root / "docs" / "mcp-migration.md",
     ]
     docs_root = root / "vaner-docs"
@@ -58,7 +67,11 @@ def test_mcp_v2_tools_documented() -> None:
         targets.extend(docs_root.glob("content/docs/**/*.mdx"))
     content = "\n".join(path.read_text(encoding="utf-8") for path in targets if path.exists())
     missing = [name for name in sorted(NEW_TOOL_NAMES) if name not in content]
-    assert missing == []
+    assert missing == [], (
+        "Missing tool names from docs/mcp-migration.md (and vaner-docs if checked out): "
+        f"{missing}. Add them to docs/mcp-migration.md or to the appropriate page under "
+        "docs.vaner.ai (vaner-docs/content/docs/)."
+    )
 
 
 def test_source_and_docs_do_not_reference_removed_tools() -> None:
@@ -86,11 +99,19 @@ def test_source_and_docs_do_not_reference_removed_tools() -> None:
     assert violations == []
 
 
-def test_readme_init_flags_match_current_cli_surface() -> None:
+def test_readme_does_not_reference_retired_init_flags() -> None:
+    """The README must not reference flags that were removed from the CLI.
+
+    Previously this test also asserted that ``--no-mcp`` and
+    ``--interactive/--no-interactive`` were *present* in the README. The
+    README is now a front-door (see PR #212) and intentionally does not
+    enumerate every flag — that surface lives at
+    docs.vaner.ai/getting-started. We keep the negative assertions so a
+    stale flag can't sneak back in unnoticed.
+    """
+
     root = Path(__file__).resolve().parents[2]
     readme = (root / "README.md").read_text(encoding="utf-8")
 
     assert "--clients" not in readme
     assert "--accept-cloud-costs" not in readme
-    assert "--no-mcp" in readme
-    assert "--interactive/--no-interactive" in readme


### PR DESCRIPTION
## Summary

Cuts the README from 280 → 100 lines. The previous version blurred audiences (end users + contributors + integrators in the same flow), buried the quickstart 125 lines deep, duplicated the MCP tool catalog from docs.vaner.ai, and leaked managed-skill internals (`.cursor/skills/vaner/vaner-feedback/`, primer delimiters) onto the front page.

The new shape:

1. **What is Vaner** — one paragraph
2. **Install** — two paths only: desktop app for most users (link to vaner.ai), one-line CLI for power users / CI. Full install matrix → [docs.vaner.ai/getting-started](https://docs.vaner.ai/getting-started)
3. **First run** — two commands; cockpit URL printed inline
4. **Connect your AI client** — table with the three commands that actually fit on one line (Claude Code plugin, Claude Code manual, Codex CLI); every other client delegates to [docs.vaner.ai/integrations](https://docs.vaner.ai/integrations)
5. **Documentation** — index of the eight sections docs.vaner.ai hosts
6. **Contributing** — dev-setup quickstart; CONTRIBUTING.md absorbs testing/CI/DCO/PyPI
7. License + governance footer

## What dropped (moved to docs)

- Long install flag matrix (`--backend-preset`, `--compute-preset`, `--max-session-minutes`, …)
- Primer / managed-skill internals (already correct end-user behavior; the docs cover it)
- Non-interactive CI walkthrough, asciinema "coming soon" placeholder, `--minimal` flag, "not yet a `prune` command" debris
- Full MCP tool catalog + minimal-agent-loop pseudo (already in docs.vaner.ai/mcp)
- Long Cockpit prose (one sentence + link to docs.vaner.ai/cockpit)

## What's verified

- All relative links resolve (`CONTRIBUTING.md`, `SECURITY.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `examples/`, `LICENSE`, `scripts/install.sh`)
- `CONTRIBUTING.md` already covers everything cut from the README — no edits needed
- 100 lines total (target was ~120)

## Test plan

- [ ] Read the rendered README on GitHub; confirm the call-to-action structure makes sense end-to-end
- [ ] Click every external link (vaner.ai, all docs.vaner.ai/* links, modelcontextprotocol.io)
- [ ] Confirm a first-time visitor can identify "where do I install" within ~5 seconds of reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)