### PR TITLE
feat(init): auto-apply policy bundle, no five-question wizard

### DIFF
--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -820,31 +820,18 @@ def init(
     else:
         typer.echo("Tip: enable command completion with `vaner --install-completion`.")
 
-    # 0.8.6 WS6: chain into the Simple-Mode setup wizard when interactive.
-    # The wizard is a no-op-or-skip from the user's perspective; they
-    # can also run it later with `vaner setup wizard`.
-    if resolved_interactive:
-        try:
-            run_wizard_now = typer.confirm(
-                "Run the setup wizard now to choose a profile?",
-                default=True,
-            )
-        except (EOFError, KeyboardInterrupt):
-            run_wizard_now = False
-        if run_wizard_now:
-            try:
-                from vaner.cli.commands.setup import wizard_cmd
+    # Auto-pick a sensible policy bundle from the hardware probe,
+    # mirroring the simplified desktop-app onboarding. The five-question
+    # wizard is still available as `vaner setup wizard` for users who
+    # want to fine-tune.
+    try:
+        from vaner.cli.commands.setup import auto_apply_default_bundle
 
-                wizard_cmd(path=str(repo_root))
-            except typer.Exit:
-                # The wizard signals control flow with typer.Exit; let it
-                # propagate normally without aborting the rest of init.
-                pass
-            except Exception as exc:  # pragma: no cover - defensive
-                typer.echo(f"Setup wizard skipped (error: {exc}).")
-                typer.echo("Run `vaner setup wizard` to choose a profile.")
-        else:
-            typer.echo("Skipped. Run `vaner setup wizard` later to choose a profile.")
+        bundle_id, _reasons = auto_apply_default_bundle(repo_root)
+        typer.echo(f"Picked policy bundle '{bundle_id}'. Override with `vaner setup apply <bundle-id>`.")
+    except Exception as exc:  # pragma: no cover - defensive
+        typer.echo(f"Could not auto-apply policy bundle ({exc}).")
+        typer.echo("Run `vaner setup apply <bundle-id>` to set one explicitly.")
 
 
 @daemon_app.command("start")

--- a/src/vaner/cli/commands/setup.py
+++ b/src/vaner/cli/commands/setup.py
@@ -467,6 +467,24 @@ def _render_cloud_widening_warning(console: Console, warnings: list[str]) -> Non
 # ---------------------------------------------------------------------------
 
 
+def auto_apply_default_bundle(repo_root: Path) -> tuple[str, list[str]]:
+    """Pick a sensible policy bundle from a hardware probe + safe defaults.
+
+    Mirrors the simplified desktop-app onboarding: no questions asked,
+    just probe the box, score every bundle, persist the winner. Used
+    by ``vaner init`` so first-run users land on a working policy
+    without a five-question wizard. Returns ``(bundle_id, reasons)``.
+    """
+
+    init_repo(repo_root)
+    answers = _default_answers()
+    hardware = detect()
+    selection = select_policy_bundle(answers, hardware)
+    completed_at = datetime.now(UTC)
+    _persist_setup_and_policy(repo_root, answers, selection.bundle.id, completed_at=completed_at)
+    return selection.bundle.id, list(selection.reasons)
+
+
 @setup_app.command(
     "wizard",
     help="Interactive Simple-Mode wizard. Asks five questions, picks a bundle, persists it.",

--- a/tests/test_cli/test_setup_cli.py
+++ b/tests/test_cli/test_setup_cli.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 from vaner.cli.commands import setup as setup_commands
 from vaner.cli.commands.app import app
 from vaner.cli.commands.setup import setup_app
+from vaner.setup.config_io import read_policy_section
 from vaner.setup.hardware import HardwareProfile
 
 runner = CliRunner()
@@ -424,24 +425,20 @@ def test_ping_daemon_for_refresh_uses_env_base_url(monkeypatch: pytest.MonkeyPat
 # ---------------------------------------------------------------------------
 
 
-def test_init_chains_into_wizard_when_interactive(
+def test_init_auto_picks_bundle_interactive(
     tmp_path: Path,
     fake_hardware: HardwareProfile,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Drive `vaner init` interactively; confirm wizard runs and persists."""
+    """`vaner init` auto-applies a policy bundle. No five-question wizard."""
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    # Avoid touching ~/.claude during MCP wiring; init's primer / MCP
-    # config code paths create files there. Pin HOME to a tmp dir.
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-    # Track whether the wizard was invoked. We monkeypatch the wizard
-    # callable that init imports lazily.
     wizard_calls: list[str] = []
 
     def _fake_wizard(path: str | None = None, **_kwargs: object) -> None:
@@ -449,13 +446,9 @@ def test_init_chains_into_wizard_when_interactive(
 
     monkeypatch.setattr("vaner.cli.commands.setup.wizard_cmd", _fake_wizard)
 
-    # Scripted answers for init's existing prompts:
-    # - Step 1 backend: "7" → "skip" (but backend_preset stays None; downstream
-    #   compute prompt still fires because the check is `backend_preset != "skip"`)
-    # - Step 2 compute: "1" → background
-    # - Shell completion confirm: "n" (skip subprocess install)
-    # - Wizard chain confirm: "y" (we want to chain in)
-    scripted = "\n".join(["7", "1", "n", "y", ""]) + "\n"
+    # Init's existing two prompts: backend=skip (7), compute=background (1),
+    # then the shell-completion confirm answers "n".
+    scripted = "\n".join(["7", "1", "n", ""]) + "\n"
     result = runner.invoke(
         app,
         [
@@ -469,15 +462,18 @@ def test_init_chains_into_wizard_when_interactive(
         input=scripted,
     )
     assert result.exit_code == 0, result.output
-    assert wizard_calls, "vaner init did not chain into the setup wizard"
+    assert not wizard_calls, "vaner init must not invoke the five-question wizard"
+
+    policy_section = read_policy_section(repo)
+    assert policy_section.get("selected_bundle_id"), "init did not auto-apply a bundle"
 
 
-def test_init_does_not_chain_when_non_interactive(
+def test_init_auto_picks_bundle_non_interactive(
     tmp_path: Path,
     fake_hardware: HardwareProfile,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`vaner init --no-interactive` does not invoke the wizard."""
+    """`vaner init --no-interactive` also auto-applies a bundle."""
 
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -508,3 +504,6 @@ def test_init_does_not_chain_when_non_interactive(
     )
     assert result.exit_code == 0, result.output
     assert not wizard_calls
+
+    policy_section = read_policy_section(repo)
+    assert policy_section.get("selected_bundle_id"), "init did not auto-apply a bundle"


### PR DESCRIPTION
Aligns `vaner init` with the simplified desktop-app onboarding (and with the new docs in vaner-docs#38, which removed simple-mode.mdx and stopped describing the wizard).

## Behavior
- `vaner init` now probes hardware, picks a sensible policy bundle, and persists it. One-line output: `Picked policy bundle '<id>'. Override with \`vaner setup apply <bundle-id>\`.`
- `vaner setup wizard` stays available for users who explicitly want the five-question flow. Init just no longer prompts to chain into it.

## Code
- New `auto_apply_default_bundle(repo_root) -> (bundle_id, reasons)` helper in `vaner.cli.commands.setup`. Reuses the existing `select_policy_bundle` + `persist_setup_and_policy` machinery.
- `vaner.cli.commands.app:init` swaps the wizard-confirm prompt block for a single call to that helper.

## Tests
- Renamed both init-chain tests; new versions assert the wizard is *not* invoked and that a bundle id was persisted to `.vaner/config.toml`.
- Full `tests/test_cli/test_setup_cli.py` + `test_init.py` + `test_init_wizard_snapshot.py` green locally (23 passed).

## Test plan
- [x] Local pytest green
- [x] ruff check + format clean
- [ ] CI green