### PR TITLE
feat(primer): add Zed, Windsurf, Roo Code primer surfaces

### DIFF
--- a/src/vaner/cli/commands/primer.py
+++ b/src/vaner/cli/commands/primer.py
@@ -166,6 +166,22 @@ def _render_cursor_mdc(body: str, version: str) -> str:
     return frontmatter + "\n" + body.rstrip() + "\n"
 
 
+def _render_windsurf_md(body: str, version: str) -> str:
+    """Render a Windsurf ``.windsurf/rules/*.md`` rule file.
+
+    Windsurf rules use a ``trigger:`` frontmatter field with values
+    ``always_on``, ``model_decision``, ``glob``, or ``manual`` (per
+    docs.windsurf.com/windsurf/cascade/memories). We pick ``always_on``
+    so the primer is unconditionally injected, mirroring the Cursor
+    ``alwaysApply: true`` behaviour. Workspace rule files are capped at
+    12,000 chars by Windsurf — well above the canonical primer's size.
+    """
+    frontmatter = (
+        f"---\ndescription: Vaner usage primer (v={version})\ntrigger: always_on\n---\n"
+    )
+    return frontmatter + "\n" + body.rstrip() + "\n"
+
+
 # ---------------------------------------------------------------------------
 # Per-client path resolvers
 # ---------------------------------------------------------------------------
@@ -207,6 +223,32 @@ def _path_continue(repo_root: Path, scope: PrimerScope) -> Path | None:
     return repo_root / ".continue" / "rules" / "vaner.md"
 
 
