### PR TITLE
feat(cursor-plugin): full Cursor plugin parallel to plugins/vaner/

### DIFF
--- a/cursor-plugins/vaner/.cursor-plugin/plugin.json
+++ b/cursor-plugins/vaner/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "vaner",
+  "version": "0.8.8",
+  "description": "Vaner: predictive context middleware for AI coding workflows. Bundles the Vaner MCP server, the vaner-feedback skill, an alwaysApply primer rule, a sessionStart hook that checks for the `vaner` CLI, and a beforeSubmitPrompt hook that pre-fetches prepared work as you type.",
+  "author": {
+    "name": "Borgels Olsen Holding ApS",
+    "email": "support@vaner.ai",
+    "url": "https://vaner.ai"
+  },
+  "homepage": "https://vaner.ai",
+  "repository": "https://github.com/Borgels/vaner",
+  "license": "Apache-2.0",
+  "keywords": [
+    "mcp",
+    "context",
+    "retrieval",
+    "scenarios",
+    "vaner",
+    "predictive"
+  ]
+}

--- a/cursor-plugins/vaner/hooks.json
+++ b/cursor-plugins/vaner/hooks.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": ["python3", "${CURSOR_PLUGIN_ROOT}/scripts/session_start.py"],
+        "timeout_ms": 5000,
+        "failClosed": false
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "command": ["python3", "${CURSOR_PLUGIN_ROOT}/scripts/before_submit_prompt.py"],
+        "timeout_ms": 3000,
+        "failClosed": false
+      }
+    ]
+  }
+}

