### PR TITLE
fix(release): verify SBOM as SLSA subject

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,11 @@ jobs:
           python scripts/release/preflight.py primary-artifacts --dist-dir dist-assets/dist --sbom dist-assets/sbom.json > /tmp/primary-artifacts.txt
           while IFS= read -r artifact; do
             [ -n "$artifact" ] || continue
-            gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY"
+            if [[ "$artifact" == dist-assets/dist/* ]]; then
+              gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY"
+            else
+              echo "Skipping GitHub artifact attestation for $artifact; SBOM is verified by Sigstore bundle and SLSA subject."
+            fi
             bundle="${artifact}.sigstore.json"
             cosign verify-blob \
               --bundle "$bundle" \


### PR DESCRIPTION
Fixes the v0.9.0 release verify failure where sbom.json was checked through the GitHub build-provenance attestation API even though it is verified by its Sigstore bundle and included as a SLSA subject.