+def _path_zed(repo_root: Path, scope: PrimerScope) -> Path | None:
+    """Zed auto-detects ``.rules`` (and other names) at the repo root.
+
+    See https://zed.dev/docs/ai/rules — Zed reads ``.rules``, ``AGENTS.md``,
+    ``CLAUDE.md``, ``.cursorrules``, ``.windsurfrules``, ``.clinerules``,
+    ``.github/copilot-instructions.md``, and friends. We pick ``.rules`` as
+    the Zed-native name; if the user already has e.g. ``AGENTS.md`` (because
+    Codex CLI is also configured), Zed concatenates all detected rule sources.
+    """
+    if scope != PrimerScope.REPO:
+        return None
+    return repo_root / ".rules"
+
+
+def _path_windsurf(repo_root: Path, scope: PrimerScope) -> Path | None:
+    if scope != PrimerScope.REPO:
+        return None
+    return repo_root / ".windsurf" / "rules" / "vaner.md"
+
+
+def _path_roo(repo_root: Path, scope: PrimerScope) -> Path | None:
+    if scope != PrimerScope.REPO:
+        return None
+    return repo_root / ".roo" / "rules" / "vaner.md"
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
@@ -245,6 +287,34 @@ PRIMER_SURFACES: dict[str, PrimerSurface] = {
     ),
     "continue": PrimerSurface(
         path=_path_continue,
+        render=_render_plain_block,
+        strategy="replace",
+        marker_style="html",
+    ),
+    "zed": PrimerSurface(
+        # Zed scans the repo root for any of several rule filenames;
+        # ``.rules`` is the Zed-native one. Block-merge so a user-edited
+        # ``.rules`` file is preserved outside the primer block.
+        path=_path_zed,
+        render=_render_plain_block,
+        strategy="block",
+        marker_style="html",
+    ),
+    "windsurf": PrimerSurface(
+        # ``.windsurf/rules/vaner.md`` — one file per rule, frontmatter
+        # ``trigger: always_on`` makes Cascade unconditionally inject it.
+        # Replace-strategy because the file is named for Vaner and the
+        # frontmatter is part of the contract.
+        path=_path_windsurf,
+        render=_render_windsurf_md,
+        strategy="replace",
+        marker_style="html",
+    ),
+    "roo": PrimerSurface(
+        # ``.roo/rules/vaner.md`` — Roo loads rules alphabetically and
+        # concatenates. No frontmatter / scoping is supported, so we own
+        # the whole file (replace) like Continue does.
+        path=_path_roo,
         render=_render_plain_block,
         strategy="replace",
         marker_style="html",

--- a/src/vaner/cli/commands/primer.py
+++ b/src/vaner/cli/commands/primer.py
@@ -176,9 +176,7 @@ def _render_windsurf_md(body: str, version: str) -> str:
     ``alwaysApply: true`` behaviour. Workspace rule files are capped at
     12,000 chars by Windsurf — well above the canonical primer's size.
     """
-    frontmatter = (
-        f"---\ndescription: Vaner usage primer (v={version})\ntrigger: always_on\n---\n"
-    )
+    frontmatter = f"---\ndescription: Vaner usage primer (v={version})\ntrigger: always_on\n---\n"
     return frontmatter + "\n" + body.rstrip() + "\n"
 
 

--- a/tests/test_cli/test_primer.py
+++ b/tests/test_cli/test_primer.py
@@ -197,6 +197,68 @@ def test_write_primers_writes_all_supported_clients(temp_repo):
     assert written["codex-cli"].action == "added"
     assert written["cline"].action == "added"
     assert written["continue"].action == "added"
+    assert written["zed"].action == "added"
+    assert written["windsurf"].action == "added"
+    assert written["roo"].action == "added"
+
+
+def test_write_primer_for_client_zed_writes_dot_rules(temp_repo):
+    """Zed auto-detects ``.rules`` at the repo root (alongside other names).
+
+    Block-merge so a user-edited ``.rules`` file is preserved outside the
+    primer block — the same behaviour as Claude Code's ``CLAUDE.md``.
+    """
+
+    result = write_primer_for_client("zed", temp_repo)
+    assert result.action == "added"
+    assert result.path == temp_repo / ".rules"
+    content = result.path.read_text(encoding="utf-8")
+    assert "vaner-primer:start" in content
+    assert "Using Vaner" in content
+
+
+def test_write_primer_for_client_zed_preserves_existing_rules(temp_repo):
+    rules = temp_repo / ".rules"
+    rules.write_text("# Custom Zed rules\n\nKeep this content.\n", encoding="utf-8")
+    result = write_primer_for_client("zed", temp_repo)
+    assert result.action == "added"
+    final = rules.read_text(encoding="utf-8")
+    assert final.startswith("# Custom Zed rules\n\nKeep this content.\n")
+    assert "vaner-primer:start" in final
+
+
+def test_write_primer_for_client_windsurf_uses_md_with_trigger_frontmatter(temp_repo):
+    """Windsurf rules use ``trigger: always_on`` to mirror Cursor's
+    ``alwaysApply: true`` semantics.
+    """
+
+    result = write_primer_for_client("windsurf", temp_repo)
+    assert result.action == "added"
+    assert result.path == temp_repo / ".windsurf" / "rules" / "vaner.md"
+    content = result.path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "trigger: always_on" in content
+    assert "Using Vaner" in content
+
+
+def test_write_primer_for_client_roo_writes_under_dot_roo_rules(temp_repo):
+    result = write_primer_for_client("roo", temp_repo)
+    assert result.action == "added"
+    assert result.path == temp_repo / ".roo" / "rules" / "vaner.md"
+    content = result.path.read_text(encoding="utf-8")
+    assert "Using Vaner" in content
+
+
+def test_zed_windsurf_roo_primers_are_idempotent(temp_repo):
+    """Re-running the primer install produces no diff for any of the
+    new surfaces — same guarantee the existing 6 already had."""
+
+    for client_id in ("zed", "windsurf", "roo"):
+        first = write_primer_for_client(client_id, temp_repo)
+        second = write_primer_for_client(client_id, temp_repo)
+        assert first.action == "added", f"{client_id}: first run should add"
+        assert second.action == "skipped", f"{client_id}: re-run should skip"
+        assert first.path == second.path
 
 
 def test_write_primers_user_scope_only_touches_claude_code(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Pass 4 Phase A of the IDE/agent visibility plan. Closes the highest-leverage gap from the [client capability matrix](https://docs.vaner.ai/integrations/client-capabilities): three clients support a per-project rules surface but Vaner didn't write primers for any of them.

Without the primer, the AI in those clients literally has no instruction to use Vaner — even when the MCP server is wired up correctly, the model rarely calls `vaner.*` tools on its own.

## Changes

| Client | New surface | Strategy | Mode |
| --- | --- | --- | --- |
| Zed | `.rules` | block-merge | Auto-detected alongside `AGENTS.md` / `CLAUDE.md` / `.cursorrules` / etc. |
| Windsurf | `.windsurf/rules/vaner.md` | replace | `trigger: always_on` frontmatter |
| Roo Code | `.roo/rules/vaner.md` | replace | Concatenated alphabetically with other rules |

`vaner init` enumerates `PRIMER_SURFACES.keys()`, so the new entries are picked up automatically — no other call-site changes.

## Verification

- [x] `pytest tests/test_cli/test_primer.py` — 26 passed (was 21; +5 new tests)
- [x] Each new surface tested for: write-path correctness, idempotence on re-run, content survival when the user has edited the file outside the primer block (Zed only — the other two are replace-strategy)
- [x] `test_write_primers_writes_all_supported_clients` extended to require all three new clients

## Why this matters (for reviewers)

Per the matrix, Zed/Windsurf/Roo are exactly the clients where users today have the worst experience: MCP wiring is fine, but the agent doesn't actually use Vaner. The fix is adding rules-file primers; the file format and trigger semantics are well-documented in each client's official docs (linked in the matrix page). One PR, three small additions, contained behavior change.

## What's next (out of scope here)

The full Pass 4 plan covers: a verification panel in the desktop wizard (Phase B), per-client skill/workflow/plugin shipping (Phase C), and a containerized testbed (Phase D). This PR is just Phase A.

Reference: https://docs.vaner.ai/integrations/client-capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)