--- a/cursor-plugins/vaner/mcp/mcp.json
+++ b/cursor-plugins/vaner/mcp/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "vaner": {
+      "command": "vaner",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/cursor-plugins/vaner/rules/vaner-primer.mdc
+++ b/cursor-plugins/vaner/rules/vaner-primer.mdc
@@ -1,0 +1,20 @@
+---
+description: Vaner usage primer (bundled by the cursor-plugins/vaner plugin)
+alwaysApply: true
+---
+
+# Using Vaner
+
+Vaner is a local-first predictive context engine available to you as an MCP server. It prepares evidence-backed context packages in the background and exposes them through the `vaner.*` tool family (`vaner.resolve`, `vaner.search`, `vaner.expand`, `vaner.suggest`, `vaner.feedback`, `vaner.status`, `vaner.explain`, `vaner.warm`, `vaner.inspect`, `vaner.debug.trace`).
+
+Use Vaner when it can reduce uncertainty, prepare likely context, or continue an existing path. Do not call it mechanically when the task is trivial or self-contained.
+
+Operational patterns:
+
+1. **Prepare context early.** Before spelunking the codebase, call `vaner.resolve` with a short description of the task. It returns a ranked package with evidence and provenance. Keep the returned `resolution_id`.
+2. **Fallback and branches.** Use `vaner.search` when `vaner.resolve` confidence is weak or the task requires a retrieval style it did not cover. Use `vaner.expand` to explore adjacent scenarios without recomputing everything.
+3. **Feedback at the end.** When the task is done (or abandoned), call `vaner.feedback` with the `resolution_id` and one of `useful` / `partial` / `wrong` / `irrelevant`, optionally with `correction`, `preferred_items`, `rejected_items`, and the `skill` label. This reinforces Vaner's scenario ranking for future work.
+
+Treat Vaner as a supplement, not a replacement for reading code. Skip it entirely for one-line changes, pure reformatting, or questions already answered in the open conversation.
+
+Your MCP client may prefix these tool names. For example, Claude Code exposes plugin MCP tools as `mcp__plugin_<plugin>_<server>__<tool>` — so `vaner.resolve` appears as `mcp__plugin_vaner_vaner__vaner.resolve`. The conceptual names in this document map directly to whatever prefix your client uses; no translation is needed when you reason about them, only when you call them.

--- a/cursor-plugins/vaner/scripts/before_submit_prompt.py
+++ b/cursor-plugins/vaner/scripts/before_submit_prompt.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Cursor beforeSubmitPrompt hook for the Vaner plugin.
+
+Mirrors the Claude Code plugin's ``composer_submit.py`` — fires on
+every prompt submit and POSTs a DraftIntentSnapshot to the local
+Vaner daemon's loopback endpoint so the engine pre-fetches prepared
+work for the upcoming turn.
+
+Cursor's beforeSubmitPrompt hook payload (per cursor.com/docs/hooks)
+arrives on stdin as JSON with at least:
+
+    {
+      "prompt": "<the user's draft prompt>",
+      "session_id": "<cursor session id>",
+      "timestamp": <epoch>,
+      ...
+    }
+
+We forward those fields to the daemon's ``/signals/composer`` endpoint
+(introduced in Vaner 0.8.7 WS3) so prepared work warms up before the
+agent starts processing.
+
+Hook output contract: an empty JSON object (or no output) means
+"don't modify the request." We never block — this is observational —
+and we exit 0 on every failure path so a slow / down daemon never
+blocks the user's prompt submission.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DAEMON_BASE_URL = os.environ.get("VANER_DAEMON_URL", "http://127.0.0.1:8473")
+COMPOSER_ENDPOINT = "/signals/composer"
+HTTP_TIMEOUT_SECONDS = 1.5
+
+
+def _read_event() -> dict:
+    """Parse the Cursor hook event JSON from stdin.
+
+    Returns an empty dict on parse error so the hook still emits a
+    valid no-op response.
+    """
+
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return {}
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _post_composer_signal(prompt: str, session_id: str) -> None:
+    """POST a minimal DraftIntentSnapshot to the daemon. Best-effort."""
+
+    payload = {
+        "kind": "composer_lifecycle",
+        "source": "cursor-plugin",
+        "session_id": session_id,
+        "prompt_preview": prompt[:512],
+        "prompt_length": len(prompt),
+    }
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        DAEMON_BASE_URL + COMPOSER_ENDPOINT,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        urllib.request.urlopen(  # noqa: S310 — loopback POST only
+            request, timeout=HTTP_TIMEOUT_SECONDS
+        )
+    except (urllib.error.URLError, TimeoutError, OSError):
+        # Daemon down / endpoint unavailable — never block the prompt.
+        return
+
+
+def main() -> int:
+    event = _read_event()
+    prompt = str(event.get("prompt") or "")
+    session_id = str(event.get("session_id") or "")
+    if prompt:
+        _post_composer_signal(prompt, session_id)
+    # Empty observational response — pass-through.
+    sys.stdout.write("{}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cursor-plugins/vaner/scripts/session_start.py
+++ b/cursor-plugins/vaner/scripts/session_start.py
@@ -40,7 +40,8 @@ def _load_primer_body() -> str:
     """Return the primer markdown body without the .mdc YAML frontmatter."""
 
     try:
-        text = open(PRIMER_PATH, encoding="utf-8").read()
+        with open(PRIMER_PATH, encoding="utf-8") as fh:
+            text = fh.read()
     except OSError:
         return ""
     # Strip the leading ``---\n...---\n`` frontmatter; everything after
@@ -71,12 +72,15 @@ def _emit(payload: dict) -> None:
 
 
 def main() -> int:
-    # Drain stdin (Cursor sends a JSON event payload but this hook
-    # doesn't need its content); ignore parse errors.
+    # Drain stdin so Cursor's hook channel doesn't backpressure; this
+    # hook ignores the event payload's content. OSError on read is
+    # benign (e.g. closed pipe during shutdown) — silently swallow it
+    # and proceed so session start is never blocked by IO conditions
+    # outside our control.
     try:
         sys.stdin.read()
     except OSError:
-        pass
+        pass  # noqa: S110 — intentional; never block session start
 
     if shutil.which("vaner") is not None:
         primer = _load_primer_body()

--- a/cursor-plugins/vaner/scripts/session_start.py
+++ b/cursor-plugins/vaner/scripts/session_start.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Cursor sessionStart hook for the Vaner plugin.
+
+Mirrors the Claude Code plugin's ``check-vaner.sh`` shape but emits
+Cursor's hook output format. On every session:
+
+* Detect whether the ``vaner`` CLI is on PATH.
+* If yes, inject the canonical Vaner usage primer as ``additional_context``
+  so the model uses the MCP tools well (resolve early, search/expand as
+  fallback, feedback at end). Also probes the cockpit at
+  http://127.0.0.1:8473/status — if it answers, append a single-line
+  hint so the model can point the user at the live pipeline view.
+* If no, inject installer pointers as ``user_message`` so the user can
+  see why the plugin's MCP server isn't starting.
+
+Cursor hook output contract (per cursor.com/docs/hooks):
+    Observational hooks emit ``{"additional_context": "...",
+    "user_message": "..."}`` to stdout. Empty / missing keys are no-ops.
+
+Always exits 0 — failures must not block session start.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import urllib.error
+import urllib.request
+
+PLUGIN_ROOT = os.environ.get("CURSOR_PLUGIN_ROOT") or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PRIMER_PATH = os.path.join(PLUGIN_ROOT, "rules", "vaner-primer.mdc")
+
+
+_PRIMER_FRONTMATTER_END = "---\n"
+
+
+def _load_primer_body() -> str:
+    """Return the primer markdown body without the .mdc YAML frontmatter."""
+
+    try:
+        text = open(PRIMER_PATH, encoding="utf-8").read()
+    except OSError:
+        return ""
+    # Strip the leading ``---\n...---\n`` frontmatter; everything after
+    # the second delimiter is the body.
+    if not text.startswith(_PRIMER_FRONTMATTER_END):
+        return text.strip()
+    end_idx = text.find(_PRIMER_FRONTMATTER_END, len(_PRIMER_FRONTMATTER_END))
+    if end_idx == -1:
+        return text.strip()
+    return text[end_idx + len(_PRIMER_FRONTMATTER_END) :].strip()
+
+
+def _cockpit_reachable(timeout: float = 1.0) -> bool:
+    """Probe the local cockpit. Returns False on any error within ``timeout``."""
+
+    try:
+        with urllib.request.urlopen(  # noqa: S310 — loopback only
+            "http://127.0.0.1:8473/status", timeout=timeout
+        ) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def _emit(payload: dict) -> None:
+    json.dump(payload, sys.stdout)
+    sys.stdout.write("\n")
+
+
+def main() -> int:
+    # Drain stdin (Cursor sends a JSON event payload but this hook
+    # doesn't need its content); ignore parse errors.
+    try:
+        sys.stdin.read()
+    except OSError:
+        pass
+
+    if shutil.which("vaner") is not None:
+        primer = _load_primer_body()
+        if not primer:
+            # Primer file missing — silently no-op rather than
+            # disrupting session start.
+            _emit({})
+            return 0
+        cockpit_hint = ""
+        if _cockpit_reachable():
+            cockpit_hint = (
+                "\n\nLive Vaner state is available at http://127.0.0.1:8473/ "
+                "(cockpit is up). Mention this if the user asks about "
+                "prediction state, scenario queue depth, or wants to see "
+                "the live pipeline view."
+            )
+        _emit({"additional_context": primer + cockpit_hint})
+        return 0
+
+    # vaner NOT on PATH — surface a user-visible message.
+    message = (
+        "The Vaner Cursor plugin is enabled but the `vaner` CLI is not on "
+        "PATH, so the bundled MCP server cannot start. Install Vaner "
+        "with:\n\n"
+        "    curl -fsSL https://vaner.ai/install.sh | bash -s -- --yes\n\n"
+        "Or download Vaner Desktop at https://vaner.ai and re-open Cursor."
+    )
+    _emit({"user_message": message})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cursor-plugins/vaner/skills/vaner-feedback/SKILL.md
+++ b/cursor-plugins/vaner/skills/vaner-feedback/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: vaner-feedback
+description: Report scenario outcomes back to Vaner after completing a task.
+tags: [vaner, feedback]
+vaner:
+  kind: research
+  feedback: auto
+x-vaner-managed: true
+---
+
+Use this skill when finishing a task that used Vaner MCP scenarios.
+
+1. Keep the `resolution_id` returned by `vaner.resolve`, and note any item ids you want to praise or reject from `vaner.expand` / `vaner.search`.
+2. Call `vaner.feedback` with `rating` (`useful` | `partial` | `wrong` | `irrelevant`) and include `resolution_id` plus any optional `correction`, `preferred_items`, or `rejected_items`.
+3. Set `skill` to `vaner-feedback` so Vaner can attribute telemetry and improve future scenario ranking.

--- a/scripts/bump-plugin-version.sh
+++ b/scripts/bump-plugin-version.sh
@@ -25,14 +25,15 @@ esac
 
 PLUGIN_JSON="plugins/vaner/.claude-plugin/plugin.json"
 MARKETPLACE_JSON=".claude-plugin/marketplace.json"
+CURSOR_PLUGIN_JSON="cursor-plugins/vaner/.cursor-plugin/plugin.json"
 
-python3 - "$MODE" "$PLUGIN_JSON" "$MARKETPLACE_JSON" <<'PY'
+python3 - "$MODE" "$PLUGIN_JSON" "$MARKETPLACE_JSON" "$CURSOR_PLUGIN_JSON" <<'PY'
 import json
 import pathlib
 import sys
 import tomllib
 
-mode, plugin_path, marketplace_path = sys.argv[1], sys.argv[2], sys.argv[3]
+mode, plugin_path, marketplace_path, cursor_plugin_path = sys.argv[1:5]
 
 pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
 source_version = pyproject["project"]["version"]
@@ -48,6 +49,7 @@ def dump(path: str, doc: dict) -> None:
 
 plugin = load(plugin_path)
 marketplace = load(marketplace_path)
+cursor_plugin = load(cursor_plugin_path)
 
 def plugin_entry(doc: dict) -> dict:
     for entry in doc.get("plugins", []):
@@ -69,6 +71,11 @@ if mode == "--check":
             f"{marketplace_path}::plugins[name=vaner].version = "
             f"{entry.get('version')!r}, expected {source_version!r}"
         )
+    if cursor_plugin.get("version") != source_version:
+        errors.append(
+            f"{cursor_plugin_path}::version = {cursor_plugin.get('version')!r}, "
+            f"expected {source_version!r}"
+        )
     if errors:
         print("version parity failed:", file=sys.stderr)
         for err in errors:
@@ -79,7 +86,9 @@ if mode == "--check":
 
 plugin["version"] = source_version
 entry["version"] = source_version
+cursor_plugin["version"] = source_version
 dump(plugin_path, plugin)
 dump(marketplace_path, marketplace)
+dump(cursor_plugin_path, cursor_plugin)
 print(f"synced plugin version to {source_version}")
 PY

--- a/scripts/sync-plugin-skill.sh
+++ b/scripts/sync-plugin-skill.sh
@@ -5,7 +5,10 @@
 set -euo pipefail
 
 SRC="src/vaner/defaults/skills/vaner-feedback/SKILL.md"
-DST="plugins/vaner/skills/vaner-feedback/SKILL.md"
+DSTS=(
+  "plugins/vaner/skills/vaner-feedback/SKILL.md"
+  "cursor-plugins/vaner/skills/vaner-feedback/SKILL.md"
+)
 
 usage() {
   echo "usage: $0 --check | --write" >&2
@@ -16,19 +19,28 @@ usage() {
 
 case "$1" in
   --check)
-    if [[ ! -f "$DST" ]]; then
-      echo "missing: $DST (run: $0 --write)" >&2
-      exit 1
-    fi
-    if ! diff -q "$SRC" "$DST" >/dev/null; then
-      echo "out of sync: $SRC vs $DST" >&2
+    fail=0
+    for dst in "${DSTS[@]}"; do
+      if [[ ! -f "$dst" ]]; then
+        echo "missing: $dst (run: $0 --write)" >&2
+        fail=1
+        continue
+      fi
+      if ! diff -q "$SRC" "$dst" >/dev/null; then
+        echo "out of sync: $SRC vs $dst" >&2
+        fail=1
+      fi
+    done
+    if [[ $fail -ne 0 ]]; then
       echo "run: $0 --write" >&2
       exit 1
     fi
     ;;
   --write)
-    mkdir -p "$(dirname "$DST")"
-    cp "$SRC" "$DST"
+    for dst in "${DSTS[@]}"; do
+      mkdir -p "$(dirname "$dst")"
+      cp "$SRC" "$dst"
+    done
     ;;
   *)
     usage

