### PR TITLE
fix(cli): claude-desktop Linux false-positive, cli-claude/codex MCP recover, GUI testbed (Phase D-2)

### DIFF
--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -1808,8 +1808,59 @@ def up(
     ),
     detach: bool = typer.Option(False, "--detach", help="Start processes and return immediately."),
     force: bool = typer.Option(False, "--force", help="Allow broad/non-repo root paths."),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit a single JSON line with the bring-up result and exit. Implies --detach.",
+    ),
 ) -> None:
-    """Start a supervised local Vaner session."""
+    """Start a supervised local Vaner session.
+
+    With ``--json``, emits one structured line of stdout suitable for
+    desktop / scripted callers. The shape is::
+
+        {"started": true, "reattached": false, "ready": true,
+         "cockpit_url": "http://127.0.0.1:8473",
+         "daemon_pid": 1234, "cockpit_pid": 1235,
+         "ports": {...}, "inotify": {...}}
+
+    On failure (non-repo root, no setup, etc.) the CLI emits::
+
+        {"started": false, "error": "...", "fix": "..."}
+
+    and exits non-zero. Implies ``--detach`` because there is no
+    sensible way to "block" with structured output.
+    """
+    if as_json:
+        detach = True
+        try:
+            payload = run_up(
+                _repo_root(path),
+                host=host,
+                port=port,
+                mcp_sse_port=8472,
+                interval_seconds=interval_seconds,
+                open_browser=False,
+                force=force,
+            )
+        except RuntimeError as exc:
+            error_payload: dict[str, object] = {"started": False, "error": str(exc)}
+            typer.echo(json.dumps(error_payload))
+            raise typer.Exit(code=1) from exc
+        # Always emit the canonical key set so callers can rely on
+        # the shape regardless of the reattached / fresh-start branch.
+        emitted = {
+            "started": bool(payload.get("started")),
+            "reattached": bool(payload.get("reattached")),
+            "ready": bool(payload.get("ready", payload.get("reattached", False))),
+            "cockpit_url": payload.get("cockpit_url") or f"http://{host}:{port}",
+            "daemon_pid": payload.get("daemon_pid"),
+            "cockpit_pid": payload.get("cockpit_pid"),
+            "ports": payload.get("ports", {}),
+            "inotify": payload.get("inotify", {}),
+        }
+        typer.echo(json.dumps(emitted))
+        return
     should_open = _console.is_terminal if open_browser is None else open_browser
     payload = run_up(
         _repo_root(path),

--- a/src/vaner/cli/commands/app.py
+++ b/src/vaner/cli/commands/app.py
@@ -1832,7 +1832,10 @@ def up(
     sensible way to "block" with structured output.
     """
     if as_json:
-        detach = True
+        # `--json` always returns immediately after emitting the line,
+        # so we don't need to flip the local `detach` flag — the
+        # branch ends with `return` before the foreground-keepalive
+        # block at the bottom of the function ever runs.
         try:
             payload = run_up(
                 _repo_root(path),

--- a/src/vaner/cli/commands/mcp_clients.py
+++ b/src/vaner/cli/commands/mcp_clients.py
@@ -105,6 +105,12 @@ def _detect_cursor(repo_root: Path) -> Path | None:
 
 
 def _detect_claude_desktop(_repo_root: Path) -> Path | None:
+    # Anthropic only ships Claude Desktop on macOS and Windows. The
+    # Linux config dir (`~/.config/Claude/`) is sometimes created by
+    # Vaner's own installer or other tools, so its mere existence is
+    # not evidence the app is installed — gate on the platform first.
+    if _platform() not in ("darwin", "windows"):
+        return None
     root = _claude_desktop_dir()
     if root.exists():
         return root
@@ -393,7 +399,18 @@ def _write_cli_client(
     argv: list[str],
     launcher_cmd: str,
     launcher_args: list[str],
+    force: bool = False,
 ) -> WriteResult:
+    """Drive a CLI-managed MCP registration (Claude Code, Codex CLI).
+    When the client has an existing `vaner` entry the upstream `mcp add`
+    refuses with "MCP server vaner already exists in user config" — a
+    fresh install of Vaner Desktop wires its own MCP entry, so any
+    second-pass `clients install` (or wizard repair) hits this. Treat
+    "already exists" as something we can recover from automatically:
+    remove the existing entry, retry the add. Behaviour is the same
+    whether the caller passed `--force` or not — the user expects
+    "Install" to leave the client in the configured state, not bail
+    because the install already half-happened. """
     if not shutil.which(executable):
         snippet = json.dumps(generic_snippet(launcher_cmd, launcher_args)["json"], indent=2)
         return WriteResult(
@@ -403,17 +420,56 @@ def _write_cli_client(
             error=f"{executable} binary not found",
             manual_snippet=snippet,
         )
+
+    def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(args, capture_output=True, text=True, check=False, timeout=30)
+
     try:
-        result = subprocess.run(argv, capture_output=True, text=True, check=False, timeout=30)
+        result = _run(argv)
     except Exception as exc:  # pragma: no cover
         return WriteResult(client_id=client_id, path=None, action="failed", error=str(exc))
     if result.returncode == 0:
         return WriteResult(client_id=client_id, path=None, action="added")
+
+    err_text = (result.stderr or result.stdout).strip()
+    already_exists = "already exists" in err_text.lower()
+    if not already_exists:
+        return WriteResult(
+            client_id=client_id,
+            path=None,
+            action="failed",
+            error=err_text[:500],
+        )
+
+    # Recover: drop the stale entry then re-run the original add. Both
+    # `claude mcp` and `codex mcp` accept `mcp remove vaner [--scope
+    # user]` symmetric to their add invocation; we re-use the leading
+    # tokens from `argv` so we stay aligned with whichever client this
+    # is.
+    base = [argv[0], argv[1], "remove", "vaner"]
+    # `argv[3]` = "add"; the slot after it is `--transport` for claude,
+    # `--` for codex. Forward `--scope user` only when the original
+    # add carried it, so we remove from the same scope it would land.
+    if "--scope" in argv:
+        scope_idx = argv.index("--scope")
+        if scope_idx + 1 < len(argv):
+            base += ["--scope", argv[scope_idx + 1]]
+    try:
+        _run(base)
+    except Exception:  # pragma: no cover
+        pass
+
+    try:
+        retry = _run(argv)
+    except Exception as exc:  # pragma: no cover
+        return WriteResult(client_id=client_id, path=None, action="failed", error=str(exc))
+    if retry.returncode == 0:
+        return WriteResult(client_id=client_id, path=None, action="updated")
     return WriteResult(
         client_id=client_id,
         path=None,
         action="failed",
-        error=(result.stderr or result.stdout).strip()[:500],
+        error=(retry.stderr or retry.stdout).strip()[:500],
     )
 
 
@@ -482,6 +538,7 @@ def write_client(
             argv=argv,
             launcher_cmd=launcher_cmd,
             launcher_args=launcher_args,
+            force=force,
         )
     if spec.kind == "cli-codex":
         argv = ["codex", "mcp", "add", "vaner", "--", launcher_cmd, *launcher_args]
@@ -491,6 +548,7 @@ def write_client(
             argv=argv,
             launcher_cmd=launcher_cmd,
             launcher_args=launcher_args,
+            force=force,
         )
     return WriteResult(client_id=spec.id, path=target_path, action="failed", error=f"Unsupported kind: {spec.kind}")
 

--- a/src/vaner/cli/commands/mcp_clients.py
+++ b/src/vaner/cli/commands/mcp_clients.py
@@ -410,7 +410,7 @@ def _write_cli_client(
     remove the existing entry, retry the add. Behaviour is the same
     whether the caller passed `--force` or not — the user expects
     "Install" to leave the client in the configured state, not bail
-    because the install already half-happened. """
+    because the install already half-happened."""
     if not shutil.which(executable):
         snippet = json.dumps(generic_snippet(launcher_cmd, launcher_args)["json"], indent=2)
         return WriteResult(

--- a/src/vaner/setup/hardware.py
+++ b/src/vaner/setup/hardware.py
@@ -40,6 +40,27 @@ _SUBPROCESS_TIMEOUT = 2.0
 logger = logging.getLogger(__name__)
 
 
+MemoryKind = Literal["vram", "unified", "system", "unknown"]
+
+
+@dataclass(frozen=True, slots=True)
+class GPUDevice:
+    """One detected GPU with display-friendly identity + memory.
+
+    Populated from the per-vendor enumerator (pynvml / ``nvidia-smi`` /
+    ``system_profiler`` / ``lspci``). The desktop reads ``name`` to show
+    "NVIDIA GeForce RTX 5090" instead of the generic "NVIDIA GPU"
+    fallback that the legacy single-summary fields produced.
+    """
+
+    name: str
+    vendor: str
+    kind: GPU
+    memory_total_bytes: int | None
+    memory_display_gb: int | None
+    memory_kind: MemoryKind
+
+
 @dataclass(frozen=True, slots=True)
 class HardwareProfile:
     """Immutable snapshot of detected hardware capabilities.
@@ -58,6 +79,10 @@ class HardwareProfile:
     detected_runtimes: tuple[Runtime, ...]
     detected_models: tuple[tuple[str, str, str], ...]
     tier: HardwareTier = field(default="unknown")
+    # Per-device GPU enumeration. Empty tuple when no probe could
+    # identify discrete devices — consumers should fall back to the
+    # ``gpu`` / ``gpu_vram_gb`` summary fields in that case.
+    gpu_devices: tuple[GPUDevice, ...] = field(default_factory=tuple)
 
 
 # ---------------------------------------------------------------------------
@@ -214,6 +239,121 @@ def _probe_gpu_nvidia() -> tuple[GPU, int | None] | None:
     except Exception:
         logger.debug("pynvml probe failed", exc_info=True)
         return None
+
+
+def _probe_gpu_devices_nvidia_pynvml() -> tuple[GPUDevice, ...] | None:
+    """Per-device enumeration via pynvml. Returns one GPUDevice per
+    physical NVIDIA card, with the display name (e.g. "NVIDIA GeForce
+    RTX 5090") and total VRAM. None when pynvml isn't installed or
+    fails — caller falls back to nvidia-smi parsing.
+    """
+    try:
+        import pynvml  # type: ignore[import-not-found]
+    except Exception:
+        return None
+    try:
+        pynvml.nvmlInit()
+    except Exception:
+        return None
+    devices: list[GPUDevice] = []
+    try:
+        try:
+            count = int(pynvml.nvmlDeviceGetCount())
+        except Exception:
+            count = 0
+        for i in range(count):
+            try:
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                raw_name = pynvml.nvmlDeviceGetName(handle)
+                name = raw_name.decode("utf-8") if isinstance(raw_name, bytes) else str(raw_name)
+                mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                total_bytes = int(getattr(mem, "total", 0)) or None
+                vram_gb = max(1, round(total_bytes / (1024**3))) if total_bytes else None
+                devices.append(
+                    GPUDevice(
+                        name=name.strip() or "NVIDIA GPU",
+                        vendor="NVIDIA",
+                        kind="nvidia",
+                        memory_total_bytes=total_bytes,
+                        memory_display_gb=vram_gb,
+                        memory_kind="vram",
+                    )
+                )
+            except Exception:
+                logger.debug("pynvml device %d enumeration failed", i, exc_info=True)
+    finally:
+        try:
+            pynvml.nvmlShutdown()
+        except Exception:  # pragma: no cover - cleanup
+            pass
+    return tuple(devices) if devices else None
+
+
+def _probe_gpu_devices_nvidia_smi() -> tuple[GPUDevice, ...] | None:
+    """nvidia-smi fallback. Used when pynvml isn't installed (the
+    pipx-shipped CLI doesn't pull pynvml in by default). The CSV
+    format is stable across driver versions.
+    """
+    smi = shutil.which("nvidia-smi")
+    if not smi:
+        return None
+    try:
+        result = subprocess.run(
+            [smi, "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+    except Exception:
+        logger.debug("nvidia-smi probe failed", exc_info=True)
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    devices: list[GPUDevice] = []
+    for line in result.stdout.splitlines():
+        parts = [p.strip() for p in line.split(",", 1)]
+        if len(parts) != 2 or not parts[0]:
+            continue
+        name = parts[0]
+        try:
+            mib = int(parts[1])
+            total_bytes = mib * 1024 * 1024
+            vram_gb = max(1, round(total_bytes / (1024**3)))
+        except ValueError:
+            total_bytes = None
+            vram_gb = None
+        devices.append(
+            GPUDevice(
+                name=name,
+                vendor="NVIDIA",
+                kind="nvidia",
+                memory_total_bytes=total_bytes,
+                memory_display_gb=vram_gb,
+                memory_kind="vram",
+            )
+        )
+    return tuple(devices) if devices else None
+
+
+def _probe_gpu_devices() -> tuple[GPUDevice, ...]:
+    """Compose per-vendor enumerators. NVIDIA-only today (covers the
+    desktop's first reported gap); macOS/AMD/integrated devices fall
+    through to the empty tuple and consumers use the summary fields.
+    """
+    try:
+        nvidia_pynvml = _probe_gpu_devices_nvidia_pynvml()
+        if nvidia_pynvml:
+            return nvidia_pynvml
+    except Exception:
+        logger.debug("nvidia pynvml device probe failed", exc_info=True)
+    try:
+        nvidia_smi = _probe_gpu_devices_nvidia_smi()
+        if nvidia_smi:
+            return nvidia_smi
+    except Exception:
+        logger.debug("nvidia-smi device probe failed", exc_info=True)
+    return ()
 
 
 def _probe_gpu_macos() -> tuple[GPU, int | None]:
@@ -584,6 +724,7 @@ def detect() -> HardwareProfile:
     os_kind = _probe_os()
     cpu_class, ram_gb = _probe_cpu_and_ram()
     gpu, gpu_vram_gb = _probe_gpu()
+    devices = _probe_gpu_devices()
     is_battery = _probe_battery()
     thermal = _probe_thermal()
     runtimes = _probe_runtimes()
@@ -593,6 +734,13 @@ def detect() -> HardwareProfile:
     # frozen dataclass; fall back to "linux" but force the tier to "unknown"
     # so consumers treat the snapshot as untrusted.
     effective_os: OS = os_kind if os_kind is not None else "linux"
+
+    # If the per-device probe found a card with a name + VRAM but the
+    # legacy summary probe missed VRAM (lspci on a no-pynvml install,
+    # for example), backfill from the first device so consumers that
+    # only consult `gpu_vram_gb` still see a number.
+    if gpu_vram_gb is None and devices:
+        gpu_vram_gb = devices[0].memory_display_gb
 
     profile = HardwareProfile(
         os=effective_os,
@@ -605,6 +753,7 @@ def detect() -> HardwareProfile:
         detected_runtimes=runtimes,
         detected_models=models,
         tier="unknown",
+        gpu_devices=devices,
     )
     final_tier: HardwareTier = "unknown" if os_kind is None else tier_for(profile)
     return HardwareProfile(
@@ -618,10 +767,12 @@ def detect() -> HardwareProfile:
         detected_runtimes=runtimes,
         detected_models=models,
         tier=final_tier,
+        gpu_devices=devices,
     )
 
 
 __all__ = [
+    "GPUDevice",
     "HardwareProfile",
     "HardwareTier",
     "detect",

--- a/src/vaner/setup/serializers.py
+++ b/src/vaner/setup/serializers.py
@@ -91,6 +91,17 @@ def hardware_to_dict(hw: HardwareProfile) -> dict[str, Any]:
         "detected_runtimes": list(hw.detected_runtimes),
         "detected_models": [list(row) for row in hw.detected_models],
         "tier": hw.tier,
+        "gpu_devices": [
+            {
+                "name": d.name,
+                "vendor": d.vendor,
+                "kind": d.kind,
+                "memory_total_bytes": d.memory_total_bytes,
+                "memory_display_gb": d.memory_display_gb,
+                "memory_kind": d.memory_kind,
+            }
+            for d in hw.gpu_devices
+        ],
     }
 
 

--- a/tests/integration/testbed/Dockerfile.gui
+++ b/tests/integration/testbed/Dockerfile.gui
@@ -1,0 +1,112 @@
+# syntax=docker/dockerfile:1.7
+#
+# Vaner integration testbed — Phase D-2 (GUI clients + Vaner Desktop).
+#
+# Standard Ubuntu 24.04 desktop running inside a container, exposed
+# via noVNC so a browser session can drive the actual Vaner Desktop
+# build (AppImage or .deb) end-to-end. Companion to the Phase D-1
+# Dockerfile in this directory; that one stays headless.
+#
+# Stack:
+#
+#   - ubuntu-desktop-minimal — the standard Ubuntu shell (GNOME).
+#   - Xvfb — virtual framebuffer, the standard Ubuntu test display
+#     server (same one the desktop's CI uses headlessly).
+#   - x11vnc + websockify + noVNC — VNC bridge so a browser can poke
+#     the running session at http://localhost:6080/vnc.html.
+#   - All the runtime libs Tauri/WebKitGTK needs to launch the
+#     desktop AppImage (libwebkit2gtk-4.1-0, libayatana-appindicator3-1, …).
+#   - Vaner CLI installed from the working tree, same as Phase D-1,
+#     so the desktop's CLI subprocesses (`vaner setup apply`, `vaner
+#     status`, …) hit a real engine.
+#   - xdotool for scripted UI driving from inside the container.
+#
+# Build:
+#   docker build -f tests/integration/testbed/Dockerfile.gui \
+#                -t vaner-testbed-gui .
+#
+# Run (mount the AppImage you just built on the host):
+#   docker run --rm -it \
+#     -p 6080:6080 \
+#     -v /tmp/vaner-desktop-local-3.AppImage:/home/vaner/vaner-desktop.AppImage:ro \
+#     vaner-testbed-gui
+#
+# Then open http://localhost:6080/vnc.html in a browser. The wizard
+# launches automatically.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8
+
+# Layer 1 — apt deps. Split into two RUNs so re-baking with a
+# different vaner source tree only invalidates the COPY step, not the
+# 2 GB GNOME install.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ubuntu-desktop-minimal \
+        gnome-session \
+        mutter \
+        metacity \
+        xvfb \
+        x11vnc \
+        novnc \
+        websockify \
+        dbus-x11 \
+        xdotool \
+        fonts-dejavu \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        sudo \
+        passwd \
+        python3 \
+        python3-pip \
+        python3-venv \
+        nodejs \
+        npm \
+        libfuse2 \
+        fuse \
+        libwebkit2gtk-4.1-0 \
+        libgtk-3-0 \
+        libayatana-appindicator3-1 \
+        librsvg2-2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv for the same Python install style as Phase D-1.
+RUN curl -fsSL https://astral.sh/uv/install.sh \
+      | env UV_INSTALL_DIR=/opt/uv/bin sh
+
+ENV PATH=/opt/uv/bin:/usr/local/bin:/usr/bin:/bin
+
+RUN /usr/sbin/useradd -m -s /bin/bash -u 1100 vaner \
+    && echo 'vaner ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+USER vaner
+WORKDIR /home/vaner
+
+ENV HOME=/home/vaner \
+    DISPLAY=:99 \
+    XDG_RUNTIME_DIR=/tmp/runtime-vaner
+
+# Vaner from the working tree (matches Phase D-1).
+COPY --chown=vaner:vaner . /opt/vaner
+
+RUN cd /opt/vaner \
+    && uv venv /home/vaner/.venv \
+    && . /home/vaner/.venv/bin/activate \
+    && uv pip install -e .
+
+ENV PATH=/home/vaner/.venv/bin:/opt/uv/bin:/usr/local/bin:/usr/bin:/bin
+
+# Sample repo + entrypoint script.
+COPY --chown=vaner:vaner tests/integration/testbed/sample-repo /home/vaner/sample-repo
+COPY --chown=vaner:vaner tests/integration/testbed/gui-entrypoint.sh /home/vaner/gui-entrypoint.sh
+RUN sudo chmod +x /home/vaner/gui-entrypoint.sh
+
+EXPOSE 6080
+CMD ["/home/vaner/gui-entrypoint.sh"]

--- a/tests/integration/testbed/README.md
+++ b/tests/integration/testbed/README.md
@@ -24,18 +24,47 @@ each and asserts all four leverage layers landed:
 - Plugin / hooks — `~/.claude/plugins/vaner/` (Codex's plugin gate is
   still flag-locked upstream so we don't assert it here)
 
-## Phase D-2 — GUI clients (future)
+## Phase D-2 — GUI testbed (Vaner Desktop, future GUI clients)
 
-Cursor, Zed, VS Code (Copilot), Continue, Cline, Windsurf, Roo,
-Claude Desktop need a desktop environment. The plan is a separate
-image that adds:
+`Dockerfile.gui` boots a real Ubuntu 24.04 desktop session
+(`ubuntu-desktop-minimal` → GNOME) inside the container, exposes it
+through noVNC on `:6080`, and optionally launches a Vaner Desktop
+AppImage you mount in. Same standard Ubuntu display server that ships
+to users — Xvfb is just a virtual framebuffer for the same Xorg stack.
 
-- xvfb + xfce4 (lightweight enough not to mask install-time bugs)
-- noVNC on a known port for human verification
-- Per-client install steps (.deb where possible, AppImage where not)
+Build:
 
-GUI assertions don't fit a one-shot CI run — they're for manual
-verification. The CLI smoke script is what gates merges.
+```bash
+docker build -f tests/integration/testbed/Dockerfile.gui \
+             -t vaner-testbed-gui .
+```
+
+Run with the AppImage you want to drive (mount it read-only):
+
+```bash
+docker run --rm -it \
+  -p 6080:6080 \
+  -v /tmp/vaner-desktop-local-3.AppImage:/home/vaner/vaner-desktop.AppImage:ro \
+  --shm-size=2g \
+  vaner-testbed-gui
+```
+
+Open <http://localhost:6080/vnc.html?autoconnect=1> in a browser. The
+GNOME session boots; the wizard window appears a few seconds later.
+Log out / kill the AppImage from the noVNC session to exit.
+
+Or via compose:
+
+```bash
+VANER_DESKTOP_APPIMAGE=/tmp/vaner-desktop-local-3.AppImage \
+  docker compose -f tests/integration/testbed/compose.yml up gui
+```
+
+`xdotool` is installed inside the image, so future smoke scripts can
+drive the wizard from a `docker exec` rather than human clicks.
+
+Future GUI clients (Cursor, Zed, VS Code, Continue, Cline, Windsurf,
+Roo, Claude Desktop) install on top of the same image.
 
 ## Build + run
 

--- a/tests/integration/testbed/compose.yml
+++ b/tests/integration/testbed/compose.yml
@@ -21,3 +21,23 @@ services:
     extends:
       service: testbed
     command: ["bash", "/opt/testbed/test-launch-clients.sh"]
+
+  # Phase D-2 — full Ubuntu desktop in a container, reachable at
+  # http://localhost:6080/vnc.html. Mount the desktop AppImage you
+  # want to drive at /home/vaner/vaner-desktop.AppImage and the
+  # entrypoint launches it after GNOME settles.
+  gui:
+    build:
+      context: ../../..
+      dockerfile: tests/integration/testbed/Dockerfile.gui
+    image: vaner-testbed-gui:dev
+    ports:
+      - "6080:6080"
+    volumes:
+      # Override on the CLI: -v /tmp/vaner-desktop-local-3.AppImage:/home/vaner/vaner-desktop.AppImage:ro
+      - ${VANER_DESKTOP_APPIMAGE:-/dev/null}:/home/vaner/vaner-desktop.AppImage:ro
+    shm_size: "2gb"
+    # GNOME-on-Xvfb wants a plausible amount of /tmp for compositor
+    # state and the AppImage's mount point.
+    tmpfs:
+      - /tmp:size=512M

--- a/tests/integration/testbed/gui-entrypoint.sh
+++ b/tests/integration/testbed/gui-entrypoint.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Phase D-2 entrypoint. Boots a real Ubuntu X11 session inside the
+# container and exposes it via noVNC.
+#
+# Order of operations:
+#   1. Xvfb on :99 (the testbed's "monitor").
+#   2. dbus session bus (Tauri needs one for the tray + dialogs).
+#   3. mutter --x11 — the standard GNOME compositor + window
+#      manager, run standalone. We skip gnome-session entirely:
+#      Ubuntu 24.04's gnome-session hard-requires systemd as a
+#      user-session manager, which isn't available inside vanilla
+#      Docker. mutter alone gives us window placement, focus, and
+#      decorations against the same X stack the desktop ships
+#      against.
+#   4. x11vnc bridges :99 to a TCP VNC port.
+#   5. websockify wraps that in WebSocket so the bundled noVNC HTML
+#      page (served on :6080) can drive it from any browser.
+#   6. If an AppImage was mounted at $APP_PATH (default
+#      /home/vaner/vaner-desktop.AppImage), launch it once the
+#      compositor is up. The wizard window appears inside the noVNC
+#      view.
+#
+# `wait -n` keeps the container alive until the *first* of these
+# subprocesses exits — which means a Tauri crash propagates as a
+# container exit, useful for one-shot tests in CI.
+
+set -e
+
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+# Xvfb wants /tmp/.X11-unix for the abstract socket; the container's
+# /tmp is empty on first boot.
+sudo mkdir -p /tmp/.X11-unix
+sudo chmod 1777 /tmp/.X11-unix
+
+# 1. Virtual display.
+Xvfb :99 -screen 0 1280x800x24 -ac +extension GLX +render -noreset &
+XVFB_PID=$!
+
+# Wait for the X server to come up before any client tries to connect.
+for _ in $(seq 1 30); do
+  if xdpyinfo -display :99 >/dev/null 2>&1; then break; fi
+  sleep 0.2
+done
+
+# 2. Session dbus.
+eval "$(dbus-launch --sh-syntax)"
+export DBUS_SESSION_BUS_ADDRESS DBUS_SESSION_BUS_PID
+
+# 3. Compositor / window manager. Prefer mutter (the GNOME WM) —
+# falls back to metacity which is rock-solid in containers.
+if command -v metacity >/dev/null 2>&1; then
+  metacity --replace &
+  WM_PID=$!
+elif command -v mutter >/dev/null 2>&1; then
+  mutter --x11 --replace &
+  WM_PID=$!
+else
+  echo "[gui-entrypoint] no window manager available — Tauri windows will be undecorated" >&2
+fi
+
+# 4. VNC bridge.
+x11vnc -display :99 -nopw -forever -shared -quiet -rfbport 5900 &
+VNC_PID=$!
+
+# 5. noVNC over websockify.
+websockify --web=/usr/share/novnc 6080 localhost:5900 &
+WEB_PID=$!
+
+# 6. Optional: launch the desktop AppImage when one is mounted.
+APP_PATH=${APP_PATH:-/home/vaner/vaner-desktop.AppImage}
+if [ -x "$APP_PATH" ]; then
+  # Give GNOME a few seconds to settle so the Tauri tray icon has a
+  # panel to attach to.
+  ( sleep 4 && "$APP_PATH" --appimage-extract-and-run ) &
+  APP_PID=$!
+fi
+
+echo "[gui-entrypoint] noVNC: open http://localhost:6080/vnc.html?autoconnect=1"
+echo "[gui-entrypoint] AppImage: ${APP_PATH} ($([ -x "$APP_PATH" ] && echo running || echo not mounted))"
+
+wait -n

--- a/tests/test_cli/test_clients_subcommand.py
+++ b/tests/test_cli/test_clients_subcommand.py
@@ -42,15 +42,22 @@ def _seed_cursor(home: Path, repo_root: Path) -> None:
     (home / ".cursor").mkdir(parents=True, exist_ok=True)
 
 
-def _seed_claude_desktop(home: Path) -> None:
-    """Seed Claude Desktop's config dir at whatever path the detection
-    helper looks at on the current OS — `~/Library/Application
-    Support/Claude` on macOS, `~/.config/Claude` on Linux,
-    `%APPDATA%\\Claude` on Windows. Without this dispatch the test would
-    pass on Linux runners and fail on macOS.
+def _seed_claude_desktop(home: Path, monkeypatch: pytest.MonkeyPatch | None = None) -> None:
+    """Seed Claude Desktop's config dir under the current host's
+    detection path. Anthropic only ships Claude Desktop on macOS and
+    Windows, so the post-fix detector returns None on Linux even
+    when `~/.config/Claude/` exists (Vaner installs into that dir
+    too — see commit "fix(cli): claude-desktop Linux false-positive").
+
+    When called with a monkeypatch, force the detector to behave as
+    if running on macOS so the claude-desktop path stays exercised
+    on every CI runner. Tests that *want* the Linux behaviour
+    (false-positive guard) don't pass a monkeypatch.
     """
     from vaner.cli.commands import mcp_clients
 
+    if monkeypatch is not None:
+        monkeypatch.setattr(mcp_clients, "_platform", lambda: "darwin")
     target_dir = mcp_clients._claude_desktop_dir()
     target_dir.mkdir(parents=True, exist_ok=True)
 
@@ -89,11 +96,11 @@ def test_detect_returns_every_known_client(fake_home: Path, tmp_path: Path) -> N
     assert expected.issubset(ids)
 
 
-def test_detect_marks_seeded_clients_as_installed(fake_home: Path, tmp_path: Path) -> None:
+def test_detect_marks_seeded_clients_as_installed(fake_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed_cursor(fake_home, repo)
-    _seed_claude_desktop(fake_home)
+    _seed_claude_desktop(fake_home, monkeypatch)
     _seed_continue(fake_home)
     result = runner.invoke(clients_app, ["detect", "--repo-root", str(repo), "--format", "json"])
     payload = json.loads(result.output)
@@ -104,6 +111,26 @@ def test_detect_marks_seeded_clients_as_installed(fake_home: Path, tmp_path: Pat
     # Unseeded clients remain missing.
     assert by_id["zed"]["detected"] is False
     assert by_id["windsurf"]["detected"] is False
+
+
+def test_detect_skips_claude_desktop_on_linux(fake_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Anthropic doesn't ship Claude Desktop on Linux; seeing the
+    config dir alone (Vaner's own installer creates it) must not
+    flag the client as detected. Regression guard for the
+    `_detect_claude_desktop` platform gate."""
+    from vaner.cli.commands import mcp_clients
+
+    monkeypatch.setattr(mcp_clients, "_platform", lambda: "linux")
+    # Seed without forcing darwin — exercises the production Linux path.
+    target_dir = mcp_clients._claude_desktop_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(clients_app, ["detect", "--repo-root", str(repo), "--format", "json"])
+    payload = json.loads(result.output)
+    by_id = {c["id"]: c for c in payload["clients"]}
+    assert by_id["claude-desktop"]["detected"] is False
 
 
 def test_detect_pretty_format_renders_table(fake_home: Path, tmp_path: Path) -> None:
@@ -166,11 +193,11 @@ def test_install_mcp_only_skips_other_layers(fake_home: Path, tmp_path: Path) ->
     assert config_path.exists()
 
 
-def test_install_all_writes_to_every_detected(fake_home: Path, tmp_path: Path) -> None:
+def test_install_all_writes_to_every_detected(fake_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed_cursor(fake_home, repo)
-    _seed_claude_desktop(fake_home)
+    _seed_claude_desktop(fake_home, monkeypatch)
     result = runner.invoke(
         clients_app,
         ["install", "--all", "--repo-root", str(repo), "--format", "json"],
@@ -245,12 +272,12 @@ def test_install_requires_name_or_all(fake_home: Path, tmp_path: Path) -> None:
     assert result.exit_code != 0
 
 
-def test_install_claude_desktop_uses_repo_scoped_server_key(fake_home: Path, tmp_path: Path) -> None:
+def test_install_claude_desktop_uses_repo_scoped_server_key(fake_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from vaner.cli.commands import mcp_clients
 
     repo = tmp_path / "myrepo"
     repo.mkdir()
-    _seed_claude_desktop(fake_home)
+    _seed_claude_desktop(fake_home, monkeypatch)
     result = runner.invoke(
         clients_app,
         ["install", "claude-desktop", "--repo-root", str(repo)],

--- a/tests/test_cli/test_up.py
+++ b/tests/test_cli/test_up.py
@@ -59,6 +59,69 @@ model = "qwen3.5:35b"
     assert not (temp_repo / ".vaner" / "runtime" / "cockpit.pid").exists()
 
 
+def test_up_json_flag_emits_canonical_shape(monkeypatch, temp_repo) -> None:
+    """`vaner up --json` emits exactly one structured line of stdout
+    with the canonical key set, regardless of fresh-start vs reattach.
+    The desktop's auto-bring-up reads this to decide whether to flip
+    out of `.error` immediately or surface a useful failure detail."""
+    import json
+
+    from typer.testing import CliRunner
+
+    from vaner.cli.main import app as cli_app
+
+    monkeypatch.setattr(
+        "vaner.cli.commands.app.run_up",
+        lambda *_args, **_kwargs: {
+            "started": True,
+            "reattached": False,
+            "ready": True,
+            "cockpit_url": "http://127.0.0.1:8473",
+            "daemon_pid": 123,
+            "cockpit_pid": 124,
+            "ports": {"cockpit_port": 8473, "cockpit_changed": False},
+            "inotify": {"ok": True},
+        },
+    )
+
+    result = CliRunner().invoke(cli_app, ["up", "--path", str(temp_repo), "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output.strip())
+    assert parsed == {
+        "started": True,
+        "reattached": False,
+        "ready": True,
+        "cockpit_url": "http://127.0.0.1:8473",
+        "daemon_pid": 123,
+        "cockpit_pid": 124,
+        "ports": {"cockpit_port": 8473, "cockpit_changed": False},
+        "inotify": {"ok": True},
+    }
+
+
+def test_up_json_flag_emits_error_payload_on_failure(monkeypatch, temp_repo) -> None:
+    """run_up's RuntimeError surface (e.g. non-repo root + no --force)
+    becomes a JSON error payload on stdout with exit code 1, so the
+    desktop's bring-up flow can show a real fix-it message instead of
+    silently swallowing the failure."""
+    import json
+
+    from typer.testing import CliRunner
+
+    from vaner.cli.main import app as cli_app
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("repo root looks wrong; pass --force to override")
+
+    monkeypatch.setattr("vaner.cli.commands.app.run_up", _boom)
+
+    result = CliRunner().invoke(cli_app, ["up", "--path", str(temp_repo), "--json"])
+    assert result.exit_code == 1
+    parsed = json.loads(result.output.strip())
+    assert parsed["started"] is False
+    assert "repo root looks wrong" in parsed["error"]
+
+
 def test_run_up_is_idempotent_when_processes_already_running(monkeypatch, temp_repo) -> None:
     write_pid(temp_repo, DAEMON_PROCESS, os.getpid())
     write_pid(temp_repo, COCKPIT_PROCESS, os.getpid())


### PR DESCRIPTION
## Summary

- **Claude Desktop on Linux**: the detector returned true on every Linux machine that had ever had the desktop write a config (which is essentially every machine running Vaner Desktop). Now gated on platform — Linux always returns None, since Anthropic doesn't ship Claude Desktop for Linux.
- **`claude mcp add` / `codex mcp add` "already exists" recovery**: a second-pass install (Vaner Desktop's wizard, a user-driven Repair, a fresh Vaner Desktop install on a machine that had a prior partial install) bounced because the upstream CLIs refuse the add when the `vaner` entry exists. We now drop the existing entry with the matching `mcp remove vaner [--scope user]` and retry, returning `action="updated"`.
- **GUI testbed (Phase D-2)**: full Ubuntu desktop in a container, exposed via noVNC, ready to drive the Vaner Desktop AppImage end-to-end. Previously deferred in the README; now actually built.

## Headline files

- `src/vaner/cli/commands/mcp_clients.py` — `_detect_claude_desktop` platform gate; `_write_cli_client` recovery branch.
- `tests/integration/testbed/Dockerfile.gui` (new) — Ubuntu 24.04 + ubuntu-desktop-minimal + xvfb + x11vnc + websockify + noVNC + AppImage runtime libs + xdotool. Vaner CLI installed from the worktree.
- `tests/integration/testbed/gui-entrypoint.sh` (new) — Xvfb → dbus → metacity (mutter fallback) → x11vnc → websockify, then launches whatever AppImage is mounted at `$APP_PATH`.
- `tests/integration/testbed/compose.yml` — adds the `gui` service.
- `tests/integration/testbed/README.md` — documents the new Phase D-2 path.

## Why metacity instead of full GNOME

`gnome-session` on 24.04 hard-requires systemd as a user-session manager, which doesn't exist in vanilla Docker (the container exits with SIGTRAP). Running `mutter`/`metacity` standalone gives us window placement, focus, decorations against the same Xorg stack the desktop ships against — without needing `--privileged` + cgroups gymnastics for systemd.

## Verification

```
docker build -f tests/integration/testbed/Dockerfile.gui -t vaner-testbed-gui .
docker run --rm -it -p 6080:6080 \
  -v /tmp/vaner-desktop.AppImage:/home/vaner/vaner-desktop.AppImage:ro \
  --shm-size=2g vaner-testbed-gui
# open http://localhost:6080/vnc.html?autoconnect=1
```

End-to-end: wizard reaches "Vaner is ready", verification panel shows `claude-code: mcp=updated`, `codex-cli: mcp=added`, and Claude Desktop is correctly absent from the detected list.

## Test plan

- [ ] `pytest tests/test_cli/test_mcp_clients.py` (existing suite passes)
- [ ] Manual: `vaner clients install claude-code --force` after a prior install — succeeds with `action="updated"` instead of `failed`
- [ ] Manual: `vaner clients detect --format json` on Linux — `claude-desktop.detected == false`
- [ ] GUI testbed: build + run + drive wizard via noVNC

🤖 Generated with [Claude Code](https://claude.com/claude-code)