### PR TITLE
feat(clients): add `vaner clients verify` for the four-layer leverage stack

### DIFF
--- a/src/vaner/cli/commands/clients.py
+++ b/src/vaner/cli/commands/clients.py
@@ -290,6 +290,103 @@ def status_cmd(
 
 
 @clients_app.command(
+    "verify",
+    help=(
+        "Report each client's leverage stack (MCP / primer / skill / plugin). "
+        "Use --format json for the desktop wizard's verification panel."
+    ),
+)
+def verify_cmd(
+    repo_root: Annotated[
+        Path | None,
+        typer.Option("--repo-root", "-C"),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option("--format", help="Output format: pretty (default), json."),
+    ] = "pretty",
+) -> None:
+    """Probe every supported client at all four leverage layers.
+
+    Layers (per docs.vaner.ai/integrations/client-capabilities):
+
+    1. MCP server — is the client's MCP config wired to Vaner?
+    2. Primer — is the per-client rules file populated with Vaner's primer?
+    3. Skill — is the ``vaner-feedback`` skill installed where supported?
+    4. Plugin — is the Vaner plugin installed where supported?
+    """
+
+    root = _resolve_repo_root(repo_root)
+    results = mcp_clients.verify_all(root)
+
+    if format == "json":
+        typer.echo(
+            json.dumps(
+                {"results": [_verification_to_dict(v) for v in results]},
+                indent=2,
+            )
+        )
+        return
+
+    if format != "pretty":
+        raise typer.BadParameter(f"unknown format {format!r}. Choose from: pretty, json")
+
+    console = Console()
+    table = Table(title="Client leverage stack", show_lines=False)
+    table.add_column("Client")
+    table.add_column("Detected")
+    table.add_column("MCP")
+    table.add_column("Primer")
+    table.add_column("Skill")
+    table.add_column("Plugin")
+    table.add_column("Status")
+
+    def _layer_cell(layer: mcp_clients.LayerStatus) -> str:
+        if not layer.applicable:
+            return "—"
+        return "✓" if layer.wired else "✗"
+
+    chip_color = {
+        "ready": "green",
+        "wired-mcp-only": "yellow",
+        "partial": "yellow",
+        "missing": "red",
+        "not-detected": "dim",
+    }
+
+    for r in results:
+        chip = f"[{chip_color.get(r.overall, 'dim')}]{r.overall}[/{chip_color.get(r.overall, 'dim')}]"
+        table.add_row(
+            r.label,
+            "yes" if r.detected else "no",
+            _layer_cell(r.layers["mcp"]),
+            _layer_cell(r.layers["primer"]),
+            _layer_cell(r.layers["skill"]),
+            _layer_cell(r.layers["plugin"]),
+            chip,
+        )
+    console.print(table)
+
+
+def _verification_to_dict(v: mcp_clients.ClientVerification) -> dict[str, object]:
+    return {
+        "client_id": v.client_id,
+        "label": v.label,
+        "detected": v.detected,
+        "overall": v.overall,
+        "layers": {
+            name: {
+                "applicable": layer.applicable,
+                "wired": layer.wired,
+                "path": str(layer.path) if layer.path is not None else None,
+                "detail": layer.detail,
+            }
+            for name, layer in v.layers.items()
+        },
+    }
+
+
+@clients_app.command(
     "doctor",
     help="Detect launcher path drift after Vaner is reinstalled / moved.",
 )

--- a/src/vaner/cli/commands/mcp_clients.py
+++ b/src/vaner/cli/commands/mcp_clients.py
@@ -691,6 +691,232 @@ def launcher_drift(detected: DetectedClient) -> LauncherDrift:
     )
 
 
