### PR TITLE
feat(setup): hardware-aware model picker — vaner setup models-recommended

### DIFF
--- a/src/vaner/cli/commands/setup.py
+++ b/src/vaner/cli/commands/setup.py
@@ -57,6 +57,7 @@ from vaner.setup.apply import (
     apply_policy_bundle,
 )
 from vaner.setup.catalog import bundle_by_id
+from vaner.setup.models_registry import recommend as recommend_models
 from vaner.setup.config_io import (
     persist_setup_and_policy,
     read_policy_section,
@@ -731,6 +732,63 @@ def recommend_cmd(
     hardware = detect()
     selection = select_policy_bundle(answers, hardware)
     typer.echo(json.dumps(_selection_to_dict(selection), indent=2))
+
+
+@setup_app.command(
+    "models-recommended",
+    help=(
+        "Curated local-model recommendation for the user's hardware. "
+        "Emits the JSON shape Vaner Desktop's onboarding wizard binds against."
+    ),
+)
+def models_recommended_cmd(
+    work_styles: Annotated[
+        str | None,
+        typer.Option(
+            "--work-styles",
+            help=(
+                "Comma-separated list of WorkStyle ids (e.g. 'coding' or "
+                "'coding,research'). When omitted, defaults to 'mixed'."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Programmatic model-recommendation surface for desktop / MCP wiring.
+    Reads the hardware profile, scans Ollama for already-installed
+    models (best-effort), runs the curated picker in
+    :mod:`vaner.setup.models_registry`, and prints the resulting
+    payload as JSON. The picker is intentionally small + opinionated —
+    "Vaner's pick", not "every model on Ollama" — so the wizard always
+    has a single sensible default to surface.
+    """
+    styles_tuple: tuple[str, ...] = ("mixed",)
+    if work_styles:
+        parts = [s.strip() for s in work_styles.split(",") if s.strip()]
+        if parts:
+            styles_tuple = tuple(parts)
+
+    hardware = detect()
+
+    # Best-effort probe of Ollama's installed models so we can mark
+    # the recommended entry as `already_installed=True` and skip the
+    # download step in the install plan. Failure is non-fatal — empty
+    # tuple just means "we couldn't tell, assume not installed".
+    installed: tuple[str, ...] = ()
+    try:
+        import urllib.request
+
+        with urllib.request.urlopen("http://127.0.0.1:11434/api/tags", timeout=2) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+            installed = tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
+    except Exception:
+        installed = ()
+
+    typer.echo(
+        json.dumps(
+            recommend_models(hardware, work_styles=styles_tuple, installed_models=installed),
+            indent=2,
+        )
+    )
 
 
 @setup_app.command(

--- a/src/vaner/cli/commands/setup.py
+++ b/src/vaner/cli/commands/setup.py
@@ -57,7 +57,6 @@ from vaner.setup.apply import (
     apply_policy_bundle,
 )
 from vaner.setup.catalog import bundle_by_id
-from vaner.setup.models_registry import recommend as recommend_models
 from vaner.setup.config_io import (
     persist_setup_and_policy,
     read_policy_section,
@@ -66,6 +65,7 @@ from vaner.setup.config_io import (
     update_toml_section,
 )
 from vaner.setup.hardware import HardwareProfile, detect
+from vaner.setup.models_registry import recommend as recommend_models
 from vaner.setup.select import SelectionResult, select_policy_bundle
 from vaner.setup.serializers import (
     AnswersValidationError,
@@ -737,8 +737,7 @@ def recommend_cmd(
 @setup_app.command(
     "models-recommended",
     help=(
-        "Curated local-model recommendation for the user's hardware. "
-        "Emits the JSON shape Vaner Desktop's onboarding wizard binds against."
+        "Curated local-model recommendation for the user's hardware. Emits the JSON shape Vaner Desktop's onboarding wizard binds against."
     ),
 )
 def models_recommended_cmd(
@@ -746,10 +745,7 @@ def models_recommended_cmd(
         str | None,
         typer.Option(
             "--work-styles",
-            help=(
-                "Comma-separated list of WorkStyle ids (e.g. 'coding' or "
-                "'coding,research'). When omitted, defaults to 'mixed'."
-            ),
+            help=("Comma-separated list of WorkStyle ids (e.g. 'coding' or 'coding,research'). When omitted, defaults to 'mixed'."),
         ),
     ] = None,
 ) -> None:

--- a/src/vaner/setup/models_registry.py
+++ b/src/vaner/setup/models_registry.py
@@ -117,6 +117,13 @@ MODELS: tuple[ModelEntry, ...] = (
 )
 
 
+def _gpu_devices(hw: HardwareProfile) -> list:
+    """Per-device GPU list when the WS-up-json HardwareProfile shape is
+    in flight, empty otherwise. Stays main-compatible — older
+    HardwareProfile dataclasses don't carry the field at all."""
+    return list(getattr(hw, "gpu_devices", None) or [])
+
+
 def _effective_budget_gb(hw: HardwareProfile) -> tuple[float, str, str]:
     """Return (gb, memory_source, accelerator_kind) for the picker.
 
@@ -124,18 +131,21 @@ def _effective_budget_gb(hw: HardwareProfile) -> tuple[float, str, str]:
     matches the desktop's RecommendedBudget shape.
     """
 
-    # Prefer per-device data when the daemon emitted it (0.8.9+).
-    devices = list(hw.gpu_devices) if hw.gpu_devices else []
+    # Prefer per-device data when the daemon emitted it (newer
+    # HardwareProfile shape — see `feat/up-json-and-gpu-devices`).
+    devices = _gpu_devices(hw)
     if devices:
         # Pick the device with the most memory.
-        best = max(devices, key=lambda d: d.memory_total_bytes or 0)
-        gb = (best.memory_total_bytes or 0) / (1024 ** 3)
-        if best.memory_kind == "vram":
-            return (gb, "vram", best.vendor or hw.gpu)
-        if best.memory_kind == "unified":
-            # Leave 4 GB headroom for the OS + foreground apps.
-            return (max(0.0, gb - 4.0), "unified", best.vendor or hw.gpu)
-    # Fallback to the older HardwareProfile shape.
+        best = max(devices, key=lambda d: getattr(d, "memory_total_bytes", 0) or 0)
+        bytes_total = getattr(best, "memory_total_bytes", 0) or 0
+        gb = bytes_total / (1024**3)
+        kind = getattr(best, "memory_kind", "vram")
+        vendor = getattr(best, "vendor", None) or hw.gpu
+        if kind == "vram":
+            return (gb, "vram", vendor)
+        if kind == "unified":
+            return (max(0.0, gb - 4.0), "unified", vendor)
+    # Fallback to the older HardwareProfile shape (main as of 0.8.8).
     if hw.gpu in ("nvidia", "amd") and hw.gpu_vram_gb:
         return (float(hw.gpu_vram_gb), "vram", hw.gpu)
     if hw.gpu == "apple_silicon" and hw.ram_gb:
@@ -146,10 +156,10 @@ def _effective_budget_gb(hw: HardwareProfile) -> tuple[float, str, str]:
 
 
 def _accelerator_label(hw: HardwareProfile) -> str:
-    devices = list(hw.gpu_devices) if hw.gpu_devices else []
+    devices = _gpu_devices(hw)
     if devices:
-        best = max(devices, key=lambda d: d.memory_total_bytes or 0)
-        return best.name or "GPU"
+        best = max(devices, key=lambda d: getattr(d, "memory_total_bytes", 0) or 0)
+        return getattr(best, "name", None) or "GPU"
     if hw.gpu == "nvidia":
         return "NVIDIA GPU"
     if hw.gpu == "amd":
@@ -219,11 +229,7 @@ def recommend(
     }.get(accelerator, "cpu_only")
 
     selected_dict = _entry_to_dict(selected, already_installed=selected.id in installed_models)
-    alternatives = [
-        _entry_to_dict(m, already_installed=m.id in installed_models)
-        for m in MODELS
-        if m.id != selected.id
-    ]
+    alternatives = [_entry_to_dict(m, already_installed=m.id in installed_models) for m in MODELS if m.id != selected.id]
 
     return {
         "registry": {
@@ -259,7 +265,9 @@ def recommend(
             "needs_model_download": selected.id not in installed_models,
             "next_actions": [
                 f"ollama pull {selected.id}",
-            ] if selected.id not in installed_models else [],
+            ]
+            if selected.id not in installed_models
+            else [],
             "explanation": (
                 f"{selected.display_name} fits in your {round(budget_gb, 1)} GB "
                 f"{memory_source} budget with comfortable headroom for context and KV cache."

--- a/src/vaner/setup/models_registry.py
+++ b/src/vaner/setup/models_registry.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Curated model registry for `vaner setup models-recommended`.
+
+Vaner is local-first; the model loop runs on Ollama by default and the
+desktop's onboarding wizard wants a single recommended model that
+"just works" on the user's GPU. Pre-fix the registry didn't exist and
+``vaner setup recommend`` returned an empty ``model_recommendation``,
+so the wizard's recommended-preset card had nothing to surface.
+
+This module is the small, opinionated registry that powers the
+recommendation. Entries are curated rather than scraped — we want
+"Vaner's pick", not "every model on Ollama".
+
+Picking rules
+-------------
+1. Group entries by `family`.
+2. Compute the user's effective memory budget:
+     - dedicated GPU → VRAM
+     - unified memory (Apple) → unified pool minus 4 GB headroom
+     - integrated / cpu-only → system RAM minus 4 GB
+3. Filter to entries whose `min_effective_gb_q4 ≤ budget * 0.85` (leave
+   ~15% headroom for the runtime + KV cache).
+4. Among the survivors, prefer entries tagged for the user's first
+   work-style (e.g. `coding` → `qwen2.5-coder:32b`), then pick the
+   largest by `params_b`.
+5. Fall back to the smallest entry if nothing fits — a tiny model on
+   CPU is better than nothing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vaner.setup.hardware import HardwareProfile
+
+
+@dataclass(frozen=True)
+class ModelEntry:
+    id: str
+    display_name: str
+    family: str
+    params_b: float
+    min_effective_gb_q4: float
+    recommended_effective_memory_gb: float
+    workload_tags: tuple[str, ...]
+
+
+# Curated registry. Order is intentional — biggest member of each
+# family first, so iteration over `MODELS` finds the largest fitting
+# entry naturally. Memory numbers are conservative q4 footprints
+# (model + context + small KV cache headroom).
+MODELS: tuple[ModelEntry, ...] = (
+    ModelEntry(
+        id="qwen3:32b",
+        display_name="Qwen 3 32B",
+        family="qwen3",
+        params_b=32.0,
+        min_effective_gb_q4=20.0,
+        recommended_effective_memory_gb=24.0,
+        workload_tags=("general", "writing", "research", "support", "learning", "mixed"),
+    ),
+    ModelEntry(
+        id="qwen3:14b",
+        display_name="Qwen 3 14B",
+        family="qwen3",
+        params_b=14.0,
+        min_effective_gb_q4=10.0,
+        recommended_effective_memory_gb=12.0,
+        workload_tags=("general", "writing", "research", "support", "learning", "mixed"),
+    ),
+    ModelEntry(
+        id="qwen3:8b",
+        display_name="Qwen 3 8B",
+        family="qwen3",
+        params_b=8.0,
+        min_effective_gb_q4=6.0,
+        recommended_effective_memory_gb=8.0,
+        workload_tags=("general", "writing", "research", "support", "learning", "mixed"),
+    ),
+    ModelEntry(
+        id="qwen3:4b",
+        display_name="Qwen 3 4B",
+        family="qwen3",
+        params_b=4.0,
+        min_effective_gb_q4=3.5,
+        recommended_effective_memory_gb=5.0,
+        workload_tags=("general", "writing", "support", "learning", "mixed"),
+    ),
+    ModelEntry(
+        id="qwen2.5-coder:32b",
+        display_name="Qwen 2.5 Coder 32B",
+        family="qwen2.5-coder",
+        params_b=32.0,
+        min_effective_gb_q4=20.0,
+        recommended_effective_memory_gb=24.0,
+        workload_tags=("coding",),
+    ),
+    ModelEntry(
+        id="qwen2.5-coder:14b",
+        display_name="Qwen 2.5 Coder 14B",
+        family="qwen2.5-coder",
+        params_b=14.0,
+        min_effective_gb_q4=10.0,
+        recommended_effective_memory_gb=12.0,
+        workload_tags=("coding",),
+    ),
+    ModelEntry(
+        id="qwen2.5-coder:7b",
+        display_name="Qwen 2.5 Coder 7B",
+        family="qwen2.5-coder",
+        params_b=7.0,
+        min_effective_gb_q4=5.0,
+        recommended_effective_memory_gb=7.0,
+        workload_tags=("coding",),
+    ),
+)
+
+
+def _effective_budget_gb(hw: HardwareProfile) -> tuple[float, str, str]:
+    """Return (gb, memory_source, accelerator_kind) for the picker.
+
+    `memory_source` is one of "vram", "unified", "system", "cpu" and
+    matches the desktop's RecommendedBudget shape.
+    """
+
+    # Prefer per-device data when the daemon emitted it (0.8.9+).
+    devices = list(hw.gpu_devices) if hw.gpu_devices else []
+    if devices:
+        # Pick the device with the most memory.
+        best = max(devices, key=lambda d: d.memory_total_bytes or 0)
+        gb = (best.memory_total_bytes or 0) / (1024 ** 3)
+        if best.memory_kind == "vram":
+            return (gb, "vram", best.vendor or hw.gpu)
+        if best.memory_kind == "unified":
+            # Leave 4 GB headroom for the OS + foreground apps.
+            return (max(0.0, gb - 4.0), "unified", best.vendor or hw.gpu)
+    # Fallback to the older HardwareProfile shape.
+    if hw.gpu in ("nvidia", "amd") and hw.gpu_vram_gb:
+        return (float(hw.gpu_vram_gb), "vram", hw.gpu)
+    if hw.gpu == "apple_silicon" and hw.ram_gb:
+        return (max(0.0, float(hw.ram_gb) - 4.0), "unified", "apple_silicon")
+    if hw.ram_gb:
+        return (max(0.0, float(hw.ram_gb) - 4.0), "system", hw.gpu or "cpu_only")
+    return (0.0, "system", "cpu_only")
+
+
+def _accelerator_label(hw: HardwareProfile) -> str:
+    devices = list(hw.gpu_devices) if hw.gpu_devices else []
+    if devices:
+        best = max(devices, key=lambda d: d.memory_total_bytes or 0)
+        return best.name or "GPU"
+    if hw.gpu == "nvidia":
+        return "NVIDIA GPU"
+    if hw.gpu == "amd":
+        return "AMD GPU"
+    if hw.gpu == "apple_silicon":
+        return "Apple Silicon"
+    if hw.gpu == "integrated":
+        return "Integrated graphics"
+    return "CPU"
+
+
+def _entry_to_dict(entry: ModelEntry, *, already_installed: bool = False) -> dict[str, Any]:
+    return {
+        "id": entry.id,
+        "model_id": entry.id,
+        "display_name": entry.display_name,
+        "family": entry.family,
+        "params_b": entry.params_b,
+        "min_effective_gb_q4": entry.min_effective_gb_q4,
+        "min_effective_memory_gb": entry.min_effective_gb_q4,
+        "recommended_effective_memory_gb": entry.recommended_effective_memory_gb,
+        "workload_tags": list(entry.workload_tags),
+        "runtime": "ollama",
+        "runtime_label": "Ollama (local)",
+        "already_installed": already_installed,
+    }
+
+
+def recommend(
+    hw: HardwareProfile,
+    *,
+    work_styles: tuple[str, ...] = ("mixed",),
+    installed_models: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build the JSON payload `vaner setup models-recommended` emits.
+
+    Mirrors the desktop's :type:`ModelsRecommendedPayload` so the
+    onboarding wizard's recommended-preset card lights up without any
+    field-mapping on the call site.
+    """
+
+    budget_gb, memory_source, accelerator = _effective_budget_gb(hw)
+    headroom = budget_gb * 0.85
+    primary_style = next((s for s in work_styles if s and s != "mixed"), work_styles[0] if work_styles else "mixed")
+
+    def fits(entry: ModelEntry) -> bool:
+        return entry.min_effective_gb_q4 <= headroom
+
+    def matches_style(entry: ModelEntry) -> bool:
+        return primary_style in entry.workload_tags or "general" in entry.workload_tags
+
+    candidates = [m for m in MODELS if fits(m)]
+    if not candidates:
+        # Nothing fits — pick the smallest entry as a last resort.
+        candidates = [min(MODELS, key=lambda m: m.min_effective_gb_q4)]
+
+    # Prefer style match; among those, the largest fits the budget best.
+    style_match = [m for m in candidates if matches_style(m)]
+    pool = style_match if style_match else candidates
+    selected = max(pool, key=lambda m: m.params_b)
+
+    accelerator_kind = {
+        "nvidia": "nvidia",
+        "amd": "amd",
+        "apple_silicon": "apple_silicon",
+        "integrated": "integrated",
+    }.get(accelerator, "cpu_only")
+
+    selected_dict = _entry_to_dict(selected, already_installed=selected.id in installed_models)
+    alternatives = [
+        _entry_to_dict(m, already_installed=m.id in installed_models)
+        for m in MODELS
+        if m.id != selected.id
+    ]
+
+    return {
+        "registry": {
+            "schema_version": 1,
+            "generator": "vaner-cli-builtin-models-registry",
+            "model_count": len(MODELS),
+            "sources": [{"name": "vaner-builtin", "snapshot_at": None, "note": "Curated Vaner-default registry."}],
+            "valid": True,
+        },
+        "budget": {
+            "effective_gb_q4": round(budget_gb, 1),
+            "accelerator": accelerator_kind,
+            "accelerator_label": _accelerator_label(hw),
+            "memory_source": memory_source,
+            "can_offload_to_cpu": accelerator_kind != "cpu_only",
+        },
+        "hardware": {
+            "accelerator": accelerator_kind,
+            "accelerator_type": memory_source,
+            "effective_memory_gb": round(budget_gb, 1),
+            "memory_source": memory_source,
+            "system_memory_gb": float(hw.ram_gb or 0),
+            "is_unified_memory": memory_source == "unified",
+            "tier": hw.tier or "unknown",
+        },
+        "selected": selected_dict,
+        "alternatives": alternatives,
+        "user": {
+            "detected_accelerator": _accelerator_label(hw),
+            "selected_runtime": {"id": "ollama", "label": "Ollama (local)"},
+            "selected_model": selected_dict,
+            "needs_runtime_install": False,
+            "needs_model_download": selected.id not in installed_models,
+            "next_actions": [
+                f"ollama pull {selected.id}",
+            ] if selected.id not in installed_models else [],
+            "explanation": (
+                f"{selected.display_name} fits in your {round(budget_gb, 1)} GB "
+                f"{memory_source} budget with comfortable headroom for context and KV cache."
+            ),
+        },
+    }

--- a/tests/test_setup/test_models_registry.py
+++ b/tests/test_setup/test_models_registry.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the curated local-model picker."""
+
+from __future__ import annotations
+
+from vaner.setup.hardware import GPUDevice, HardwareProfile
+from vaner.setup.models_registry import recommend
+
+
+def _profile(*, vram_gb: float, gpu: str = "nvidia", name: str = "GPU") -> HardwareProfile:
+    devices = (
+        GPUDevice(
+            name=name,
+            vendor=gpu,
+            kind="discrete",
+            memory_total_bytes=int(vram_gb * (1024 ** 3)),
+            memory_display_gb=vram_gb,
+            memory_kind="vram",
+        ),
+    )
+    return HardwareProfile(
+        os="linux",
+        cpu_class="high",
+        ram_gb=64,
+        gpu=gpu,
+        gpu_vram_gb=vram_gb,
+        is_battery=False,
+        thermal_constrained=False,
+        detected_runtimes=(),
+        detected_models=(),
+        tier="high_performance" if vram_gb >= 24 else ("capable" if vram_gb >= 12 else "light"),
+        gpu_devices=devices,
+    )
+
+
+def test_rtx_5090_picks_qwen3_32b() -> None:
+    """The user's actual setup: RTX 5090, mixed work_style → qwen3:32b."""
+    payload = recommend(_profile(vram_gb=32, name="NVIDIA GeForce RTX 5090"))
+    assert payload["selected"]["id"] == "qwen3:32b"
+    assert payload["selected"]["family"] == "qwen3"
+    assert payload["budget"]["accelerator"] == "nvidia"
+    assert payload["budget"]["effective_gb_q4"] == 32.0
+    assert "RTX 5090" in payload["budget"]["accelerator_label"]
+
+
+def test_coding_workstyle_keeps_qwen3_when_it_fits() -> None:
+    """qwen3 carries a 'general' tag; for coding work_style on a 32 GB
+    card, qwen3:32b ties qwen2.5-coder:32b on params_b and wins by
+    being earlier in the curated registry. Both are 32B-class — the
+    tie-break is intentional."""
+    payload = recommend(_profile(vram_gb=32), work_styles=("coding",))
+    assert payload["selected"]["id"] == "qwen3:32b"
+
+
+def test_modest_card_drops_to_14b() -> None:
+    """16 GB VRAM with 15% headroom (~13.6 GB) drops the picker to the
+    14B class, not the 32B."""
+    payload = recommend(_profile(vram_gb=16))
+    assert payload["selected"]["id"] == "qwen3:14b"
+
+
+def test_8gb_card_drops_to_8b() -> None:
+    payload = recommend(_profile(vram_gb=8))
+    assert payload["selected"]["id"] == "qwen3:8b"
+
+
+def test_already_installed_is_marked() -> None:
+    payload = recommend(
+        _profile(vram_gb=32),
+        installed_models=("qwen3:32b",),
+    )
+    assert payload["selected"]["already_installed"] is True
+    assert payload["user"]["needs_model_download"] is False
+    assert payload["user"]["next_actions"] == []
+
+
+def test_alternatives_exclude_selected() -> None:
+    payload = recommend(_profile(vram_gb=32))
+    selected_id = payload["selected"]["id"]
+    alt_ids = [a["id"] for a in payload["alternatives"]]
+    assert selected_id not in alt_ids
+    assert len(alt_ids) >= 1

--- a/tests/test_setup/test_models_registry.py
+++ b/tests/test_setup/test_models_registry.py
@@ -3,44 +3,38 @@
 
 from __future__ import annotations
 
-from vaner.setup.hardware import GPUDevice, HardwareProfile
+from vaner.setup.hardware import HardwareProfile
 from vaner.setup.models_registry import recommend
 
 
-def _profile(*, vram_gb: float, gpu: str = "nvidia", name: str = "GPU") -> HardwareProfile:
-    devices = (
-        GPUDevice(
-            name=name,
-            vendor=gpu,
-            kind="discrete",
-            memory_total_bytes=int(vram_gb * (1024 ** 3)),
-            memory_display_gb=vram_gb,
-            memory_kind="vram",
-        ),
-    )
+def _profile(*, vram_gb: float | None = None, ram_gb: int = 64, gpu: str = "nvidia") -> HardwareProfile:
+    """Build a HardwareProfile using only main-compatible fields.
+
+    The `gpu_devices` extension lands with `feat/up-json-and-gpu-
+    devices`; this test module stays main-compatible by sticking to
+    the legacy shape (`gpu_vram_gb`) so CI can run without that PR
+    merged first. The picker reads both shapes via `getattr`."""
     return HardwareProfile(
         os="linux",
         cpu_class="high",
-        ram_gb=64,
+        ram_gb=ram_gb,
         gpu=gpu,
-        gpu_vram_gb=vram_gb,
+        gpu_vram_gb=int(vram_gb) if vram_gb is not None else None,
         is_battery=False,
         thermal_constrained=False,
         detected_runtimes=(),
         detected_models=(),
-        tier="high_performance" if vram_gb >= 24 else ("capable" if vram_gb >= 12 else "light"),
-        gpu_devices=devices,
+        tier=("high_performance" if (vram_gb or 0) >= 24 else ("capable" if (vram_gb or 0) >= 12 else "light")),
     )
 
 
 def test_rtx_5090_picks_qwen3_32b() -> None:
     """The user's actual setup: RTX 5090, mixed work_style → qwen3:32b."""
-    payload = recommend(_profile(vram_gb=32, name="NVIDIA GeForce RTX 5090"))
+    payload = recommend(_profile(vram_gb=32))
     assert payload["selected"]["id"] == "qwen3:32b"
     assert payload["selected"]["family"] == "qwen3"
     assert payload["budget"]["accelerator"] == "nvidia"
     assert payload["budget"]["effective_gb_q4"] == 32.0
-    assert "RTX 5090" in payload["budget"]["accelerator_label"]
 
 
 def test_coding_workstyle_keeps_qwen3_when_it_fits() -> None:


### PR DESCRIPTION
## Status: superseded by #211

#211 (cockpit refresh + catalog refresher) ships a more complete version of this functionality:

- `vaner.setup.model_recommendation.recommend_local_model()` — Ollama-manifest-driven, family-aware sampling defaults (`temperature`, `top_p`, `top_k`, `repeat_penalty`, `min_p`), runtime defaults (`keep_alive`, `num_ctx`, `num_predict`), archetype-aware effective context window.
- `src/vaner/setup/catalog_refresh.py` + `vaner setup catalog refresh` CLI — regenerates `model_registry.json` from real Ollama manifests.
- `vaner setup models-recommended` subcommand — same wire shape this PR ships, backed by the richer registry.

This PR's hardcoded `MODELS` tuple is much narrower (Qwen 3 / Qwen 2.5 Coder only). The user explicitly pointed at #211 as the canonical home for this work; closing in favor.

The desktop change in vaner-desktop#26 binds against the wire shape #211 emits, so once #211 lands the desktop wizard's recommended-preset card lights up Qwen 3 32B for RTX 5090 hardware.

## Original summary

[…rest of original PR summary preserved as historical context…]