### PR TITLE
chore(release): bump to v0.8.10 + PyPI dist staging fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "vaner",
       "source": "./plugins/vaner",
       "description": "MCP server, feedback skill, and bootstrap hook for Vaner.",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "category": "developer-tools",
       "tags": [
         "mcp",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,36 @@ jobs:
         uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
         with:
           subject-path: "dist/*"
+      - name: Stage clean PyPI dist (drop Sigstore + intoto + SBOM siblings)
+        if: ${{ vars.PYPI_PUBLISH == '1' }}
+        run: |
+          set -euo pipefail
+          # `pypa/gh-action-pypi-publish` runs `twine check` over every file
+          # in `packages-dir`; the Sigstore bundle (`*.sigstore.json`) and any
+          # SLSA in-toto envelopes that the previous Sign / Attest steps
+          # dropped next to the wheel + sdist trip twine with
+          # "InvalidDistribution: Unknown distribution format". Stage a
+          # filtered dist that contains only the wheel + sdist + their
+          # PEP-740 attestations, leaving the rest in `dist/` for the
+          # GitHub-release upload below.
+          mkdir -p dist-pypi
+          shopt -s nullglob
+          for f in dist/*.whl dist/*.tar.gz; do
+            cp "$f" dist-pypi/
+          done
+          # Also copy attestations the action expects when `attestations:
+          # true` is set — at the time of writing those are produced by
+          # `actions/attest-build-provenance` and live alongside the
+          # artifacts inside dist/.
+          for f in dist/*.publish.attestation; do
+            [ -f "$f" ] && cp "$f" dist-pypi/
+          done
+          ls -la dist-pypi/
       - name: Publish to PyPI
         if: ${{ vars.PYPI_PUBLISH == '1' }}
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: dist-pypi/
       - name: Attach artifacts to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.10] - 2026-05-02
+
+### Changed
+
+- First PyPI publish via the `pypa/gh-action-pypi-publish` trusted-publisher OIDC flow (no API token in CI). The `release.yml` workflow gates the PyPI step on `vars.PYPI_PUBLISH=1`; flipping the variable on the repo enables auto-publish on every `v*` tag push. No code changes from 0.8.9 — this is a release-pipeline shake-down.
+
 ## [0.8.9] - 2026-05-02
 
 ### Added

--- a/cursor-plugins/vaner/.cursor-plugin/plugin.json
+++ b/cursor-plugins/vaner/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaner",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Vaner: predictive context middleware for AI coding workflows. Bundles the Vaner MCP server, the vaner-feedback skill, an alwaysApply primer rule, a sessionStart hook that checks for the `vaner` CLI, and a beforeSubmitPrompt hook that pre-fetches prepared work as you type.",
   "author": {
     "name": "Borgels Olsen Holding ApS",

--- a/plugins/vaner/.claude-plugin/plugin.json
+++ b/plugins/vaner/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaner",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Vaner: predictive context middleware for AI coding workflows. Bundles the Vaner MCP server (search, expand, resolve, feedback, and more), the vaner-feedback skill, and a SessionStart hook that checks for the `vaner` CLI.",
   "author": {
     "name": "Borgels Olsen Holding ApS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vaner"
-version = "0.8.9"
+version = "0.8.10"
 description = "Predictive context middleware layer for AI workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vaner/_version.py
+++ b/src/vaner/_version.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "0.8.9"
+VERSION = "0.8.10"


### PR DESCRIPTION
First PyPI publish via OIDC trusted publisher; no code changes from 0.8.9. Tag v0.8.10 already pushed and the release workflow is running. This PR lands the version-bump commit on main.