### PR TITLE
docs: clarify Vaner interaction surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,119 @@
-# Vaner
+<p align="center">
+  <img src="docs/assets/vaner-lockup-animated.svg" alt="Vaner" width="260">
+</p>
 
-[![CI](https://github.com/Borgels/vaner/actions/workflows/ci.yml/badge.svg)](https://github.com/Borgels/vaner/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/Borgels/vaner/actions/workflows/codeql.yml/badge.svg)](https://github.com/Borgels/vaner/actions/workflows/codeql.yml)
-[![Release](https://img.shields.io/github/v/release/Borgels/vaner)](https://github.com/Borgels/vaner/releases/latest)
-[![License](https://img.shields.io/github/license/Borgels/vaner)](LICENSE)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Borgels/vaner/badge)](https://scorecard.dev/viewer/?uri=github.com/Borgels/vaner)
+<p align="center">
+  <strong>Local-first preparation for AI coding agents.</strong><br>
+  Vaner turns idle compute into evidence-backed Prepared Work before your next prompt lands.
+</p>
 
-> Status: alpha (pre-1.0). Interfaces may evolve quickly while we stabilize core behavior.
+<p align="center">
+  <a href="https://github.com/Borgels/vaner/actions/workflows/ci.yml"><img src="https://github.com/Borgels/vaner/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/Borgels/vaner/actions/workflows/codeql.yml"><img src="https://github.com/Borgels/vaner/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
+  <a href="https://github.com/Borgels/vaner/releases/latest"><img src="https://img.shields.io/github/v/release/Borgels/vaner" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/Borgels/vaner" alt="License"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/Borgels/vaner"><img src="https://api.scorecard.dev/projects/github.com/Borgels/vaner/badge" alt="OpenSSF Scorecard"></a>
+</p>
 
-## What is Vaner?
+<p align="center">
+  <a href="https://vaner.ai"><strong>Download Desktop</strong></a>
+  ·
+  <a href="https://docs.vaner.ai">Docs</a>
+  ·
+  <a href="https://docs.vaner.ai/integrations">Integrations</a>
+  ·
+  <a href="https://github.com/Borgels/vaner/releases/latest">Latest release</a>
+</p>
 
-Vaner is a local-first preparation engine for AI coding agents. It turns idle
-compute into evidence-backed Prepared Work — review notes, bug hypotheses, docs
-drift, virtual diffs, research briefs, ready prediction-backed drafts — and
-serves the best fit when the real question arrives.
+> Status: alpha (pre-1.0). Interfaces may evolve while core behavior stabilizes.
 
-Prepared Work is non-mutating by default: virtual diffs and exports require
-explicit user action. Vaner does not silently edit your files.
+## What Vaner Does
 
-## Install
+Vaner runs beside your editor as a local engine. It watches the repository you
+scope it to, prepares useful context in the background, and serves the best fit
+to your AI client when the real question arrives.
 
-**Most users:** download the desktop app at **[vaner.ai](https://vaner.ai)**.
-The desktop app starts the engine, picks a local model for your hardware, and
-wires Vaner into the MCP clients it detects on your machine (Claude Code,
-Cursor, Zed, VS Code, Claude Desktop, …).
+Prepared Work can include review notes, bug hypotheses, docs drift, research
+briefs, virtual diffs, and prediction-backed drafts. It is non-mutating by
+default: Vaner can prepare a diff, but applying or exporting work is always an
+explicit user action.
 
-**Power users / CI:** install the CLI directly.
+## Recommended Install
+
+Most users should start with **[Vaner Desktop](https://vaner.ai)**.
+
+Desktop starts the local engine, picks an Ollama model for your hardware, and
+wires Vaner into supported AI clients it detects on your machine. You normally
+do not install Vaner inside the AI client first; the AI client is where the
+agent uses Vaner after Desktop or `vaner init` configures the integration.
+
+## How You Interact With Vaner
+
+Vaner is one local engine/daemon with several surfaces around it. MCP is the
+primary interface for AI agents. Desktop and Companion are the primary
+human-facing controls.
+
+| Surface | Primary user | Purpose | Default? | Where documented |
+| --- | --- | --- | --- | --- |
+| AI client via MCP | AI agent | Pull Prepared Work and call `vaner.*` tools from Cursor, Claude Code, Codex, Zed, and similar clients. | Yes, for agents | [MCP mode](https://docs.vaner.ai/integrations/mcp) |
+| Desktop tray/taskbar window | Human user | Install, start/stop Vaner, see status, and wire detected clients. | Yes, for humans | [Getting started](https://docs.vaner.ai/getting-started) |
+| Companion/settings thin client | Human user | Manage common settings, integrations, backend/runtime choices, and privacy posture. | Yes, through Desktop | [Configuration](https://docs.vaner.ai/configuration) |
+| Cockpit / Web UI | Advanced user | Inspect engine state, priorities, Prepared Work, diagnostics, and live activity. | No, advanced | [Prepared Work](https://docs.vaner.ai/prepared-work#inspecting-prepared-work) |
+| CLI | Power users / CI | Script setup, daemon control, status, doctor, logs, and config. | No | [CLI reference](https://docs.vaner.ai/cli) |
+| Primer/rules, skills, plugins/hooks | AI agent integration | Make MCP usage reliable and client-specific. | Yes, where supported | [Client integration depth](https://docs.vaner.ai/integrations/client-capabilities) |
+| Proxy/gateway | Compatibility users | OpenAI-compatible fallback for tools that cannot call MCP directly. | No | [Proxy mode](https://docs.vaner.ai/integrations/proxy) |
+
+## Power Users / CI
+
+Use the CLI path for CI, Docker, SSH-only machines, or scripted setup.
 
 ```bash
-# Linux/macOS — one-line installer
+# Linux/macOS one-line installer
 curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
 
-# Or via your package manager of choice
+# Or install with a Python tool runner
 pipx install 'vaner[mcp]'
 uv tool install 'vaner[mcp]'
 ```
 
-Full install matrix (flags, non-interactive CI, package upgrade, source build,
-retention/expiry): **[docs.vaner.ai/getting-started](https://docs.vaner.ai/getting-started)**.
-
-## First run
+First run:
 
 ```bash
 vaner init --path .   # detect hardware, pick a model, wire detected MCP clients
-vaner up --path .     # start the daemon + cockpit
+vaner up --path .     # start the daemon and Cockpit
 ```
 
-The cockpit opens at `http://127.0.0.1:8473/` and shows live pipeline state,
-prepared work, predictions, goals, and feedback.
+Cockpit opens at `http://127.0.0.1:8473/` with live engine state, Prepared
+Work, predictions, goals, diagnostics, and feedback.
 
-## Connect your AI client
+## AI Client Setup
 
-Vaner exposes context to your agent over [MCP](https://modelcontextprotocol.io/).
-`vaner init` wires the clients it detects automatically. Manual setup:
+Vaner exposes context to agents over [MCP](https://modelcontextprotocol.io/).
+Desktop and `vaner init` configure supported clients automatically. Manual
+setup is still available:
 
-| Client                                                      | One command                                                                                |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Claude Code (plugin, recommended)                           | `/plugin marketplace add Borgels/vaner` then `/plugin install vaner@vaner`                 |
-| Claude Code (manual MCP)                                    | `claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .`                |
-| Codex CLI                                                   | `codex mcp add vaner -- vaner mcp --path .`                                                |
-| Cursor, VS Code, Zed, Windsurf, Continue, Claude Desktop, Cline, Roo | see **[docs.vaner.ai/integrations](https://docs.vaner.ai/integrations)**          |
+| Client | One command |
+| --- | --- |
+| Claude Code plugin | `/plugin marketplace add Borgels/vaner` then `/plugin install vaner@vaner` |
+| Claude Code MCP | `claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .` |
+| Codex CLI | `codex mcp add vaner -- vaner mcp --path .` |
+| Cursor, VS Code, Zed, Windsurf, Continue, Claude Desktop, Cline, Roo | See [Integrations](https://docs.vaner.ai/integrations) |
 
 ## Documentation
 
-Full docs at **[docs.vaner.ai](https://docs.vaner.ai)**:
-
-- [Getting started](https://docs.vaner.ai/getting-started) — install + first run
-- [Integrations](https://docs.vaner.ai/integrations) — every supported MCP client
-- [Cockpit](https://docs.vaner.ai/cockpit) — live pipeline view + diagnostics
-- [Configuration](https://docs.vaner.ai/configuration) — backends, compute, retention
-- [CLI reference](https://docs.vaner.ai/cli) — every command
-- [MCP tools](https://docs.vaner.ai/mcp) — `vaner.*` namespace
-- [Architecture](https://docs.vaner.ai/architecture) — how the engine works
-- [Security](https://docs.vaner.ai/security) — local-first guarantees, threat model
+- [Getting started](https://docs.vaner.ai/getting-started): Desktop install and first run
+- [Architecture](https://docs.vaner.ai/architecture): how the local engine works
+- [Integrations](https://docs.vaner.ai/integrations): supported MCP clients
+- [MCP mode](https://docs.vaner.ai/integrations/mcp): the `vaner.*` agent tool surface
+- [Prepared Work](https://docs.vaner.ai/prepared-work): what Vaner prepares and how to inspect it
+- [Configuration](https://docs.vaner.ai/configuration): backends, compute, retention, privacy posture
+- [CLI reference](https://docs.vaner.ai/cli): setup, daemon control, status, doctor, logs, config
+- [Security](https://docs.vaner.ai/security): local-first guarantees and threat model
 
 ## Contributing
 
-See **[CONTRIBUTING.md](CONTRIBUTING.md)** for dev setup, testing, CI, the
-Claude Code plugin parity rules, and DCO sign-off. Quick start:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, CI,
+Claude Code plugin parity rules, and DCO sign-off.
 
 ```bash
 git clone https://github.com/Borgels/vaner.git
@@ -88,12 +124,14 @@ pre-commit install
 pytest tests -m "not slow and not integration"
 ```
 
-## Community
+## Project
 
-- Security policy: [`SECURITY.md`](SECURITY.md)
-- Governance: [`GOVERNANCE.md`](GOVERNANCE.md) · maintainers: [`MAINTAINERS.md`](MAINTAINERS.md)
-- Code of conduct: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) · support: [`SUPPORT.md`](SUPPORT.md)
-- Examples: [`examples/`](examples/)
+- Security policy: [SECURITY.md](SECURITY.md)
+- Governance: [GOVERNANCE.md](GOVERNANCE.md)
+- Maintainers: [MAINTAINERS.md](MAINTAINERS.md)
+- Code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- Support: [SUPPORT.md](SUPPORT.md)
+- Examples: [examples/](examples/)
 
 ## License
 

--- a/docs/assets/vaner-lockup-animated.svg
+++ b/docs/assets/vaner-lockup-animated.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="92" viewBox="0 0 360 92" role="img" aria-label="Vaner">
+  <style>
+    .wordmark {
+      fill: #1a1620;
+      font: 600 48px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      letter-spacing: 0;
+    }
+    .cursor {
+      fill: #b27a2e;
+      animation: blink 1.25s steps(1, end) infinite;
+    }
+    @keyframes blink {
+      50% { opacity: 0.18; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .cursor { animation: none; }
+    }
+  </style>
+  <g transform="translate(18 24)">
+    <circle cx="22" cy="22" r="18" fill="none" stroke="#6d4f9a" stroke-width="2.8" />
+    <circle cx="22" cy="22" r="8" fill="#6d4f9a" />
+    <path d="M22 22 L36 12" stroke="#b27a2e" stroke-width="1.8" stroke-linecap="round" />
+    <circle cx="36" cy="12" r="3.2" fill="#b27a2e" />
+  </g>
+  <text x="84" y="61" class="wordmark">vaner<tspan class="cursor">_</tspan></text>
+</svg>

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -54,7 +54,7 @@ rm -rf ~/.claude/skills/vaner
 
 `vaner init` still works and still writes a managed feedback skill to `~/.claude/skills/vaner/vaner-feedback/SKILL.md` plus a per-repo `.cursor/mcp.json`. For Claude Code users the plugin supersedes both — the plugin-shipped skill resolves as `/vaner:vaner-feedback` (namespaced), and the plugin's `.mcp.json` registers the MCP server at the user scope. The standalone skill can coexist harmlessly (contents are byte-identical and CI-enforced) or be removed.
 
-For Cursor, Codex CLI, and other clients that don't support Claude Code plugins, continue using `vaner init` / the per-client instructions at [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp).
+For Cursor, Codex CLI, and other clients that don't support Claude Code plugins, continue using `vaner init` / the per-client instructions at [docs.vaner.ai/integrations/mcp](https://docs.vaner.ai/integrations/mcp).
 
 ## Running in scripted / non-interactive mode
 

--- a/docs/mcp-migration.md
+++ b/docs/mcp-migration.md
@@ -57,7 +57,7 @@ that need the lean legacy shape can pass either include flag as `false`.
 
 ## Full v1 tool surface
 
-The complete `vaner.*` MCP tool family at v1.0 (see [docs.vaner.ai/mcp](https://docs.vaner.ai/mcp) for full schemas):
+The complete `vaner.*` MCP tool family at v1.0 (see [docs.vaner.ai/integrations/mcp](https://docs.vaner.ai/integrations/mcp) for full schemas):
 
 - `vaner.status` — engine health, model, compute config, prediction metrics.
 - `vaner.suggest` — intent-priming suggestions for a draft prompt.


### PR DESCRIPTION
## Summary
- make Desktop the clear recommended quickstart path in README
- add the interaction-surface matrix covering MCP, Desktop, Companion, Cockpit, CLI, integration layers, and proxy/gateway
- replace stale docs.vaner.ai/mcp links with /integrations/mcp

## Tests
- git diff --check