### PR TITLE
feat(skills): per-client skill/workflow/prompt installer for 7 clients

### DIFF
--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -69,6 +69,7 @@ from vaner.cli.commands.primer import PRIMER_SURFACES, write_primers
 from vaner.cli.commands.profile import export_pins, import_pins, pin_fact, profile_show, unpin_fact
 from vaner.cli.commands.runtime_snapshot import runtime_snapshot
 from vaner.cli.commands.setup import setup_app
+from vaner.cli.commands.skills import SKILL_SURFACES, write_skills
 from vaner.cli.commands.supervisor import run_down, run_up
 from vaner.daemon.http import create_daemon_http_app
 from vaner.daemon.preflight import check_repo_root
@@ -550,6 +551,29 @@ def init(
                 typer.echo(f"Warning: could not write primer for {r.client_id}: {r.error}")
         except Exception as exc:  # pragma: no cover - defensive
             typer.echo(f"Warning: could not install primers: {exc}")
+
+        # Skills layer — vaner-feedback per-client adapter (layer 3 of the
+        # leverage stack documented at docs.vaner.ai/integrations/
+        # client-capabilities). Each surface emits the skill in the
+        # client's native idiom (Agent Skills standard for claude-code /
+        # cursor / codex-cli; Continue prompt; Cline/Windsurf workflow;
+        # Roo slash command).
+        try:
+            skill_clients = sorted(SKILL_SURFACES.keys())
+            skill_results = write_skills(skill_clients, repo_root)
+            installed = [r for r in skill_results if r.action in ("added", "updated")]
+            skipped = [r for r in skill_results if r.action == "skipped"]
+            failed = [r for r in skill_results if r.action == "failed"]
+            if installed:
+                typer.echo("Installed vaner-feedback skills / workflows / prompts:")
+                for r in installed:
+                    typer.echo(f"  - {r.path} ({r.action})")
+            if skipped:
+                typer.echo(f"Skill already up to date for {len(skipped)} client(s); no changes needed.")
+            for r in failed:
+                typer.echo(f"Warning: could not write skill for {r.client_id}: {r.error}")
+        except Exception as exc:  # pragma: no cover - defensive
+            typer.echo(f"Warning: could not install skills: {exc}")
 
     import sys as _sys
 

--- a/src/vaner/cli/commands/init.py
+++ b/src/vaner/cli/commands/init.py
@@ -144,21 +144,15 @@ def init_repo(repo_root: Path) -> Path:
     return config_path
 
 
-def _default_vaner_feedback_skill() -> str:
-    packaged = Path(__file__).resolve().parents[2] / "defaults" / "skills" / "vaner-feedback" / "SKILL.md"
-    if packaged.exists():
-        return packaged.read_text(encoding="utf-8")
-    return "Report scenario outcomes back to Vaner after completing a task.\n"
-
-
-def _write_managed_skill(base_dir: Path, content: str) -> Path:
-    skill_path = base_dir / "skills" / "vaner" / "vaner-feedback" / "SKILL.md"
-    skill_path.parent.mkdir(parents=True, exist_ok=True)
-    skill_path.write_text(content, encoding="utf-8")
-    return skill_path
-
-
 def write_mcp_configs(repo_root: Path) -> tuple[list[Path], str]:
+    """Write Cursor's MCP config to ``.cursor/mcp.json``.
+
+    Skill writing was moved to :mod:`vaner.cli.commands.skills` in
+    Phase C of the IDE/agent visibility plan — that module ships the
+    ``vaner-feedback`` skill into the right surface for every client
+    Vaner supports (not just Cursor + Claude Code).
+    """
+
     launcher = shutil.which("vaner") or "vaner"
     args = ["mcp", "--path", str(repo_root)]
     payload = {"mcpServers": {"vaner": {"command": launcher, "args": args}}}
@@ -167,12 +161,7 @@ def write_mcp_configs(repo_root: Path) -> tuple[list[Path], str]:
     cursor_path.parent.mkdir(parents=True, exist_ok=True)
     cursor_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
-    skill_content = _default_vaner_feedback_skill()
-    repo_skill_path = _write_managed_skill(repo_root / ".cursor", skill_content)
-    claude_skill_path = _write_managed_skill(Path.home() / ".claude", skill_content)
-
-    written_paths = [cursor_path, repo_skill_path, claude_skill_path]
-    return written_paths, launcher
+    return [cursor_path], launcher
 
 
 @dataclass(slots=True)

--- a/src/vaner/cli/commands/mcp_clients.py
+++ b/src/vaner/cli/commands/mcp_clients.py
@@ -739,10 +739,11 @@ class ClientVerification:
     ]
 
 