--- a/tests/test_cli/test_cursor_plugin.py
+++ b/tests/test_cli/test_cursor_plugin.py
@@ -1,0 +1,223 @@
+"""Tests for the Cursor plugin bundle at ``cursor-plugins/vaner/``.
+
+Mirrors the spirit of the Claude Code plugin parity tests:
+
+* Manifest exists, parses, and matches the package version.
+* hooks.json declares both hooks and references the right scripts.
+* Each hook script's stdin → stdout contract emits valid JSON in
+  Cursor's hook output format (``additional_context`` /
+  ``user_message`` keys).
+* The bundled SKILL.md is byte-identical to the canonical copy
+  (enforced by ``scripts/sync-plugin-skill.sh --check`` in CI; this
+  test catches the drift earlier in dev).
+
+Cursor 1.7+ docs: https://cursor.com/docs/hooks
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CURSOR_PLUGIN_DIR = REPO_ROOT / "cursor-plugins" / "vaner"
+CANONICAL_SKILL = REPO_ROOT / "src" / "vaner" / "defaults" / "skills" / "vaner-feedback" / "SKILL.md"
+
+
+# ---------------------------------------------------------------------------
+# Manifest + bundled assets
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_parses_with_required_keys() -> None:
+    manifest = json.loads((CURSOR_PLUGIN_DIR / ".cursor-plugin" / "plugin.json").read_text())
+    for key in ("name", "version", "description", "author", "license"):
+        assert key in manifest, f"manifest missing required key: {key}"
+    assert manifest["name"] == "vaner"
+
+
+def test_manifest_version_matches_package_version() -> None:
+    """Version parity gate (also enforced by scripts/bump-plugin-version.sh).
+
+    The plugin's version must match ``pyproject.toml``'s; otherwise users
+    end up on the wrong tool surface."""
+
+    import tomllib
+
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    expected = pyproject["project"]["version"]
+    manifest = json.loads((CURSOR_PLUGIN_DIR / ".cursor-plugin" / "plugin.json").read_text())
+    assert manifest["version"] == expected, "Cursor plugin version drift; run scripts/bump-plugin-version.sh --write"
+
+
+def test_skill_is_byte_identical_to_canonical() -> None:
+    """The bundled vaner-feedback SKILL.md must match the canonical
+    copy under src/vaner/defaults/skills/. Drift means CI's
+    sync-plugin-skill.sh check fails — catching it here keeps the
+    feedback loop short."""
+
+    bundled = (CURSOR_PLUGIN_DIR / "skills" / "vaner-feedback" / "SKILL.md").read_bytes()
+    canonical = CANONICAL_SKILL.read_bytes()
+    assert bundled == canonical, "Cursor plugin's SKILL.md is out of sync; run scripts/sync-plugin-skill.sh --write"
+
+
+def test_primer_rule_uses_always_apply_frontmatter() -> None:
+    """The bundled primer rule must declare ``alwaysApply: true`` so
+    Cursor injects it on every chat — without it, the rule wouldn't
+    fire and the model would see no Vaner instruction."""
+
+    text = (CURSOR_PLUGIN_DIR / "rules" / "vaner-primer.mdc").read_text(encoding="utf-8")
+    assert text.startswith("---\n"), "rule file must start with YAML frontmatter"
+    assert "alwaysApply: true" in text
+
+
+# ---------------------------------------------------------------------------
+# hooks.json contract
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_json_declares_both_session_start_and_before_submit() -> None:
+    hooks = json.loads((CURSOR_PLUGIN_DIR / "hooks.json").read_text())
+    assert hooks["version"] == 1
+    assert "sessionStart" in hooks["hooks"]
+    assert "beforeSubmitPrompt" in hooks["hooks"]
+
+
+def test_hooks_json_commands_reference_existing_scripts() -> None:
+    hooks = json.loads((CURSOR_PLUGIN_DIR / "hooks.json").read_text())
+    for event_name, entries in hooks["hooks"].items():
+        for entry in entries:
+            cmd = entry["command"]
+            # The command list templates ``${CURSOR_PLUGIN_ROOT}`` —
+            # resolve it locally for the existence check.
+            resolved = [arg.replace("${CURSOR_PLUGIN_ROOT}", str(CURSOR_PLUGIN_DIR)) for arg in cmd]
+            assert len(resolved) >= 2, f"{event_name} hook command shape unexpected: {cmd}"
+            script_path = Path(resolved[1])
+            assert script_path.exists(), f"{event_name} references non-existent script: {script_path}"
+
+
+# ---------------------------------------------------------------------------
+# Hook scripts — stdin/stdout contract
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(script: Path, stdin_payload: dict, env: dict | None = None) -> dict:
+    """Invoke a hook script and parse its stdout as JSON."""
+
+    full_env = os.environ.copy()
+    full_env["CURSOR_PLUGIN_ROOT"] = str(CURSOR_PLUGIN_DIR)
+    if env:
+        full_env.update(env)
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(stdin_payload),
+        capture_output=True,
+        text=True,
+        env=full_env,
+        check=False,
+        timeout=8,
+    )
+    assert result.returncode == 0, f"{script.name} exited {result.returncode}; stderr: {result.stderr}"
+    stdout = result.stdout.strip() or "{}"
+    return json.loads(stdout)
+
+
+def test_session_start_emits_additional_context_when_vaner_on_path(monkeypatch, tmp_path) -> None:
+    """When ``vaner`` is on PATH, the hook injects the canonical primer
+    so the model uses Vaner correctly. Cursor reads ``additional_context``
+    from the hook's stdout."""
+
+    # Stub a fake ``vaner`` so shutil.which finds it.
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    (fake_bin / "vaner").write_text("#!/bin/sh\nexit 0\n")
+    (fake_bin / "vaner").chmod(0o755)
+    env = {"PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
+
+    out = _run_hook(
+        CURSOR_PLUGIN_DIR / "scripts" / "session_start.py",
+        stdin_payload={"event": "sessionStart"},
+        env=env,
+    )
+    assert "additional_context" in out
+    assert "Vaner" in out["additional_context"]
+    assert "vaner.resolve" in out["additional_context"]
+
+
+def test_session_start_emits_user_message_when_vaner_missing(tmp_path) -> None:
+    """Without ``vaner`` on PATH, the hook surfaces installer pointers as
+    ``user_message`` so the user sees why the bundled MCP isn't running."""
+
+    # Empty PATH so shutil.which can't find vaner.
+    env = {"PATH": str(tmp_path / "empty")}
+    out = _run_hook(
+        CURSOR_PLUGIN_DIR / "scripts" / "session_start.py",
+        stdin_payload={"event": "sessionStart"},
+        env=env,
+    )
+    assert "user_message" in out
+    assert "vaner.ai" in out["user_message"]
+
+
+def test_before_submit_prompt_returns_empty_object_on_no_daemon() -> None:
+    """The composer hook is observational — it never blocks. Even when
+    the daemon is unreachable, it must exit 0 and emit a valid JSON
+    object so Cursor doesn't reject the user's prompt."""
+
+    out = _run_hook(
+        CURSOR_PLUGIN_DIR / "scripts" / "before_submit_prompt.py",
+        stdin_payload={"prompt": "test prompt", "session_id": "abc"},
+        # Force the daemon URL to a port nothing's listening on.
+        env={"VANER_DAEMON_URL": "http://127.0.0.1:9"},
+    )
+    assert out == {}
+
+
+def test_before_submit_prompt_handles_empty_stdin() -> None:
+    """Cursor may invoke the hook with an empty payload during init or
+    edge cases. The script must still produce a valid response."""
+
+    out = _run_hook(
+        CURSOR_PLUGIN_DIR / "scripts" / "before_submit_prompt.py",
+        stdin_payload={},
+        env={"VANER_DAEMON_URL": "http://127.0.0.1:9"},
+    )
+    assert out == {}
+
+
+# ---------------------------------------------------------------------------
+# MCP server entry
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_json_declares_vaner_server() -> None:
+    """The plugin bundles its MCP server entry so users get the full
+    leverage stack (MCP + skill + primer + hooks) on a single install,
+    matching the Claude Code plugin's atomic-bundle behaviour."""
+
+    mcp = json.loads((CURSOR_PLUGIN_DIR / "mcp" / "mcp.json").read_text())
+    assert "vaner" in mcp["mcpServers"]
+    assert mcp["mcpServers"]["vaner"]["command"] == "vaner"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        ".cursor-plugin/plugin.json",
+        "hooks.json",
+        "mcp/mcp.json",
+        "rules/vaner-primer.mdc",
+        "skills/vaner-feedback/SKILL.md",
+        "scripts/session_start.py",
+        "scripts/before_submit_prompt.py",
+    ],
+)
+def test_required_files_exist(filename: str) -> None:
+    """Catch accidental deletion or rename of any required plugin asset."""
+
+    assert (CURSOR_PLUGIN_DIR / filename).exists(), f"missing required file: {filename}"


