### PR TITLE
fix(setup): pick qwen3.6 (latest+best) for 32 GB cards instead of qwen3.5

### DIFF
--- a/src/vaner/setup/model_recommendation.py
+++ b/src/vaner/setup/model_recommendation.py
@@ -300,7 +300,25 @@ def _workload_tags(answers: SetupAnswers | None) -> set[str]:
 
 
 def _fit_status(model: RecommendedModel, effective_memory_gb: float) -> Literal["recommended", "fits", "too_large"]:
-    if effective_memory_gb >= model.recommended_effective_memory_gb:
+    """Bucket how well a model fits the user's accelerator budget.
+
+    The registry's ``recommended_effective_memory_gb`` is derived from
+    the family's *max* context window — qwen3.6 with its 262K ceiling
+    needs ~56 GB to be "recommended" by that yardstick. That's
+    accurate but punitive: a 32 GB card can comfortably run qwen3.6
+    with a 32K-or-65K context, which is what
+    :func:`compute_effective_context_window` ends up picking at
+    runtime. So we relax the "recommended" tier to "min × 1.3"
+    (weights + ~30% KV headroom — enough for a sensible context) so
+    the picker doesn't always default to a much smaller model on
+    hardware that can clearly run the larger one. The strict
+    "recommended" tier remains the upper bound.
+    """
+    # `min + 4` GB ≈ weights + a sensible 32K-ish KV-cache budget, which
+    # is what `compute_effective_context_window` actually picks at
+    # runtime on a card sized at the model's `min_effective_memory_gb`.
+    relaxed_recommended = model.min_effective_memory_gb + 4.0
+    if effective_memory_gb >= min(model.recommended_effective_memory_gb, relaxed_recommended):
         return "recommended"
     if effective_memory_gb >= model.min_effective_memory_gb:
         return "fits"
@@ -314,12 +332,22 @@ def _score_model(
     runtime_available: bool,
     fit: str,
 ) -> float:
+    """Score a candidate against the user's hardware + workload tags.
+
+    Weight choices encode "Vaner picks the best model that fits"
+    rather than "the safest small model". Quality and recency carry
+    more weight than stability or download size — a 22 GB download
+    is a one-time cost on a user's machine, but a quality / recency
+    delta is the experience every cycle. Stability stays in the
+    sum because brand-new releases occasionally have rough edges,
+    but its multiplier is reduced so the latest-of-latest entry
+    isn't penalised into oblivion."""
     tag_overlap = len(workload_tags.intersection(model.workload_tags))
-    score = model.stability_rank * 3.0
-    score += model.quality_rank * 2.2
+    score = model.stability_rank * 1.5
+    score += model.quality_rank * 3.0
     score += tag_overlap * 35.0
-    score += max(0.0, 30.0 - model.download_size_gb) * 1.5
-    score += model.recency_rank * 0.35
+    score += max(0.0, 30.0 - model.download_size_gb) * 0.5
+    score += model.recency_rank * 1.0
     if fit == "recommended":
         score += 75
     elif fit == "fits":


### PR DESCRIPTION
## Summary

Per direct user feedback (\"ugh why 3.5 — I wanted 3.6\"), the local-model picker now lands on `qwen3.6:latest` for an RTX 5090.

Catalog already had qwen3.6 marked as quality=98, recency=100 (highest of both), but two scoring quirks pushed qwen3.5 ahead:

1. **\"recommended\" was punitive.** `recommended_effective_memory_gb` was computed against the family's *max* context window — qwen3.6's 262K ceiling needs ~56 GB to qualify as \"recommended,\" so a 32 GB card landed on qwen3.6=\"fits\" vs qwen3.5=\"recommended\" and the +50 fit-bonus delta closed the score gap. But `compute_effective_context_window` already picks a sane runtime context (32K-ish on a card sized at the model's min memory), so the strict \"recommended\" was double-counting worst-case context.
2. **Scoring favored small + safe over best.** `stability * 3.0 + quality * 2.2 + download_savings * 1.5` made a 6 GB qwen3.5 download win over a 22 GB qwen3.6 even though the 22 GB is a one-time cost vs. a permanent quality / recency delta on every cycle.

## Changes

- `_fit_status`: relax \"recommended\" to `min_effective_memory_gb + 4 GB` (weights + 32K KV cache ≈ what we actually run with). Strict ceiling stays as upper bound.
- `_score_model`: rebalance to `stability*1.5 + quality*3.0 + recency*1.0 + download_savings*0.5`. Vaner picks the best model that fits.

## Verified

```
$ vaner setup models-recommended --work-styles coding
Selected: Qwen 3.6 · qwen3.6:latest
Fit: recommended
Budget: 30.0 GB
```

(pre-fix: `Qwen 3.5 · qwen3.5:latest`)

## Test plan

- [x] pytest tests/test_setup — 231 passed, 1 skipped
- [x] ruff check + ruff format --check clean
- [ ] Manual: `vaner setup models-recommended --work-styles coding` returns Qwen 3.6 on a high-end card

🤖 Generated with [Claude Code](https://claude.com/claude-code)