-# Skill-supporting clients today and the per-client SKILL.md path.
-# Vaner currently ships ``vaner-feedback`` to Claude Code and Cursor.
-# When skills land for Codex CLI, VS Code Copilot, etc. (per the
-# capability matrix), add them here.
+# Skill-supporting clients today and the per-client skill-file path.
+# Mirrors :data:`vaner.cli.commands.skills.SKILL_SURFACES`. We can't import
+# from skills.py directly because that module imports from this file
+# transitively via the CLI entry; the resolvers here are kept in lock-step
+# manually.
 def _claude_code_skill_path(_repo_root: Path) -> Path:
     return _home() / ".claude" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md"
 
@@ -751,9 +752,34 @@ def _cursor_skill_path(repo_root: Path) -> Path:
     return repo_root / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md"
 
 
+def _codex_cli_skill_path(_repo_root: Path) -> Path:
+    return _home() / ".codex" / "skills" / "vaner-feedback" / "SKILL.md"
+
+
+def _continue_prompt_path(repo_root: Path) -> Path:
+    return repo_root / ".continue" / "prompts" / "vaner-feedback.md"
+
+
+def _cline_workflow_path(repo_root: Path) -> Path:
+    return repo_root / ".clinerules" / "workflows" / "vaner-feedback.md"
+
+
+def _windsurf_workflow_path(repo_root: Path) -> Path:
+    return repo_root / ".windsurf" / "workflows" / "vaner-feedback.md"
+
+
+def _roo_slash_command_path(repo_root: Path) -> Path:
+    return repo_root / ".roo" / "commands" / "vaner-feedback.md"
+
+
 _SKILL_PATH_RESOLVERS: dict[str, Callable[[Path], Path]] = {
     "claude-code": _claude_code_skill_path,
     "cursor": _cursor_skill_path,
+    "codex-cli": _codex_cli_skill_path,
+    "continue": _continue_prompt_path,
+    "cline": _cline_workflow_path,
+    "windsurf": _windsurf_workflow_path,
+    "roo": _roo_slash_command_path,
 }
 
 