### PR DESCRIPTION
## Summary

Phase C2 of the IDE/agent visibility plan. Cursor 1.7+ has a full plugin system parallel to Claude Code's, with 17 hook events and atomic install bundles. This PR ships the Vaner Cursor plugin so Cursor users get the same leverage stack on a single plugin-install click — MCP server + primer + skill + lifecycle hooks — without running \`vaner init\` per-repo.

## What's bundled (\`cursor-plugins/vaner/\`)

| File | Purpose |
| --- | --- |
| \`.cursor-plugin/plugin.json\` | Manifest. Version pinned to \`pyproject.toml\` via the parity check |
| \`mcp/mcp.json\` | MCP server entry — installs without separate wiring |
| \`rules/vaner-primer.mdc\` | Primer rule with \`alwaysApply: true\` |
| \`skills/vaner-feedback/SKILL.md\` | Agent Skills standard skill, byte-identical to canonical |
| \`hooks.json\` | Declares \`sessionStart\` + \`beforeSubmitPrompt\` |
| \`scripts/session_start.py\` | Hook: detect \`vaner\` CLI, inject primer or installer pointers |
| \`scripts/before_submit_prompt.py\` | Hook: pre-fetch prepared work via composer signal |

## Lifecycle hook behavior

- **sessionStart**: Mirrors the Claude Code plugin's \`SessionStart\`. Detects the \`vaner\` CLI on PATH, injects the canonical primer as \`additional_context\`, probes the cockpit at \`127.0.0.1:8473\` and appends a hint when reachable. When \`vaner\` is missing, surfaces installer pointers as \`user_message\` so the user sees why the bundled MCP isn't running.

- **beforeSubmitPrompt**: Mirrors the Claude Code plugin's \`UserPromptSubmit\`. Reads the prompt event and POSTs a DraftIntentSnapshot to \`/signals/composer\` so the daemon pre-fetches prepared work as the user types. Observational — never blocks.

Both hooks exit 0 with an empty JSON object on every failure path so a slow / down daemon never disrupts the user.

## Parity gates extended

- \`scripts/sync-plugin-skill.sh\` extended to enforce that **both** \`plugins/vaner/skills/vaner-feedback/SKILL.md\` and \`cursor-plugins/vaner/skills/vaner-feedback/SKILL.md\` stay byte-identical to \`src/vaner/defaults/skills/vaner-feedback/SKILL.md\`.
- \`scripts/bump-plugin-version.sh\` extended to sync the Cursor manifest's version alongside the Claude Code plugin's manifest and the marketplace JSON.

Both pre-commit gates and the \`validate-claude-plugin.yml\` CI workflow already invoke these scripts; no workflow changes needed.

## Tests (\`tests/test_cli/test_cursor_plugin.py\`, 18 cases)

- Manifest parses + version matches \`pyproject.toml\`
- Required-files matrix (deletion / rename trips the test)
- Skill byte-identical to canonical
- Primer has \`alwaysApply: true\`
- \`hooks.json\` declares both events and references existing scripts
- Hook scripts driven via subprocess with stdin/stdout fixtures:
  - sessionStart with vaner-on-PATH → \`additional_context\` with primer body
  - sessionStart with vaner-missing → \`user_message\` with installer pointers
  - beforeSubmitPrompt with no daemon → \`{}\` (never blocks)
  - beforeSubmitPrompt with empty stdin → \`{}\`

All 18 pass; \`ruff check\` + \`ruff format --check\` clean.

## Out of scope

- Marketplace submission. The plugin is ready for it but Cursor's marketplace requires manual review per their docs; that's a separate flow.
- A \`vaner-install\` / \`vaner-next\` skill (Claude Code plugin has these as command-only skills). Can ship later if the plugin gains traction.

Reference: https://docs.vaner.ai/integrations/client-capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)