### PR TITLE
feat(hooks): Cline + Windsurf prompt-submit hooks (Phase C4)

### DIFF
--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -51,6 +51,7 @@ from vaner.cli.commands.deep_run import deep_run_app
 from vaner.cli.commands.distill import distill_skill_file
 from vaner.cli.commands.explain import render_human, render_json
 from vaner.cli.commands.guidance import guidance_app
+from vaner.cli.commands.hooks import HOOK_SURFACES, write_hooks
 from vaner.cli.commands.init import (
     BACKEND_PRESETS,
     COMPUTE_PRESETS,
@@ -574,6 +575,28 @@ def init(
                 typer.echo(f"Warning: could not write skill for {r.client_id}: {r.error}")
         except Exception as exc:  # pragma: no cover - defensive
             typer.echo(f"Warning: could not install skills: {exc}")
+
+        # Hooks layer — prompt-submit hooks for clients with stable
+        # hook APIs that aren't already covered by an atomic plugin
+        # (Cline, Windsurf today). Same composer-submit script is used
+        # across both. Claude Code + Cursor get hooks via their plugin
+        # bundles; Codex CLI hooks ship when ``codex_hooks`` goes GA.
+        try:
+            hook_clients = sorted(HOOK_SURFACES.keys())
+            hook_results = write_hooks(hook_clients, repo_root)
+            installed = [r for r in hook_results if r.action in ("added", "updated")]
+            skipped = [r for r in hook_results if r.action == "skipped"]
+            failed = [r for r in hook_results if r.action == "failed"]
+            if installed:
+                typer.echo("Installed prompt-submit hooks:")
+                for r in installed:
+                    typer.echo(f"  - {r.path} ({r.action})")
+            if skipped:
+                typer.echo(f"Hook already up to date for {len(skipped)} client(s); no changes needed.")
+            for r in failed:
+                typer.echo(f"Warning: could not write hook for {r.client_id}: {r.error}")
+        except Exception as exc:  # pragma: no cover - defensive
+            typer.echo(f"Warning: could not install hooks: {exc}")
 
     import sys as _sys
 

--- a/src/vaner/cli/commands/hooks.py
+++ b/src/vaner/cli/commands/hooks.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-client hook installer.
+
+Layer 4 of the four-layer leverage stack documented at
+docs.vaner.ai/integrations/client-capabilities. Mirrors the design of
+:mod:`vaner.cli.commands.primer` and :mod:`vaner.cli.commands.skills`:
+a per-client surface with a path resolver and a render function, plus
+a non-destructive writer.
+
+What's shipped today
+--------------------
+
+This module installs **prompt-submit hooks** for the two clients with
+stable hook APIs that aren't already covered by an atomic plugin:
+
+* **Cline** — drops an executable script into ``.clinerules/hooks/``.
+  Cline scans the directory and dispatches by filename; we ship
+  ``UserPromptSubmit`` so Vaner pre-fetches prepared work as the user
+  types.
+* **Windsurf** — writes ``.windsurf/hooks.json`` declaring a shell
+  command that runs the canonical composer-submit script on the
+  ``user_prompt`` event.
+
+The composer-submit script (``defaults/hooks/composer_submit.py``)
+is shared across both clients — same contract, same behaviour. It
+POSTs a DraftIntentSnapshot to the local daemon's ``/signals/composer``
+endpoint and never blocks the user (always exits 0 with ``{}`` output).
+
+Out of scope here
+-----------------
+
+* **Claude Code** and **Cursor** install hooks via their plugin systems
+  (``plugins/vaner/hooks/hooks.json`` and ``cursor-plugins/vaner/hooks.json``
+  respectively). Those bundles are atomic install units; this module
+  doesn't duplicate them.
+* **Codex CLI** has hooks behind a ``codex_hooks = true`` flag —
+  defer until GA.
+* **VS Code Copilot** exposes only ``resolveMcpServerDefinition`` to
+  third-party extensions; no general session-lifecycle hook surface.
+* **Continue / Zed / Roo / Claude Desktop** have no hook system.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal
+
+HookAction = Literal["added", "updated", "skipped", "unsupported", "failed"]
+
+
+class HookScope(StrEnum):
+    REPO = "repo"
+    USER = "user"
+
+
+@dataclass(slots=True)
+class HookResult:
+    client_id: str
+    scope: HookScope
+    path: Path | None
+    action: HookAction
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HookSurface:
+    """Declarative description of where and how to write a client's hook."""
+
+    # Resolves the target file for a scope, or None if not supported.
+    path: Callable[[Path, HookScope], Path | None]
+    # Renders the canonical hook config / script for the file's
+    # native format.
+    render: Callable[[Path, str], str]  # (script_source_path, version) -> file body
+    # ``script`` writes an executable file (Cline). ``config`` writes
+    # a JSON config that references the canonical script (Windsurf).
+    kind: Literal["script", "config"]
+
+
+# ---------------------------------------------------------------------------
+# Canonical composer-submit script
+# ---------------------------------------------------------------------------
+
+
+_PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+_CANONICAL_SCRIPT = _PACKAGE_ROOT / "defaults" / "hooks" / "composer_submit.py"
+
+
+def canonical_script_path() -> Path:
+    """Return the path to the canonical composer-submit script bundled
+    with the vaner package. The hook installers either copy this file
+    verbatim (Cline) or reference it from a JSON config (Windsurf).
+    """
+
+    return _CANONICAL_SCRIPT
+
+
+def hook_version() -> str:
+    """Track ``vaner.__version__`` so re-installs after upgrade refresh."""
+
+    try:
+        from vaner import __version__
+
+        return str(__version__)
+    except Exception:  # pragma: no cover - defensive
+        return "0"
+
+
+# ---------------------------------------------------------------------------
+# Per-client renders
+# ---------------------------------------------------------------------------
+
+
+def _render_cline_user_prompt_submit(script_source: Path, _version: str) -> str:
+    """Cline scans ``.clinerules/hooks/`` for executable scripts. The
+    filename maps to the event name (``UserPromptSubmit``). We copy
+    the canonical composer-submit script verbatim.
+
+    Per docs.cline.bot/features/hooks: hooks "receive JSON via stdin
+    and emit JSON via stdout." The canonical script does exactly that,
+    so it works as-is for Cline.
+    """
+
+    return script_source.read_text(encoding="utf-8")
+
+
+def _render_windsurf_hooks_json(script_source: Path, version: str) -> str:
+    """Windsurf reads a single ``.windsurf/hooks.json`` declaring shell
+    commands per event. We invoke the canonical script via ``python3``
+    so the file format stays portable across OSes — Windsurf doesn't
+    require executable bits.
+
+    Per docs.windsurf.com/windsurf/cascade/hooks: pre-hooks block by
+    exiting with code 2; observational hooks ignore output. Our script
+    always exits 0, so the hook is observational by construction.
+    """
+
+    payload = {
+        "version": 1,
+        "x-vaner-managed": f"v={version}",
+        "hooks": {
+            "user_prompt": [
+                {
+                    "command": ["python3", str(script_source)],
+                    "timeout_ms": 3000,
+                    "fail_closed": False,
+                }
+            ]
+        },
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Per-client path resolvers
+# ---------------------------------------------------------------------------
+
+
+def _path_cline(repo_root: Path, scope: HookScope) -> Path | None:
+    if scope != HookScope.REPO:
+        return None
+    return repo_root / ".clinerules" / "hooks" / "UserPromptSubmit"
+
+
+def _path_windsurf(repo_root: Path, scope: HookScope) -> Path | None:
+    if scope != HookScope.REPO:
+        return None
+    return repo_root / ".windsurf" / "hooks.json"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+HOOK_SURFACES: dict[str, HookSurface] = {
+    "cline": HookSurface(path=_path_cline, render=_render_cline_user_prompt_submit, kind="script"),
+    "windsurf": HookSurface(path=_path_windsurf, render=_render_windsurf_hooks_json, kind="config"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-client writer
+# ---------------------------------------------------------------------------
+
+
+def write_hook_for_client(
+    client_id: str,
+    repo_root: Path,
+    *,
+    scope: HookScope = HookScope.REPO,
+    version: str | None = None,
+    dry_run: bool = False,
+) -> HookResult:
+    """Install the prompt-submit hook for ``client_id``.
+
+    Idempotent: identical-content writes return ``skipped``. The hook
+    file is owned end-to-end by Vaner — there is no merge primitive,
+    since each hook file is named for Vaner's purpose.
+
+    Cline scripts get an executable bit (``chmod +x``) so the OS will
+    actually run them. Windsurf JSON configs don't need it.
+    """
+
+    surface = HOOK_SURFACES.get(client_id)
+    if surface is None:
+        return HookResult(client_id=client_id, scope=scope, path=None, action="unsupported")
+
+    target = surface.path(repo_root, scope)
+    if target is None:
+        return HookResult(client_id=client_id, scope=scope, path=None, action="unsupported")
+
+    resolved_version = version or hook_version()
+    rendered = surface.render(canonical_script_path(), resolved_version)
+
+    try:
+        existing = target.read_text(encoding="utf-8") if target.exists() else ""
+    except OSError as exc:
+        return HookResult(client_id=client_id, scope=scope, path=target, action="failed", error=str(exc))
+
+    if existing == rendered:
+        return HookResult(client_id=client_id, scope=scope, path=target, action="skipped")
+
+    action: HookAction = "updated" if existing else "added"
+    if dry_run:
+        return HookResult(client_id=client_id, scope=scope, path=target, action=action)
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(rendered, encoding="utf-8")
+        if surface.kind == "script":
+            # Make the script executable so Cline can run it.
+            current_mode = target.stat().st_mode
+            target.chmod(current_mode | 0o111)
+    except OSError as exc:  # pragma: no cover - defensive I/O guard
+        return HookResult(client_id=client_id, scope=scope, path=target, action="failed", error=str(exc))
+    return HookResult(client_id=client_id, scope=scope, path=target, action=action)
+
+
+def write_hooks(
+    client_ids: list[str],
+    repo_root: Path,
+    *,
+    dry_run: bool = False,
+) -> list[HookResult]:
+    """Install hooks for each client in ``client_ids``."""
+
+    version = hook_version()
+    results: list[HookResult] = []
+    for client_id in client_ids:
+        results.append(write_hook_for_client(client_id, repo_root, version=version, dry_run=dry_run))
+    return results
+
+
+# ``shutil`` is imported above only so test fixtures can patch it; not
+# used directly in this module.
+_ = shutil

--- a/src/vaner/cli/commands/mcp_clients.py
+++ b/src/vaner/cli/commands/mcp_clients.py
@@ -783,21 +783,41 @@ _SKILL_PATH_RESOLVERS: dict[str, Callable[[Path], Path]] = {
 }
 
 
-# Plugin-supporting clients today. Vaner ships a full Claude Code plugin;
-# Cursor (1.7+) supports plugins but Vaner doesn't yet ship one.
-# When the Cursor plugin lands, add it here.
+# Plugin / hook-supporting clients. Vaner ships:
+#   * Claude Code — full plugin (plugins/vaner/), installed via
+#     marketplace; verify by checking the user's plugin store.
+#   * Cursor — full plugin (cursor-plugins/vaner/), installed
+#     manually today; verify by checking the user's plugin store.
+#   * Cline — prompt-submit hook script written to
+#     .clinerules/hooks/UserPromptSubmit (Phase C4).
+#   * Windsurf — .windsurf/hooks.json declaring the prompt-submit
+#     hook (Phase C4).
 def _claude_code_plugin_marker(_repo_root: Path) -> Path:
     """The Claude Code plugin is installed via the ``/plugin install``
-    marketplace flow, which writes to a per-user plugin store. We use
-    the user's installed-plugins manifest as a proxy. If the user
-    installed the plugin via marketplace, this file lists it.
-    """
+    marketplace flow, which writes to a per-user plugin store."""
 
     return _home() / ".claude" / "plugins" / "vaner" / ".claude-plugin" / "plugin.json"
 
 
+def _cursor_plugin_marker(_repo_root: Path) -> Path:
+    """Cursor's plugin store lives under the user's profile dir."""
+
+    return _home() / ".cursor" / "plugins" / "vaner" / ".cursor-plugin" / "plugin.json"
+
+
+def _cline_hook_marker(repo_root: Path) -> Path:
+    return repo_root / ".clinerules" / "hooks" / "UserPromptSubmit"
+
+
+def _windsurf_hook_marker(repo_root: Path) -> Path:
+    return repo_root / ".windsurf" / "hooks.json"
+
+
 _PLUGIN_PATH_RESOLVERS: dict[str, Callable[[Path], Path]] = {
     "claude-code": _claude_code_plugin_marker,
+    "cursor": _cursor_plugin_marker,
+    "cline": _cline_hook_marker,
+    "windsurf": _windsurf_hook_marker,
 }
 
 

--- a/src/vaner/defaults/hooks/composer_submit.py
+++ b/src/vaner/defaults/hooks/composer_submit.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Composer-submit hook script — installed into per-client hook surfaces
+by :mod:`vaner.cli.commands.hooks`.
+
+Fires on the user's prompt-submit event in Cline (``UserPromptSubmit``)
+and Windsurf (``user_prompt``). Reads the hook event JSON from stdin
+and POSTs a DraftIntentSnapshot to the local Vaner daemon's
+``/signals/composer`` endpoint so prepared work warms up before the
+agent starts processing the prompt.
+
+Hook output contract is observational across both clients:
+
+* **Cline**: emits ``{}`` (empty JSON) on success — no cancel, no
+  context modification, no error. The hook never blocks; failures
+  silently no-op.
+* **Windsurf**: exits 0 with no output on success. Pre-hooks block by
+  exiting with code 2; we never want to block, so we always exit 0.
+
+Designed to be drop-in across both clients — same script, same
+contract — so :mod:`vaner.cli.commands.hooks` can ship one canonical
+file and just point per-client config at it.
+
+Source: docs.vaner.ai/integrations/client-capabilities
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DAEMON_BASE_URL = os.environ.get("VANER_DAEMON_URL", "http://127.0.0.1:8473")
+COMPOSER_ENDPOINT = "/signals/composer"
+HTTP_TIMEOUT_SECONDS = 1.5
+SOURCE = os.environ.get("VANER_HOOK_SOURCE", "vaner-hook")
+
+
+def _read_event() -> dict:
+    """Parse the hook event JSON from stdin. Returns ``{}`` on parse error."""
+
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return {}
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _extract_prompt(event: dict) -> tuple[str, str]:
+    """Pull (prompt, session_id) out of the event payload.
+
+    Each client uses slightly different keys; we accept the union so
+    one script works across both Cline and Windsurf without per-client
+    branching.
+    """
+
+    prompt_keys = ("prompt", "user_prompt", "input", "message", "text")
+    session_keys = ("session_id", "sessionId", "task_id", "taskId")
+    prompt = ""
+    session = ""
+    for key in prompt_keys:
+        value = event.get(key)
+        if isinstance(value, str) and value:
+            prompt = value
+            break
+    for key in session_keys:
+        value = event.get(key)
+        if isinstance(value, str) and value:
+            session = value
+            break
+    return prompt, session
+
+
+def _post_composer_signal(prompt: str, session_id: str) -> None:
+    """POST a minimal DraftIntentSnapshot to the daemon. Best-effort."""
+
+    payload = {
+        "kind": "composer_lifecycle",
+        "source": SOURCE,
+        "session_id": session_id,
+        "prompt_preview": prompt[:512],
+        "prompt_length": len(prompt),
+    }
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        DAEMON_BASE_URL + COMPOSER_ENDPOINT,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        urllib.request.urlopen(  # noqa: S310 — loopback POST only
+            request, timeout=HTTP_TIMEOUT_SECONDS
+        )
+    except (urllib.error.URLError, TimeoutError, OSError):
+        # Daemon down / endpoint unavailable — never block the prompt.
+        return
+
+
+def main() -> int:
+    event = _read_event()
+    prompt, session_id = _extract_prompt(event)
+    if prompt:
+        _post_composer_signal(prompt, session_id)
+    # Empty JSON object is a valid no-op for Cline; Windsurf accepts
+    # it as well (unused output is ignored in observational hooks).
+    sys.stdout.write("{}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli/test_hooks.py
+++ b/tests/test_cli/test_hooks.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the per-client hook installer (Phase C4 of the IDE/agent
+visibility plan).
+
+Layer 4 of the leverage stack documented at
+docs.vaner.ai/integrations/client-capabilities. Today this module
+ships prompt-submit hooks for Cline and Windsurf — the two clients
+with stable hook APIs that aren't already covered by an atomic plugin
+bundle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from vaner.cli.commands.hooks import (
+    HOOK_SURFACES,
+    canonical_script_path,
+    hook_version,
+    write_hook_for_client,
+    write_hooks,
+)
+
+# ---------------------------------------------------------------------------
+# Canonical script
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_script_exists_and_is_python() -> None:
+    """The composer-submit script must ship with the package; the
+    installers point per-client config at this exact path."""
+
+    script = canonical_script_path()
+    assert script.exists()
+    text = script.read_text(encoding="utf-8")
+    assert text.startswith("#!/usr/bin/env python3")
+    # The script targets the daemon's /signals/composer endpoint.
+    assert "/signals/composer" in text
+
+
+def test_hook_version_is_non_empty() -> None:
+    assert hook_version()
+
+
+# ---------------------------------------------------------------------------
+# Per-client writer
+# ---------------------------------------------------------------------------
+
+
+def test_write_hook_cline_drops_executable_at_user_prompt_submit(tmp_path: Path) -> None:
+    """Cline scans ``.clinerules/hooks/`` for executable scripts; the
+    filename maps to the event. We ship ``UserPromptSubmit`` and chmod
+    +x so the OS can run it."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_hook_for_client("cline", repo)
+    assert result.action == "added"
+    assert result.path == repo / ".clinerules" / "hooks" / "UserPromptSubmit"
+    assert result.path.exists()
+    # Executable bit must be set so Cline can dispatch.
+    assert os.access(result.path, os.X_OK), "Cline hook must be executable"
+    text = result.path.read_text(encoding="utf-8")
+    assert "/signals/composer" in text
+
+
+def test_write_hook_windsurf_writes_hooks_json(tmp_path: Path) -> None:
+    """Windsurf's hook surface is a JSON config that references a
+    shell command. We invoke the canonical script via python3 so the
+    file format stays portable."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_hook_for_client("windsurf", repo)
+    assert result.action == "added"
+    assert result.path == repo / ".windsurf" / "hooks.json"
+    payload = json.loads(result.path.read_text(encoding="utf-8"))
+    assert payload["version"] == 1
+    assert "user_prompt" in payload["hooks"]
+    command = payload["hooks"]["user_prompt"][0]["command"]
+    # The command list invokes python3 against the canonical script.
+    assert command[0] == "python3"
+    assert command[1] == str(canonical_script_path())
+    # Observational hook, never blocks.
+    assert payload["hooks"]["user_prompt"][0]["fail_closed"] is False
+
+
+def test_write_hook_unsupported_client_returns_unsupported(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_hook_for_client("nope-some-client", repo)
+    assert result.action == "unsupported"
+    assert result.path is None
+
+
+def test_write_hook_is_idempotent(tmp_path: Path) -> None:
+    """Two runs in a row produce ``skipped`` — safe to call from
+    re-runs of ``vaner init``."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    first = write_hook_for_client("cline", repo)
+    second = write_hook_for_client("cline", repo)
+    assert first.action == "added"
+    assert second.action == "skipped"
+
+
+def test_write_hook_dry_run_does_not_touch_disk(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = write_hook_for_client("cline", repo, dry_run=True)
+    assert result.action == "added"
+    assert result.path is not None
+    assert not result.path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Batch writer
+# ---------------------------------------------------------------------------
+
+
+def test_write_hooks_writes_both_cline_and_windsurf(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    results = write_hooks(sorted(HOOK_SURFACES.keys()), repo)
+    by_id = {r.client_id: r for r in results}
+    assert {"cline", "windsurf"} == set(by_id.keys())
+    for client_id in ("cline", "windsurf"):
+        assert by_id[client_id].action == "added"
+        assert by_id[client_id].path is not None
+        assert by_id[client_id].path.exists()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the canonical script's stdin/stdout contract
+# ---------------------------------------------------------------------------
+
+
+def _run_script(stdin_payload: dict, env: dict | None = None) -> str:
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    result = subprocess.run(
+        [sys.executable, str(canonical_script_path())],
+        input=json.dumps(stdin_payload),
+        capture_output=True,
+        text=True,
+        env=full_env,
+        check=False,
+        timeout=8,
+    )
+    assert result.returncode == 0, f"composer_submit.py exited {result.returncode}; stderr: {result.stderr}"
+    return result.stdout
+
+
+def test_canonical_script_returns_empty_object_on_no_daemon() -> None:
+    """The hook is observational — must never block. Even when the
+    daemon is unreachable, it exits 0 with ``{}`` so neither Cline
+    nor Windsurf reject the user's prompt."""
+
+    out = _run_script(
+        {"prompt": "test prompt", "session_id": "abc"},
+        env={"VANER_DAEMON_URL": "http://127.0.0.1:9"},
+    )
+    assert json.loads(out.strip()) == {}
+
+
+def test_canonical_script_handles_empty_stdin() -> None:
+    out = _run_script({}, env={"VANER_DAEMON_URL": "http://127.0.0.1:9"})
+    assert json.loads(out.strip()) == {}
+
+
+def test_canonical_script_accepts_user_prompt_key_alias() -> None:
+    """Windsurf uses ``user_prompt``; Cline uses ``prompt``. The script
+    must accept either so a single canonical file works for both."""
+
+    out = _run_script(
+        {"user_prompt": "windsurf-style payload", "task_id": "windsurf-123"},
+        env={"VANER_DAEMON_URL": "http://127.0.0.1:9"},
+    )
+    assert json.loads(out.strip()) == {}
+
+
+# ---------------------------------------------------------------------------
+# Verify-layer integration
+# ---------------------------------------------------------------------------
+
+
+def test_verify_reports_plugin_applicable_for_cline_and_windsurf(tmp_path: Path) -> None:
+    """After Phase C4, ``vaner clients verify`` reports the plugin
+    layer as ``applicable`` for Cline and Windsurf (whose hook
+    surfaces Vaner now writes), in addition to Claude Code and Cursor
+    (which have full plugin bundles)."""
+
+    from vaner.cli.commands.mcp_clients import verify_all
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    results = verify_all(repo)
+    by_id = {r.client_id: r for r in results}
+    assert by_id["cline"].layers["plugin"].applicable is True
+    assert by_id["windsurf"].layers["plugin"].applicable is True
+    assert by_id["claude-code"].layers["plugin"].applicable is True
+    assert by_id["cursor"].layers["plugin"].applicable is True


### PR DESCRIPTION
## Summary

Phase C4 of the IDE/agent visibility plan. Closes the last hook gap from the [capability matrix](https://docs.vaner.ai/integrations/client-capabilities) that isn't behind a feature flag (Codex CLI hooks) or covered by an atomic plugin bundle (Claude Code + Cursor):

- **Cline** — 8 hook events; we ship \`UserPromptSubmit\`
- **Windsurf** — 12 hook events; we ship \`user_prompt\`

Both fire on the user's prompt-submit event. The canonical script POSTs a DraftIntentSnapshot to the daemon's \`/signals/composer\` endpoint so Vaner pre-fetches prepared work as the user types — same shape as the Claude Code plugin's \`UserPromptSubmit\` and the Cursor plugin's \`beforeSubmitPrompt\`.

## What's added

| File | Purpose |
| --- | --- |
| \`src/vaner/defaults/hooks/composer_submit.py\` | Canonical hook script. Drop-in across Cline + Windsurf (accepts both clients' payload key conventions). Always exits 0 with \`{}\` — never blocks. |
| \`src/vaner/cli/commands/hooks.py\` | Installer module mirroring \`primer.py\` / \`skills.py\`. \`write_hook_for_client\` + batch \`write_hooks\`. |
| \`tests/test_cli/test_hooks.py\` | 12 new tests covering writer behavior + canonical script contract. |

\`vaner init\` now writes hooks via \`write_hooks\` after the skills block.

## Verify integration

\`mcp_clients._PLUGIN_PATH_RESOLVERS\` extended so \`vaner clients verify\` reports plugin-layer status accurately for:
- \`claude-code\` — plugin marker (existing)
- \`cursor\` — plugin marker (Phase C2)
- \`cline\` — \`.clinerules/hooks/UserPromptSubmit\` marker (this PR)
- \`windsurf\` — \`.windsurf/hooks.json\` marker (this PR)

## Test plan

- [x] 12 new test cases pass
- [x] 77 cli tests total pass (was 65 before this PR)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Canonical script's stdin/stdout contract verified end-to-end via subprocess (no daemon, empty stdin, both client payload shapes)

## Phase C status after this PR

| C | Item | Status |
| --- | --- | --- |
| C1 | Codex CLI skill | ✅ Phase C-1 (vaner#215) |
| C2 | Cursor plugin | ✅ vaner#216 |
| C3 | Cline workflow | ✅ Phase C-1 (vaner#215) |
| **C3** | **Cline hooks** | **✅ this PR** |
| C4 | Windsurf workflow | ✅ Phase C-1 (vaner#215) |
| **C4** | **Windsurf hooks** | **✅ this PR** |
| C5 | Continue prompt | ✅ Phase C-1 |
| C6 | VS Code Copilot skill | ⏳ Defer until 1.108+ skills GA |
| C7 | Roo slash command | ✅ Phase C-1 |
| C8 | Codex CLI hooks | ⏳ Defer until \`codex_hooks\` flag GA |
| C9 | Claude Desktop MCPB | ⏳ UX-only, low priority |

After this merges, Phase C is **functionally complete** for every supported client whose hook layer Vaner can ship into today.

Reference: https://docs.vaner.ai/integrations/client-capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)