+# ---------------------------------------------------------------------------
+# Verify — multi-layer leverage stack probe
+# ---------------------------------------------------------------------------
+#
+# The four layers Vaner can install into a client (per
+# docs.vaner.ai/integrations/client-capabilities):
+#
+#   1. MCP server  — universal floor; technical wiring
+#   2. Primer      — system-instruction-like rules file telling the model
+#                    when to call Vaner. Without this, the model rarely
+#                    uses Vaner even when MCP is wired.
+#   3. Skill       — agent-callable subroutine (Vaner ships ``vaner-feedback``
+#                    for clients that use the Agent Skills standard).
+#   4. Plugin      — atomic install bundle with hooks, monitors, MCP, and
+#                    skills (Vaner ships the Claude Code plugin).
+#
+# verify_all() reports per-layer status so the desktop wizard can show
+# the user a chip per client at the right depth, and so doctor flows can
+# distinguish "the AI can call Vaner" from "the AI actually will."
+
+
+@dataclass(slots=True)
+class LayerStatus:
+    """Status of a single leverage layer for one client."""
+
+    applicable: bool
+    wired: bool
+    path: Path | None = None
+    detail: str = ""
+
+
+@dataclass(slots=True)
+class ClientVerification:
+    """Per-client verification of the four-layer leverage stack."""
+
+    client_id: str
+    label: str
+    detected: bool
+    layers: dict[str, LayerStatus]
+    overall: Literal[
+        "ready",
+        "wired-mcp-only",
+        "partial",
+        "missing",
+        "not-detected",
+    ]
+
+
+# Skill-supporting clients today and the per-client SKILL.md path.
+# Vaner currently ships ``vaner-feedback`` to Claude Code and Cursor.
+# When skills land for Codex CLI, VS Code Copilot, etc. (per the
+# capability matrix), add them here.
+def _claude_code_skill_path(_repo_root: Path) -> Path:
+    return _home() / ".claude" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md"
+
+
+def _cursor_skill_path(repo_root: Path) -> Path:
+    return repo_root / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md"
+
+
+_SKILL_PATH_RESOLVERS: dict[str, Callable[[Path], Path]] = {
+    "claude-code": _claude_code_skill_path,
+    "cursor": _cursor_skill_path,
+}
+
+
+# Plugin-supporting clients today. Vaner ships a full Claude Code plugin;
+# Cursor (1.7+) supports plugins but Vaner doesn't yet ship one.
+# When the Cursor plugin lands, add it here.
+def _claude_code_plugin_marker(_repo_root: Path) -> Path:
+    """The Claude Code plugin is installed via the ``/plugin install``
+    marketplace flow, which writes to a per-user plugin store. We use
+    the user's installed-plugins manifest as a proxy. If the user
+    installed the plugin via marketplace, this file lists it.
+    """
+
+    return _home() / ".claude" / "plugins" / "vaner" / ".claude-plugin" / "plugin.json"
+
+
+_PLUGIN_PATH_RESOLVERS: dict[str, Callable[[Path], Path]] = {
+    "claude-code": _claude_code_plugin_marker,
+}
+
+
+def _verify_mcp_layer(spec: ClientSpec, repo_root: Path) -> LayerStatus:
+    """Probe layer 1 — is the client's MCP config wired to Vaner?"""
+
+    config_path = spec.config_path(repo_root)
+    if config_path is None:
+        # CLI-managed clients (Claude Code, Codex CLI) — we shell out to
+        # ``<cli> mcp list`` for the truthy answer. detect_all() already
+        # treats these as "configured" iff the CLI knows about Vaner.
+        return LayerStatus(applicable=True, wired=False, path=None, detail="cli-managed")
+
+    if spec.kind == "json-mcpServers":
+        wired = _contains_vaner_entry(config_path, container_key="mcpServers")
+    elif spec.kind == "json-servers":
+        wired = _contains_vaner_entry(config_path, container_key="servers")
+    elif spec.kind == "json-context_servers":
+        wired = _contains_vaner_entry(config_path, container_key="context_servers")
+    elif spec.kind == "yaml-continue":
+        wired = config_path.exists() and "name: vaner" in config_path.read_text(encoding="utf-8")
+    else:
+        wired = False
+    return LayerStatus(applicable=True, wired=wired, path=config_path)
+
+
+def _verify_primer_layer(client_id: str, repo_root: Path) -> LayerStatus:
+    """Probe layer 2 — does the per-client primer file exist with our block?"""
+
+    # Lazy import: vaner.cli.commands.primer pulls in primer assets.
+    from vaner.cli.commands.primer import (
+        PRIMER_BLOCK_START_PREFIX,
+        PRIMER_SURFACES,
+        PrimerScope,
+    )
+
+    surface = PRIMER_SURFACES.get(client_id)
+    if surface is None:
+        return LayerStatus(applicable=False, wired=False, path=None, detail="no primer surface")
+
+    target = surface.path(repo_root, PrimerScope.REPO)
+    if target is None or not target.exists():
+        return LayerStatus(applicable=True, wired=False, path=target, detail="not written")
+
+    text = target.read_text(encoding="utf-8")
+    if surface.strategy == "replace":
+        # Replace-strategy files are owned by Vaner; if any version of the
+        # file exists with our canonical-primer header it counts as wired.
+        wired = "Using Vaner" in text or "vaner-primer" in text
+    else:
+        wired = PRIMER_BLOCK_START_PREFIX in text
+    return LayerStatus(applicable=True, wired=wired, path=target)
+
+
+def _verify_skill_layer(client_id: str, repo_root: Path) -> LayerStatus:
+    """Probe layer 3 — is the vaner-feedback skill installed?"""
+
+    resolver = _SKILL_PATH_RESOLVERS.get(client_id)
+    if resolver is None:
+        return LayerStatus(applicable=False, wired=False, path=None, detail="no skill surface")
+    target = resolver(repo_root)
+    return LayerStatus(applicable=True, wired=target.exists(), path=target)
+
+
+def _verify_plugin_layer(client_id: str, repo_root: Path) -> LayerStatus:
+    """Probe layer 4 — is the Vaner plugin installed?"""
+
+    resolver = _PLUGIN_PATH_RESOLVERS.get(client_id)
+    if resolver is None:
+        return LayerStatus(applicable=False, wired=False, path=None, detail="no plugin surface")
+    target = resolver(repo_root)
+    return LayerStatus(applicable=True, wired=target.exists(), path=target)
+
+
+def _compute_overall_status(
+    detected: bool,
+    layers: dict[str, LayerStatus],
+) -> Literal["ready", "wired-mcp-only", "partial", "missing", "not-detected"]:
+    """Boil per-layer results into a single chip color for the wizard.
+
+    ``ready``           — every applicable layer is wired
+    ``wired-mcp-only``  — MCP is wired but at least one higher applicable
+                          layer is missing (the "AI probably won't use Vaner"
+                          failure mode)
+    ``partial``         — some layers wired, some not (often a re-install
+                          regression)
+    ``missing``         — detected but Vaner not wired at all
+    ``not-detected``    — client not installed on this machine
+    """
+
+    if not detected:
+        return "not-detected"
+    applicable = {name: s for name, s in layers.items() if s.applicable}
+    wired_names = [name for name, s in applicable.items() if s.wired]
+    if not wired_names:
+        return "missing"
+    if len(wired_names) == len(applicable):
+        return "ready"
+    if wired_names == ["mcp"]:
+        return "wired-mcp-only"
+    return "partial"
+
+
+def verify_all(repo_root: Path | None = None) -> list[ClientVerification]:
+    """Probe every supported MCP client at all four leverage layers.
+
+    Returns one ``ClientVerification`` per registered client, with status
+    chips the desktop wizard or doctor flow can render directly.
+    """
+
+    root = repo_root or Path.cwd()
+    detected_by_id = {d.spec.id: d for d in detect_all(root)}
+    out: list[ClientVerification] = []
+    for spec in CLIENTS:
+        detected_entry = detected_by_id.get(spec.id)
+        detected = detected_entry is not None and detected_entry.status != ClientStatus.MISSING
+
+        # MCP layer: prefer detect_all's CONFIGURED flag for CLI-managed
+        # clients (Claude Code / Codex CLI), since their MCP wiring lives
+        # outside any file we own.
+        if spec.kind in ("cli-claude", "cli-codex"):
+            mcp = LayerStatus(
+                applicable=True,
+                wired=detected_entry is not None and detected_entry.status == ClientStatus.CONFIGURED,
+                path=None,
+                detail="cli-managed",
+            )
+        else:
+            mcp = _verify_mcp_layer(spec, root)
+        primer = _verify_primer_layer(spec.id, root)
+        skill = _verify_skill_layer(spec.id, root)
+        plugin = _verify_plugin_layer(spec.id, root)
+        layers = {"mcp": mcp, "primer": primer, "skill": skill, "plugin": plugin}
+        out.append(
+            ClientVerification(
+                client_id=spec.id,
+                label=spec.label,
+                detected=detected,
+                layers=layers,
+                overall=_compute_overall_status(detected, layers),
+            )
+        )
+    return out
+
+
 def print_other_client_help(launcher_cmd: str, launcher_args: list[str]) -> str:
     snippet = generic_snippet(launcher_cmd, launcher_args)
     lines = [

--- a/tests/test_cli/test_clients_subcommand.py
+++ b/tests/test_cli/test_clients_subcommand.py
@@ -369,7 +369,8 @@ def test_verify_marks_zed_primer_applicable(fake_home: Path, tmp_path: Path) -> 
 
 
 def test_verify_marks_skill_layer_inapplicable_when_no_skill_surface(
-    fake_home: Path, tmp_path: Path,
+    fake_home: Path,
+    tmp_path: Path,
 ) -> None:
     """Skill is only applicable for the clients Vaner ships a skill into
     today (claude-code, cursor). Everywhere else the layer is reported

--- a/tests/test_cli/test_clients_subcommand.py
+++ b/tests/test_cli/test_clients_subcommand.py
@@ -325,6 +325,85 @@ def test_doctor_detects_launcher_drift(fake_home: Path, tmp_path: Path, monkeypa
 
 
 # ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+def test_verify_json_returns_per_layer_status_for_every_client(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        clients_app,
+        ["verify", "--repo-root", str(repo), "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ids = {r["client_id"] for r in payload["results"]}
+    # The full registry of supported clients shows up.
+    assert {"claude-code", "cursor", "zed", "windsurf", "roo"}.issubset(ids)
+    # Every entry exposes the four layers, even when "applicable" is False.
+    for r in payload["results"]:
+        assert set(r["layers"].keys()) == {"mcp", "primer", "skill", "plugin"}
+        assert r["overall"] in {"ready", "wired-mcp-only", "partial", "missing", "not-detected"}
+
+
+def test_verify_marks_zed_primer_applicable(fake_home: Path, tmp_path: Path) -> None:
+    """Zed is one of the three primer clients added in the recent
+    PR (Phase A). The verify surface must report primer.applicable=true
+    so the desktop wizard knows the layer is reachable here.
+    """
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        clients_app,
+        ["verify", "--repo-root", str(repo), "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    zed = next(r for r in payload["results"] if r["client_id"] == "zed")
+    assert zed["layers"]["primer"]["applicable"] is True
+    # No primer file written → wired=False, expected path is .rules.
+    assert zed["layers"]["primer"]["wired"] is False
+    assert zed["layers"]["primer"]["path"].endswith("/.rules")
+
+
+def test_verify_marks_skill_layer_inapplicable_when_no_skill_surface(
+    fake_home: Path, tmp_path: Path,
+) -> None:
+    """Skill is only applicable for the clients Vaner ships a skill into
+    today (claude-code, cursor). Everywhere else the layer is reported
+    as ``applicable=False`` so the wizard hides the chip.
+    """
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        clients_app,
+        ["verify", "--repo-root", str(repo), "--format", "json"],
+    )
+    payload = json.loads(result.output)
+    by_id = {r["client_id"]: r for r in payload["results"]}
+    assert by_id["zed"]["layers"]["skill"]["applicable"] is False
+    assert by_id["windsurf"]["layers"]["skill"]["applicable"] is False
+    assert by_id["claude-code"]["layers"]["skill"]["applicable"] is True
+    assert by_id["cursor"]["layers"]["skill"]["applicable"] is True
+
+
+def test_verify_pretty_format_emits_table(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        clients_app,
+        ["verify", "--repo-root", str(repo), "--format", "pretty"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Client leverage stack" in result.output
+    assert "MCP" in result.output
+    assert "Primer" in result.output
+
+
+# ---------------------------------------------------------------------------
 # Top-level command registration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase B of the IDE/agent visibility plan. Adds `vaner clients verify --format json` that probes every supported MCP client at all four leverage layers and reports a single per-client status the desktop wizard's final-slide verification panel can render directly.

The four layers (per [the capability matrix](https://docs.vaner.ai/integrations/client-capabilities)):

1. **MCP server** — universal floor; technical wiring
2. **Primer** — system-instruction-like rules file
3. **Skill** — agent-callable subroutine (\`vaner-feedback\`)
4. **Plugin** — atomic install bundle with hooks

Per-client overall status:

- 🟢 **ready** — every applicable layer wired
- 🟡 **wired-mcp-only** — MCP wired but a higher applicable layer isn't (the failure mode where the AI can call Vaner but usually doesn't)
- 🟠 **partial** — some applicable layers wired, some not
- 🔴 **missing** — detected but Vaner not wired at all
- ⚪ **not-detected** — client not installed

## Implementation

- \`mcp_clients.verify_all(repo_root)\` — pure function returning one \`ClientVerification\` per registered client.
- MCP probe reuses existing \`_contains_vaner_entry\`.
- Primer probe imports \`PRIMER_SURFACES\` (Phase A added Zed/Windsurf/Roo) and looks for either the primer block markers or the replace-strategy "Using Vaner" header.
- Skill probe — Claude Code (\`~/.claude/skills/vaner/...\`) and Cursor (\`.cursor/skills/vaner/...\`). Other clients reported as \`applicable=False\` until Vaner ships skills there.
- Plugin probe — Claude Code only today. Cursor 1.7+ supports plugins but Vaner doesn't ship one yet — tracked in Pass 4 Phase C.
- \`vaner clients verify --format json\` for the desktop wizard.
- \`vaner clients verify --format pretty\` renders a Rich table.

## Test plan

- [x] 4 new test cases under \`test_clients_subcommand.py\`
- [x] All 20 existing tests in that file still pass
- [x] \`ruff check\` + \`ruff format --check\` clean

## Companion PR

The matching desktop-side PR opens against \`vaner-desktop\` (separate repo) and adds:
- \`clients_verify\` Tauri command (shells out to this CLI subcommand)
- \`WizardVerificationPanel.svelte\` component
- Wires into the wizard's final \"Vaner is ready\" slide

Reference: https://docs.vaner.ai/integrations/client-capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)