--- a/src/vaner/cli/commands/skills.py
+++ b/src/vaner/cli/commands/skills.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Skill / workflow / prompt installer per MCP client.
+
+Layer 3 of the four-layer leverage stack documented at
+docs.vaner.ai/integrations/client-capabilities. Mirrors the design of
+:mod:`vaner.cli.commands.primer`: a per-client surface with a path
+resolver and a render function, plus a non-destructive writer.
+
+Why per-client adapters instead of one canonical file
+-----------------------------------------------------
+The clients converge on the *idea* of "agent-callable subroutine" but
+diverge on:
+
+* **File location** — ``~/.claude/skills/...``, ``.cursor/skills/...``,
+  ``~/.codex/skills/...``, ``.continue/prompts/...``,
+  ``.clinerules/workflows/...``, ``.windsurf/workflows/...``,
+  ``.roo/commands/...``.
+* **File format** — Agent Skills (Claude Code, Cursor, Codex CLI, VS
+  Code 1.108+) all share the ``SKILL.md + frontmatter`` standard.
+  Continue uses prompts (``.md`` + ``invokable: true`` frontmatter).
+  Cline + Windsurf use workflows (filename-as-command markdown).
+  Roo uses slash commands (markdown + ``description`` frontmatter,
+  agent-invocable via the ``run_slash_command`` tool).
+* **Invocation model** — Agent-Skills clients auto-load by metadata
+  match. Continue/Cline/Windsurf are user-invoked only. Roo can be
+  agent-invoked via ``run_slash_command``.
+
+So we ship the same essential body (when to feedback, how to call
+``vaner.feedback``) and adapt the wrapping per client.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal
+
+SkillAction = Literal["added", "updated", "skipped", "unsupported", "failed"]
+
+SKILL_NAME = "vaner-feedback"
+SKILL_DESCRIPTION = "Report scenario outcomes back to Vaner after completing a task."
+
+
+class SkillScope(StrEnum):
+    """Where the skill file lives relative to the user."""
+
+    REPO = "repo"
+    USER = "user"
+
+
+@dataclass(slots=True)
+class SkillResult:
+    """Outcome of a single per-client skill write."""
+
+    client_id: str
+    scope: SkillScope
+    path: Path | None
+    action: SkillAction
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SkillSurface:
+    """Declarative description of where and how to write a client's skill."""
+
+    # Resolves the target file for a scope, or None if not supported.
+    path: Callable[[Path, SkillScope], Path | None]
+    # Renders the canonical skill body (without frontmatter) into the
+    # file's native format.
+    render: Callable[[str, str], str]  # (body, version) -> full file content
+
+
+# ---------------------------------------------------------------------------
+# Canonical skill source — read once, cached
+# ---------------------------------------------------------------------------
+
+
+_PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+_CANONICAL_SKILL_PATH = _PACKAGE_ROOT / "defaults" / "skills" / "vaner-feedback" / "SKILL.md"
+
+_FRONTMATTER_RE = re.compile(r"^---\n.*?\n---\n", flags=re.DOTALL)
+
+
+def load_canonical_skill_body() -> str:
+    """Strip the canonical SKILL.md's frontmatter, leaving just the body.
+
+    The Agent-Skills frontmatter (``name``, ``description``, ``tags``,
+    ``vaner:``, ``x-vaner-managed``) is the contract Claude Code /
+    Cursor / Codex CLI honor; other clients want a different
+    frontmatter shape, so each renderer assembles their own.
+    """
+
+    text = _CANONICAL_SKILL_PATH.read_text(encoding="utf-8")
+    return _FRONTMATTER_RE.sub("", text, count=1).lstrip()
+
+
+def load_canonical_skill_full() -> str:
+    """Return the full canonical SKILL.md including its Agent-Skills
+    frontmatter — used unmodified for Claude Code, Cursor, Codex CLI."""
+
+    return _CANONICAL_SKILL_PATH.read_text(encoding="utf-8")
+
+
+def skill_version() -> str:
+    """Track ``vaner.__version__`` so re-installs after upgrade refresh."""
+
+    try:
+        from vaner import __version__
+
+        return str(__version__)
+    except Exception:  # pragma: no cover - defensive
+        return "0"
+
+
+def _home() -> Path:
+    return Path.home()
+
+
+# ---------------------------------------------------------------------------
+# Per-client render functions
+# ---------------------------------------------------------------------------
+
+
+def _render_agent_skill_md(_body: str, _version: str) -> str:
+    """Claude Code / Cursor / Codex CLI — drop the canonical SKILL.md
+    in unchanged. The Agent Skills frontmatter is the same standard
+    across all three.
+
+    ``_body`` and ``_version`` are accepted for signature parity with
+    other renders but ignored — the canonical file already includes the
+    full frontmatter.
+    """
+
+    return load_canonical_skill_full()
+
+
+def _render_continue_prompt(body: str, version: str) -> str:
+    """Continue ``.continue/prompts/<name>.md`` format.
+
+    Continue prompts are user-invoked via ``/<name>`` in chat. The
+    ``invokable: true`` flag is what makes the file appear as a slash
+    command (see docs.continue.dev/customize/deep-dives/prompts).
+    """
+
+    frontmatter = f"---\nname: {SKILL_NAME}\ndescription: {SKILL_DESCRIPTION}\ninvokable: true\nx-vaner-managed: true v={version}\n---\n"
+    return frontmatter + "\n" + body.rstrip() + "\n"
+
+
+def _render_cline_workflow(body: str, version: str) -> str:
+    """Cline workflow at ``.clinerules/workflows/<filename>.md``.
+
+    The filename becomes the slash command (``/vaner-feedback.md`` →
+    ``/vaner-feedback``). No formal frontmatter is required; we add a
+    delimited header so re-runs can detect ownership.
+    """
+
+    title = f"# Vaner feedback (v={version})"
+    header = f"<!-- x-vaner-managed: true v={version} -->\n{title}\n\n{SKILL_DESCRIPTION}\n"
+    return header + "\n" + body.rstrip() + "\n"
+
+
+def _render_windsurf_workflow(body: str, version: str) -> str:
+    """Windsurf workflow at ``.windsurf/workflows/<name>.md``.
+
+    Workflows are user-invoked from the Cascade panel (per
+    docs.windsurf.com/windsurf/cascade/workflows). Windsurf renders the
+    first ``# heading`` as the workflow title; we put the description on
+    line 2 followed by the canonical body.
+    """
+
+    title = "# Vaner feedback"
+    header = f"<!-- x-vaner-managed: true v={version} -->\n{title}\n\n{SKILL_DESCRIPTION}\n"
+    return header + "\n" + body.rstrip() + "\n"
+
+
+def _render_roo_slash_command(body: str, version: str) -> str:
+    """Roo Code slash command at ``.roo/commands/<name>.md``.
+
+    Frontmatter ``description`` populates the command palette; Roo's
+    ``run_slash_command`` tool means the agent itself can invoke this
+    programmatically (see docs.roocode.com/advanced-usage/available-tools/
+    run-slash-command). That makes Roo the only manual-format client
+    where Vaner gets agent-driven invocation back.
+    """
+
+    frontmatter = f"---\ndescription: {SKILL_DESCRIPTION}\nx-vaner-managed: true v={version}\n---\n"
+    return frontmatter + "\n" + body.rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Per-client path resolvers
+# ---------------------------------------------------------------------------
+
+
+def _path_claude_code(_repo_root: Path, scope: SkillScope) -> Path | None:
+    if scope != SkillScope.USER:
+        # Claude Code skills are user-scoped by convention; the project
+        # could place them at ``.claude/skills/`` too but the user-level
+        # path is the more reliable surface, so we ship there.
+        return None
+    return _home() / ".claude" / "skills" / "vaner" / SKILL_NAME / "SKILL.md"
+
+
+def _path_cursor(repo_root: Path, scope: SkillScope) -> Path | None:
+    if scope != SkillScope.REPO:
+        return None
+    return repo_root / ".cursor" / "skills" / "vaner" / SKILL_NAME / "SKILL.md"
+
+
+def _path_codex_cli(_repo_root: Path, scope: SkillScope) -> Path | None:
+    if scope != SkillScope.USER:
+        # Codex CLI also accepts ``.codex/skills/`` per-repo; we ship to
+        # ``~/.codex/skills/`` so the skill is available across every repo
+        # (Codex is typically used from any cwd).
+        return None
+    return _home() / ".codex" / "skills" / SKILL_NAME / "SKILL.md"
+
+
+def _path_continue(repo_root: Path, scope: SkillScope) -> Path | None:
+    if scope != SkillScope.REPO:
+        return None
+    return repo_root / ".continue" / "prompts" / f"{SKILL_NAME}.md"
+
+
+def _path_cline(repo_root: Path, scope: SkillScope) -> Path | None:
+    if scope != SkillScope.REPO:
+        return None
+    return repo_root / ".clinerules" / "workflows" / f"{SKILL_NAME}.md"
+
+
+def _path_windsurf(repo_root: Path, scope: SkillScope) -> Path | None:
+    if scope != SkillScope.REPO:
+        return None
+    return repo_root / ".windsurf" / "workflows" / f"{SKILL_NAME}.md"
+
+
+def _path_roo(repo_root: Path, scope: SkillScope) -> Path | None:
+    if scope != SkillScope.REPO:
+        return None
+    return repo_root / ".roo" / "commands" / f"{SKILL_NAME}.md"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+SKILL_SURFACES: dict[str, SkillSurface] = {
+    "claude-code": SkillSurface(path=_path_claude_code, render=_render_agent_skill_md),
+    "cursor": SkillSurface(path=_path_cursor, render=_render_agent_skill_md),
+    "codex-cli": SkillSurface(path=_path_codex_cli, render=_render_agent_skill_md),
+    "continue": SkillSurface(path=_path_continue, render=_render_continue_prompt),
+    "cline": SkillSurface(path=_path_cline, render=_render_cline_workflow),
+    "windsurf": SkillSurface(path=_path_windsurf, render=_render_windsurf_workflow),
+    "roo": SkillSurface(path=_path_roo, render=_render_roo_slash_command),
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-client writer
+# ---------------------------------------------------------------------------
+
+
+def _default_scope(client_id: str) -> SkillScope:
+    """Each client's "preferred" scope.
+
+    Claude Code and Codex CLI ship to the user dir so the skill is
+    available in any repo. Everyone else writes per-repo.
+    """
+
+    return SkillScope.USER if client_id in {"claude-code", "codex-cli"} else SkillScope.REPO
+
+
+def write_skill_for_client(
+    client_id: str,
+    repo_root: Path,
+    *,
+    scope: SkillScope | None = None,
+    body: str | None = None,
+    version: str | None = None,
+    dry_run: bool = False,
+) -> SkillResult:
+    """Write the Vaner skill into ``client_id``'s native surface.
+
+    Idempotent: identical-content writes report ``skipped``. The
+    rendered file is owned end-to-end by Vaner — there is no merge
+    primitive here (unlike primers), since each skill file is named for
+    Vaner and is not expected to be edited by the user.
+    """
+
+    surface = SKILL_SURFACES.get(client_id)
+    if surface is None:
+        return SkillResult(
+            client_id=client_id,
+            scope=scope or SkillScope.REPO,
+            path=None,
+            action="unsupported",
+        )
+
+    resolved_scope = scope or _default_scope(client_id)
+    target = surface.path(repo_root, resolved_scope)
+    if target is None:
+        return SkillResult(
+            client_id=client_id,
+            scope=resolved_scope,
+            path=None,
+            action="unsupported",
+        )
+
+    resolved_body = body if body is not None else load_canonical_skill_body()
+    resolved_version = version or skill_version()
+    rendered = surface.render(resolved_body, resolved_version)
+
+    try:
+        existing = target.read_text(encoding="utf-8") if target.exists() else ""
+    except OSError as exc:
+        return SkillResult(
+            client_id=client_id,
+            scope=resolved_scope,
+            path=target,
+            action="failed",
+            error=str(exc),
+        )
+
+    if existing == rendered:
+        return SkillResult(client_id=client_id, scope=resolved_scope, path=target, action="skipped")
+
+    action: SkillAction = "updated" if existing else "added"
+    if dry_run:
+        return SkillResult(client_id=client_id, scope=resolved_scope, path=target, action=action)
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(rendered, encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - defensive I/O guard
+        return SkillResult(
+            client_id=client_id,
+            scope=resolved_scope,
+            path=target,
+            action="failed",
+            error=str(exc),
+        )
+    return SkillResult(client_id=client_id, scope=resolved_scope, path=target, action=action)
+
+
+def write_skills(
+    client_ids: list[str],
+    repo_root: Path,
+    *,
+    dry_run: bool = False,
+) -> list[SkillResult]:
+    """Write the skill for each client in ``client_ids``.
+
+    Each surface's preferred scope is used (claude-code and codex-cli
+    write to the user dir; everyone else writes per-repo).
+    """
+
+    body = load_canonical_skill_body()
+    version = skill_version()
+    results: list[SkillResult] = []
+    for client_id in client_ids:
+        results.append(
+            write_skill_for_client(
+                client_id,
+                repo_root,
+                body=body,
+                version=version,
+                dry_run=dry_run,
+            )
+        )
+    return results

--- a/tests/test_cli/test_clients_subcommand.py
+++ b/tests/test_cli/test_clients_subcommand.py
@@ -368,13 +368,15 @@ def test_verify_marks_zed_primer_applicable(fake_home: Path, tmp_path: Path) -> 
     assert zed["layers"]["primer"]["path"].endswith("/.rules")
 
 
-def test_verify_marks_skill_layer_inapplicable_when_no_skill_surface(
+def test_verify_marks_skill_layer_inapplicable_for_zed_and_claude_desktop(
     fake_home: Path,
     tmp_path: Path,
 ) -> None:
-    """Skill is only applicable for the clients Vaner ships a skill into
-    today (claude-code, cursor). Everywhere else the layer is reported
-    as ``applicable=False`` so the wizard hides the chip.
+    """The skill layer is applicable wherever Vaner ships a vaner-feedback
+    surface today. After Phase C, that's claude-code, cursor, codex-cli,
+    continue, cline, windsurf, roo. The two genuine non-skill clients
+    are Zed (no skill abstraction) and Claude Desktop (cloud-only, no
+    local-disk integration). Those two stay ``applicable=False``.
     """
 
     repo = tmp_path / "repo"
@@ -385,10 +387,17 @@ def test_verify_marks_skill_layer_inapplicable_when_no_skill_surface(
     )
     payload = json.loads(result.output)
     by_id = {r["client_id"]: r for r in payload["results"]}
+    # Genuinely non-applicable per the capability matrix.
     assert by_id["zed"]["layers"]["skill"]["applicable"] is False
-    assert by_id["windsurf"]["layers"]["skill"]["applicable"] is False
+    assert by_id["claude-desktop"]["layers"]["skill"]["applicable"] is False
+    # Phase C: Vaner now ships skill/workflow/prompt surfaces for these.
     assert by_id["claude-code"]["layers"]["skill"]["applicable"] is True
     assert by_id["cursor"]["layers"]["skill"]["applicable"] is True
+    assert by_id["codex-cli"]["layers"]["skill"]["applicable"] is True
+    assert by_id["continue"]["layers"]["skill"]["applicable"] is True
+    assert by_id["cline"]["layers"]["skill"]["applicable"] is True
+    assert by_id["windsurf"]["layers"]["skill"]["applicable"] is True
+    assert by_id["roo"]["layers"]["skill"]["applicable"] is True
 
 
 def test_verify_pretty_format_emits_table(fake_home: Path, tmp_path: Path) -> None:

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -25,13 +25,26 @@ def test_init_creates_config(temp_repo):
 
 
 def test_init_writes_managed_feedback_skill(temp_repo, monkeypatch):
+    """Phase C: skill writes moved out of ``write_mcp_configs`` into the
+    dedicated :mod:`vaner.cli.commands.skills` module. The skills are
+    now installed by ``write_skills`` (called from ``vaner init``)
+    rather than the MCP-config writer.
+    """
+
+    from vaner.cli.commands.skills import SKILL_SURFACES, write_skills
+
     fake_home = temp_repo / "home"
     fake_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
-    write_mcp_configs(temp_repo)
+    results = write_skills(sorted(SKILL_SURFACES.keys()), temp_repo)
+    by_id = {r.client_id: r for r in results}
+    # The two surfaces this test originally guarded — Cursor (repo) and
+    # Claude Code (user) — must still get written.
     assert (temp_repo / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md").exists()
     assert (fake_home / ".claude" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md").exists()
+    assert by_id["cursor"].action == "added"
+    assert by_id["claude-code"].action == "added"
 
 
 def test_write_mcp_configs_prefers_absolute_vaner_binary(temp_repo, monkeypatch):
@@ -48,12 +61,20 @@ def test_write_mcp_configs_prefers_absolute_vaner_binary(temp_repo, monkeypatch)
 
 
 def test_write_mcp_configs_writes_single_current_feedback_skill(temp_repo, monkeypatch):
+    """Phase C: the skill content is now produced by the dedicated
+    skills module. This test still guards the *content* of the skill
+    that lands at the Cursor location — Agent Skills frontmatter
+    delimiters, current MCP tool names, no legacy tool references.
+    """
+
+    from vaner.cli.commands.skills import write_skill_for_client
+
     fake_home = temp_repo / "home"
     fake_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
 
-    write_mcp_configs(temp_repo)
+    write_skill_for_client("cursor", temp_repo)
     repo_skill = (temp_repo / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md").read_text(encoding="utf-8")
 
     assert repo_skill.count("---") == 2

--- a/tests/test_cli/test_skills.py
+++ b/tests/test_cli/test_skills.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the per-client skill installer (Phase C of the IDE/agent
+visibility plan).
+
+The canonical skill body lives at
+``src/vaner/defaults/skills/vaner-feedback/SKILL.md``; per-client
+adapters in ``vaner.cli.commands.skills`` ship it into the right place
+in the right format for each client. This file exercises:
+
+* every supported client's path resolver returns the documented location
+* render output is non-empty, idempotent, and stable across reruns
+* clients with frontmatter (continue, roo) emit the right keys
+* the writer is non-destructive when content is identical (skipped)
+* the user-scope surfaces (claude-code, codex-cli) honor a stubbed home
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vaner.cli.commands.skills import (
+    SKILL_SURFACES,
+    SkillScope,
+    load_canonical_skill_body,
+    skill_version,
+    write_skill_for_client,
+    write_skills,
+)
+
+# ---------------------------------------------------------------------------
+# Canonical body loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_canonical_skill_body_strips_frontmatter() -> None:
+    body = load_canonical_skill_body()
+    # The shipped SKILL.md starts with YAML frontmatter; the body
+    # loader must strip it.
+    assert not body.startswith("---")
+    # The body keeps the actual instruction text.
+    assert "vaner.feedback" in body
+    assert "resolution_id" in body
+
+
+def test_skill_version_is_non_empty() -> None:
+    assert skill_version()
+
+
+# ---------------------------------------------------------------------------
+# Per-client writer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin Path.home() to tmp_path/home for user-scope skill tests."""
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    return home
+
+
+def test_write_skill_claude_code_user_scope(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("claude-code", repo)
+    assert result.action == "added"
+    assert result.scope == SkillScope.USER
+    assert result.path == fake_home / ".claude" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md"
+    content = result.path.read_text(encoding="utf-8")
+    # Agent Skills frontmatter is preserved (claude-code uses the
+    # canonical SKILL.md unchanged).
+    assert content.startswith("---\n")
+    assert "name: vaner-feedback" in content
+
+
+def test_write_skill_cursor_repo_scope(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("cursor", repo)
+    assert result.action == "added"
+    assert result.scope == SkillScope.REPO
+    assert result.path == repo / ".cursor" / "skills" / "vaner" / "vaner-feedback" / "SKILL.md"
+    content = result.path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "name: vaner-feedback" in content
+
+
+def test_write_skill_codex_cli_user_scope(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("codex-cli", repo)
+    assert result.action == "added"
+    assert result.scope == SkillScope.USER
+    # Codex CLI uses ``~/.codex/skills/<name>/SKILL.md`` (no extra
+    # vaner-namespace dir).
+    assert result.path == fake_home / ".codex" / "skills" / "vaner-feedback" / "SKILL.md"
+    content = result.path.read_text(encoding="utf-8")
+    # Same Agent Skills standard body as Claude Code / Cursor.
+    assert "name: vaner-feedback" in content
+
+
+def test_write_skill_continue_uses_invokable_prompt_format(tmp_path: Path) -> None:
+    """Continue prompts are user-invoked via ``/<name>``; the
+    ``invokable: true`` flag in frontmatter is what makes the file
+    appear as a slash command."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("continue", repo)
+    assert result.action == "added"
+    assert result.path == repo / ".continue" / "prompts" / "vaner-feedback.md"
+    content = result.path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "invokable: true" in content
+    assert "name: vaner-feedback" in content
+    # Body content carries through.
+    assert "resolution_id" in content
+
+
+def test_write_skill_cline_workflow_uses_filename_as_command(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("cline", repo)
+    assert result.action == "added"
+    # Filename is the slash command — ``/vaner-feedback`` triggers it.
+    assert result.path == repo / ".clinerules" / "workflows" / "vaner-feedback.md"
+    content = result.path.read_text(encoding="utf-8")
+    # Cline workflows don't require frontmatter; we add a managed-marker
+    # comment so re-runs can detect ownership.
+    assert "x-vaner-managed" in content
+    assert "Vaner feedback" in content
+
+
+def test_write_skill_windsurf_workflow_with_title(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("windsurf", repo)
+    assert result.action == "added"
+    assert result.path == repo / ".windsurf" / "workflows" / "vaner-feedback.md"
+    content = result.path.read_text(encoding="utf-8")
+    # Windsurf renders the first heading as the workflow title.
+    assert "# Vaner feedback" in content
+    assert "x-vaner-managed" in content
+
+
+def test_write_skill_roo_slash_command_with_description(tmp_path: Path) -> None:
+    """Roo slash commands carry a ``description`` frontmatter field
+    that surfaces in the command palette. ``run_slash_command`` lets
+    the agent invoke this programmatically."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("roo", repo)
+    assert result.action == "added"
+    assert result.path == repo / ".roo" / "commands" / "vaner-feedback.md"
+    content = result.path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "description:" in content
+    # Body carries through.
+    assert "vaner.feedback" in content
+
+
+def test_write_skill_is_idempotent(tmp_path: Path) -> None:
+    """Two runs in a row with identical content produce ``skipped``."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    first = write_skill_for_client("cursor", repo)
+    second = write_skill_for_client("cursor", repo)
+    assert first.action == "added"
+    assert second.action == "skipped"
+    assert first.path == second.path
+
+
+def test_write_skill_unsupported_client_returns_unsupported(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("nope-some-client", repo)
+    assert result.action == "unsupported"
+    assert result.path is None
+
+
+def test_write_skill_dry_run_does_not_touch_disk(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_skill_for_client("cursor", repo, dry_run=True)
+    assert result.action == "added"
+    assert result.path is not None
+    assert not result.path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Batch writer
+# ---------------------------------------------------------------------------
+
+
+def test_write_skills_writes_all_seven_clients(fake_home: Path, tmp_path: Path) -> None:
+    """All seven supported clients (claude-code + cursor + codex-cli +
+    continue + cline + windsurf + roo) get a skill on a single
+    ``write_skills`` call."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    results = write_skills(sorted(SKILL_SURFACES.keys()), repo)
+    by_id = {r.client_id: r for r in results}
+    expected = {"claude-code", "cursor", "codex-cli", "continue", "cline", "windsurf", "roo"}
+    assert expected == set(by_id.keys())
+    for client_id in expected:
+        assert by_id[client_id].action == "added", f"{client_id} should write on a fresh tree; got {by_id[client_id].action}"
+        assert by_id[client_id].path is not None
+        assert by_id[client_id].path.exists()
+
+
+def test_write_skills_idempotent_on_rerun(fake_home: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    write_skills(sorted(SKILL_SURFACES.keys()), repo)
+    second = write_skills(sorted(SKILL_SURFACES.keys()), repo)
+    for r in second:
+        assert r.action == "skipped", f"{r.client_id} should be skipped on re-run"


### PR DESCRIPTION
## Summary

Phase C of the IDE/agent visibility plan. Extends Vaner's \`vaner-feedback\` skill from Claude Code + Cursor (current) to **all 7 clients** that support a per-project agent-callable subroutine, per the [capability matrix](https://docs.vaner.ai/integrations/client-capabilities).

The surfaces this PR ships into:

| Client | Surface | Format | Invocation |
| --- | --- | --- | --- |
| Claude Code | \`~/.claude/skills/vaner/vaner-feedback/SKILL.md\` | Agent Skills | auto-loaded |
| Cursor | \`.cursor/skills/vaner/vaner-feedback/SKILL.md\` | Agent Skills | auto-loaded |
| **Codex CLI** | \`~/.codex/skills/vaner-feedback/SKILL.md\` | Agent Skills | auto-loaded |
| **Continue** | \`.continue/prompts/vaner-feedback.md\` | \`invokable: true\` frontmatter | manual slash |
| **Cline** | \`.clinerules/workflows/vaner-feedback.md\` | filename-as-command | manual slash |
| **Windsurf** | \`.windsurf/workflows/vaner-feedback.md\` | Cascade workflow | manual |
| **Roo Code** | \`.roo/commands/vaner-feedback.md\` | slash command | agent-invocable via \`run_slash_command\` |

The 5 bolded clients are new in this PR.

## Why this matters

Vaner ships a single canonical \`SKILL.md\` body that says *when* to call \`vaner.feedback\` and *how* to format the call. For clients that auto-load Agent Skills (Claude Code, Cursor, Codex CLI), the skill triggers on metadata match. For clients that don't (Continue, Cline, Windsurf), the user invokes via slash. For Roo, the *agent itself* can invoke via the \`run_slash_command\` tool — so we get auto-invocation back for that one.

## What changes

- New \`vaner.cli.commands.skills\` module mirrors \`primer.py\`'s design:
  - \`SkillSurface\` per client (path resolver + render fn)
  - \`SKILL_SURFACES\` registry covering all 7 clients
  - \`write_skill_for_client\` + \`write_skills\` (idempotent, scope-aware)
- \`vaner init\` now writes skills via \`write_skills\` after the primer block, parallel to \`write_primers\`.
- \`write_mcp_configs\` reverted to MCP-only — skills moved out into the new module.
- \`mcp_clients._SKILL_PATH_RESOLVERS\` extended from 2 → 7 clients so \`vaner clients verify\` reports skill-layer status accurately across Phase C clients.

## Tests

- 14 new tests in \`test_skills.py\` covering each render path, canonical-body loader, idempotence, dry-run, user-scope fixtures.
- \`test_init.py\` skill assertions rewired to the new module (the removed \`_write_managed_skill\` helper from init.py).
- \`test_clients_subcommand.py\` skill-applicability test updated: the only genuinely-non-applicable clients now are Zed (no skill abstraction) and Claude Desktop (cloud-only). The other 7 all assert \`applicable=True\`.

171 tests pass in \`tests/test_cli/\`. \`ruff check\` + \`ruff format --check\` clean.

## What's still in Phase C (not in this PR)

- C2 — **Cursor plugin** with hooks (1.7+ has 17 hook events parallel to Claude Code's). Biggest single investment, separate PR.
- C3 — **Cline hooks** (8 events).
- C4 — **Windsurf hooks** (12 events).
- C8 — **Codex CLI hooks** (waiting on \`codex_hooks\` flag GA).
- C9 — **Claude Desktop MCPB** bundle (UX-only).

Reference: https://docs.vaner.ai/integrations/client-capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)